### PR TITLE
chore(config): fix typos

### DIFF
--- a/README-task-master.md
+++ b/README-task-master.md
@@ -39,7 +39,7 @@ npm install task-master-ai
 ### Initialize a new project
 
 ```bash
-npx claude-task-init
+npx task-master-ai
 ```
 
 This will prompt you for project details and set up a new project with the necessary files and structure.
@@ -51,7 +51,7 @@ This will prompt you for project details and set up a new project with the neces
 
 ## Troubleshooting
 
-### If `npx claude-task-init` doesn't respond:
+### If `npx task-master-ai` doesn't respond:
 
 Try running it with Node directly:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install task-master-ai
 ### Initialize a new project
 
 ```bash
-npx claude-task-init
+npx task-master-ai
 ```
 
 This will prompt you for project details and set up a new project with the necessary files and structure.
@@ -51,7 +51,7 @@ This will prompt you for project details and set up a new project with the neces
 
 ## Troubleshooting
 
-### If `npx claude-task-init` doesn't respond:
+### If `npx task-master-ai` doesn't respond:
 
 Try running it with Node directly:
 

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-console.log('Starting claude-task-init...');
+console.log('Starting task-master-ai...');
 
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
When running: ```npx claude-task-init``` it doesn't work

We should use the updated ```npx task-master-ai``` instead