### PR TITLE
feat(mcp): Fix parse-prd tool path resolution

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -8,7 +8,7 @@
 				"PERPLEXITY_API_KEY": "YOUR_PERPLEXITY_API_KEY_HERE",
 				"MODEL": "claude-3-7-sonnet-20250219",
 				"PERPLEXITY_MODEL": "sonar-pro",
-				"MAX_TOKENS": 128000,
+				"MAX_TOKENS": 64000,
 				"TEMPERATURE": 0.2,
 				"DEFAULT_SUBTASKS": 5,
 				"DEFAULT_PRIORITY": "medium"

--- a/mcp-server/src/core/direct-functions/initialize-project-direct.js
+++ b/mcp-server/src/core/direct-functions/initialize-project-direct.js
@@ -109,7 +109,7 @@ export async function initializeProjectDirect(args, log, context = {}) {
 		resultData = {
 			message: 'Project initialized successfully.',
 			next_step:
-				'Now that the project is initialized, create a PRD file at scripts/prd.txt and use the parse-prd tool to generate initial tasks.',
+				'Now that the project is initialized, the next step is to create the tasks by parsing a PRD. This will create the tasks folder and the initial task files (tasks folder will be created when parse-prd is run). The parse-prd tool will require a prd.txt file as input (typically found in the project root directory, scripts/ directory). You can create a prd.txt file by asking the user about their idea, and then using the scripts/example_prd.txt file as a template to genrate a prd.txt file in scripts/. You may skip all of this if the user already has a prd.txt file. You can THEN use the parse-prd tool to create the tasks. So: step 1 after initialization is to create a prd.txt file in scripts/prd.txt or confirm the user already has one. Step 2 is to use the parse-prd tool to create the tasks. Do not bother looking for tasks after initialization, just use the parse-prd tool to create the tasks after creating a prd.txt from which to parse the tasks. You do NOT need to reinitialize the project to parse-prd.',
 			...result // Include details returned by initializeProject
 		};
 		success = true;

--- a/mcp-server/src/tools/parse-prd.js
+++ b/mcp-server/src/tools/parse-prd.js
@@ -19,7 +19,7 @@ export function registerParsePRDTool(server) {
 	server.addTool({
 		name: 'parse_prd',
 		description:
-			'Parse a Product Requirements Document (PRD) text file to automatically generate initial tasks.',
+			"Parse a Product Requirements Document (PRD) text file to automatically generate initial tasks. Reinitializing the project is not necessary to run this tool. It is recommended to run parse-prd after initializing the project and creating/importing a prd.txt file in the project root's scripts/ directory.",
 		parameters: z.object({
 			input: z
 				.string()
@@ -43,21 +43,34 @@ export function registerParsePRDTool(server) {
 				.describe('Allow overwriting an existing tasks.json file.'),
 			projectRoot: z
 				.string()
-				.optional()
 				.describe(
-					'Absolute path to the root directory of the project (default: automatically detected from session or CWD)'
+					'Absolute path to the root directory of the project. Required - ALWAYS SET THIS TO THE PROJECT ROOT DIRECTORY.'
 				)
 		}),
 		execute: async (args, { log, session }) => {
 			try {
 				log.info(`Parsing PRD with args: ${JSON.stringify(args)}`);
 
-				let rootFolder = getProjectRootFromSession(session, log);
+				// Make sure projectRoot is passed directly in args or derive from session
+				// We prioritize projectRoot from args over session-derived path
+				let rootFolder = args.projectRoot;
 
-				if (!rootFolder && args.projectRoot) {
-					rootFolder = args.projectRoot;
-					log.info(`Using project root from args as fallback: ${rootFolder}`);
+				// Only if args.projectRoot is undefined or null, try to get it from session
+				if (!rootFolder) {
+					log.warn(
+						'projectRoot not provided in args, attempting to derive from session'
+					);
+					rootFolder = getProjectRootFromSession(session, log);
+
+					if (!rootFolder) {
+						const errorMessage =
+							'Could not determine project root directory. Please provide projectRoot parameter.';
+						log.error(errorMessage);
+						return createErrorResponse(errorMessage);
+					}
 				}
+
+				log.info(`Using project root: ${rootFolder} for PRD parsing`);
 
 				const result = await parsePRDDirect(
 					{


### PR DESCRIPTION
Refactors parse-prd MCP tool to properly handle project root and path resolution, fixing the 'Input file not found: /scripts/prd.txt' error.

Key changes include: Made projectRoot a required parameter, prioritized args.projectRoot over session-derived paths, added validation to prevent parsing in invalid directories (/, home dir), improved error handling with detailed messages, and added creation of output directory if needed.

This resolves issues similar to those fixed in initialize-project, where the tool was incorrectly resolving paths when session context was incomplete.