### PR TITLE
fix: addTask mcp tool not working

### DIFF
--- a/.changeset/seven-numbers-juggle.md
+++ b/.changeset/seven-numbers-juggle.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix addTask tool `projectRoot not defined`

--- a/mcp-server/src/tools/addTask.js
+++ b/mcp-server/src/tools/addTask.js
@@ -45,6 +45,8 @@ export function registerAddTaskTool(server) {
         if (args.priority) cmdArgs.push(`--priority=${args.priority}`);
         if (args.file) cmdArgs.push(`--file=${args.file}`);
 
+        const projectRoot = args.projectRoot;
+
         const result = executeTaskMasterCommand(
           "add-task",
           log,


### PR DESCRIPTION
- Fix `projectRoot not defined` when trying to add task from the mcp 