### PR TITLE
wip: refactor(mcp): Enforce projectRoot and centralize path validation

### DIFF
--- a/mcp-server/src/core/direct-functions/add-dependency.js
+++ b/mcp-server/src/core/direct-functions/add-dependency.js
@@ -21,7 +21,7 @@ import {
  * @param {Object} log - Logger object
  * @returns {Promise<Object>} - Result object with success status and data/error information
  */
-export async function addDependencyDirect(args, log) {
+export async function addDependencyDirect(args, log, { session }) {
 	try {
 		log.info(`Adding dependency with args: ${JSON.stringify(args)}`);
 
@@ -47,7 +47,7 @@ export async function addDependencyDirect(args, log) {
 		}
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Format IDs for the core function
 		const taskId =

--- a/mcp-server/src/core/direct-functions/add-subtask.js
+++ b/mcp-server/src/core/direct-functions/add-subtask.js
@@ -25,7 +25,7 @@ import {
  * @param {Object} log - Logger object
  * @returns {Promise<{success: boolean, data?: Object, error?: string}>}
  */
-export async function addSubtaskDirect(args, log) {
+export async function addSubtaskDirect(args, log, { session }) {
 	try {
 		log.info(`Adding subtask with args: ${JSON.stringify(args)}`);
 
@@ -51,7 +51,7 @@ export async function addSubtaskDirect(args, log) {
 		}
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Parse dependencies if provided
 		let dependencies = [];

--- a/mcp-server/src/core/direct-functions/add-task.js
+++ b/mcp-server/src/core/direct-functions/add-task.js
@@ -37,13 +37,13 @@ import {
  * @param {Object} context - Additional context (reportProgress, session)
  * @returns {Promise<Object>} - Result object { success: boolean, data?: any, error?: { code: string, message: string } }
  */
-export async function addTaskDirect(args, log, context = {}) {
+export async function addTaskDirect(args, log, { session }) {
 	try {
 		// Enable silent mode to prevent console logs from interfering with JSON response
 		enableSilentMode();
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Check if this is manual task creation or AI-driven task creation
 		const isManualCreation = args.title && args.description;
@@ -74,9 +74,6 @@ export async function addTaskDirect(args, log, context = {}) {
 						.map((id) => parseInt(id.trim(), 10))
 				: [];
 		const priority = args.priority || 'medium';
-
-		// Extract context parameters for advanced functionality
-		const { session } = context;
 
 		let manualTaskData = null;
 

--- a/mcp-server/src/core/direct-functions/clear-subtasks.js
+++ b/mcp-server/src/core/direct-functions/clear-subtasks.js
@@ -20,7 +20,7 @@ import fs from 'fs';
  * @param {Object} log - Logger object
  * @returns {Promise<{success: boolean, data?: Object, error?: {code: string, message: string}}>}
  */
-export async function clearSubtasksDirect(args, log) {
+export async function clearSubtasksDirect(args, log, { session }) {
 	try {
 		log.info(`Clearing subtasks with args: ${JSON.stringify(args)}`);
 
@@ -37,7 +37,7 @@ export async function clearSubtasksDirect(args, log) {
 		}
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Check if tasks.json exists
 		if (!fs.existsSync(tasksPath)) {

--- a/mcp-server/src/core/direct-functions/complexity-report.js
+++ b/mcp-server/src/core/direct-functions/complexity-report.js
@@ -19,14 +19,14 @@ import path from 'path';
  * @param {Object} log - Logger object
  * @returns {Promise<Object>} - Result object with success status and data/error information
  */
-export async function complexityReportDirect(args, log) {
+export async function complexityReportDirect(args, log, { session }) {
 	try {
 		log.info(`Getting complexity report with args: ${JSON.stringify(args)}`);
 
 		// Get tasks file path to determine project root for the default report location
 		let tasksPath;
 		try {
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 		} catch (error) {
 			log.warn(
 				`Tasks file not found, using current directory: ${error.message}`

--- a/mcp-server/src/core/direct-functions/expand-all-tasks.js
+++ b/mcp-server/src/core/direct-functions/expand-all-tasks.js
@@ -26,9 +26,7 @@ import fs from 'fs';
  * @param {Object} context - Context object containing session
  * @returns {Promise<{success: boolean, data?: Object, error?: {code: string, message: string}}>}
  */
-export async function expandAllTasksDirect(args, log, context = {}) {
-	const { session } = context; // Only extract session, not reportProgress
-
+export async function expandAllTasksDirect(args, log, { session }) {
 	try {
 		log.info(`Expanding all tasks with args: ${JSON.stringify(args)}`);
 
@@ -37,7 +35,7 @@ export async function expandAllTasksDirect(args, log, context = {}) {
 
 		try {
 			// Find the tasks.json path
-			const tasksPath = findTasksJsonPath(args, log);
+			const tasksPath = findTasksJsonPath(args, log, session);
 
 			// Parse parameters
 			const numSubtasks = args.num ? parseInt(args.num, 10) : undefined;

--- a/mcp-server/src/core/direct-functions/expand-task.js
+++ b/mcp-server/src/core/direct-functions/expand-task.js
@@ -27,9 +27,7 @@ import fs from 'fs';
  * @param {Object} context - Context object containing session and reportProgress
  * @returns {Promise<Object>} - Task expansion result { success: boolean, data?: any, error?: { code: string, message: string }, fromCache: boolean }
  */
-export async function expandTaskDirect(args, log, context = {}) {
-	const { session } = context;
-
+export async function expandTaskDirect(args, log, { session }) {
 	// Log session root data for debugging
 	log.info(
 		`Session data in expandTaskDirect: ${JSON.stringify({
@@ -53,7 +51,7 @@ export async function expandTaskDirect(args, log, context = {}) {
 			log.info(
 				`[expandTaskDirect] No direct file path provided or file not found at ${args.file}, searching using findTasksJsonPath`
 			);
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 		}
 	} catch (error) {
 		log.error(

--- a/mcp-server/src/core/direct-functions/fix-dependencies.js
+++ b/mcp-server/src/core/direct-functions/fix-dependencies.js
@@ -18,12 +18,12 @@ import fs from 'fs';
  * @param {Object} log - Logger object
  * @returns {Promise<{success: boolean, data?: Object, error?: {code: string, message: string}}>}
  */
-export async function fixDependenciesDirect(args, log) {
+export async function fixDependenciesDirect(args, log, { session }) {
 	try {
 		log.info(`Fixing invalid dependencies in tasks...`);
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Verify the file exists
 		if (!fs.existsSync(tasksPath)) {

--- a/mcp-server/src/core/direct-functions/generate-task-files.js
+++ b/mcp-server/src/core/direct-functions/generate-task-files.js
@@ -18,14 +18,14 @@ import path from 'path';
  * @param {Object} log - Logger object.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
-export async function generateTaskFilesDirect(args, log) {
+export async function generateTaskFilesDirect(args, log, { session }) {
 	try {
 		log.info(`Generating task files with args: ${JSON.stringify(args)}`);
 
 		// Get tasks file path
 		let tasksPath;
 		try {
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 		} catch (error) {
 			log.error(`Error finding tasks file: ${error.message}`);
 			return {

--- a/mcp-server/src/core/direct-functions/initialize-project-direct.js
+++ b/mcp-server/src/core/direct-functions/initialize-project-direct.js
@@ -16,8 +16,7 @@ import os from 'os'; // Import os module for home directory check
  * @param {object} context - The context object, must contain { session }.
  * @returns {Promise<{success: boolean, data?: any, error?: {code: string, message: string}}>} - Standard result object.
  */
-export async function initializeProjectDirect(args, log, context = {}) {
-	const { session } = context;
+export async function initializeProjectDirect(args, log, { session }) {
 	const homeDir = os.homedir();
 	let targetDirectory = null;
 

--- a/mcp-server/src/core/direct-functions/list-tasks.js
+++ b/mcp-server/src/core/direct-functions/list-tasks.js
@@ -18,11 +18,11 @@ import {
  * @param {Object} log - Logger object.
  * @returns {Promise<Object>} - Task list result { success: boolean, data?: any, error?: { code: string, message: string }, fromCache: boolean }.
  */
-export async function listTasksDirect(args, log) {
+export async function listTasksDirect(args, log, { session }) {
 	let tasksPath;
 	try {
 		// Find the tasks path first - needed for cache key and execution
-		tasksPath = findTasksJsonPath(args, log);
+		tasksPath = findTasksJsonPath(args, log, session);
 	} catch (error) {
 		if (error.code === 'TASKS_FILE_NOT_FOUND') {
 			log.error(`Tasks file not found: ${error.message}`);

--- a/mcp-server/src/core/direct-functions/next-task.js
+++ b/mcp-server/src/core/direct-functions/next-task.js
@@ -19,11 +19,11 @@ import {
  * @param {Object} log - Logger object
  * @returns {Promise<Object>} - Next task result { success: boolean, data?: any, error?: { code: string, message: string }, fromCache: boolean }
  */
-export async function nextTaskDirect(args, log) {
+export async function nextTaskDirect(args, log, { session }) {
 	let tasksPath;
 	try {
 		// Find the tasks path first - needed for cache key and execution
-		tasksPath = findTasksJsonPath(args, log);
+		tasksPath = findTasksJsonPath(args, log, session);
 	} catch (error) {
 		log.error(`Tasks file not found: ${error.message}`);
 		return {

--- a/mcp-server/src/core/direct-functions/remove-dependency.js
+++ b/mcp-server/src/core/direct-functions/remove-dependency.js
@@ -19,7 +19,7 @@ import {
  * @param {Object} log - Logger object
  * @returns {Promise<{success: boolean, data?: Object, error?: {code: string, message: string}}>}
  */
-export async function removeDependencyDirect(args, log) {
+export async function removeDependencyDirect(args, log, { session }) {
 	try {
 		log.info(`Removing dependency with args: ${JSON.stringify(args)}`);
 
@@ -45,7 +45,7 @@ export async function removeDependencyDirect(args, log) {
 		}
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Format IDs for the core function
 		const taskId =

--- a/mcp-server/src/core/direct-functions/remove-subtask.js
+++ b/mcp-server/src/core/direct-functions/remove-subtask.js
@@ -20,7 +20,7 @@ import {
  * @param {Object} log - Logger object
  * @returns {Promise<{success: boolean, data?: Object, error?: {code: string, message: string}}>}
  */
-export async function removeSubtaskDirect(args, log) {
+export async function removeSubtaskDirect(args, log, { session }) {
 	try {
 		// Enable silent mode to prevent console logs from interfering with JSON response
 		enableSilentMode();
@@ -50,7 +50,7 @@ export async function removeSubtaskDirect(args, log) {
 		}
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Convert convertToTask to a boolean
 		const convertToTask = args.convert === true;

--- a/mcp-server/src/core/direct-functions/remove-task.js
+++ b/mcp-server/src/core/direct-functions/remove-task.js
@@ -17,12 +17,12 @@ import { findTasksJsonPath } from '../utils/path-utils.js';
  * @param {Object} log - Logger object
  * @returns {Promise<Object>} - Remove task result { success: boolean, data?: any, error?: { code: string, message: string }, fromCache: false }
  */
-export async function removeTaskDirect(args, log) {
+export async function removeTaskDirect(args, log, { session }) {
 	try {
 		// Find the tasks path first
 		let tasksPath;
 		try {
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 		} catch (error) {
 			log.error(`Tasks file not found: ${error.message}`);
 			return {

--- a/mcp-server/src/core/direct-functions/set-task-status.js
+++ b/mcp-server/src/core/direct-functions/set-task-status.js
@@ -18,7 +18,7 @@ import {
  * @param {Object} log - Logger object.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
-export async function setTaskStatusDirect(args, log) {
+export async function setTaskStatusDirect(args, log, { session }) {
 	try {
 		log.info(`Setting task status with args: ${JSON.stringify(args)}`);
 
@@ -49,7 +49,7 @@ export async function setTaskStatusDirect(args, log) {
 		let tasksPath;
 		try {
 			// The enhanced findTasksJsonPath will now search in parent directories if needed
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 			log.info(`Found tasks file at: ${tasksPath}`);
 		} catch (error) {
 			log.error(`Error finding tasks file: ${error.message}`);

--- a/mcp-server/src/core/direct-functions/show-task.js
+++ b/mcp-server/src/core/direct-functions/show-task.js
@@ -19,11 +19,11 @@ import {
  * @param {Object} log - Logger object
  * @returns {Promise<Object>} - Task details result { success: boolean, data?: any, error?: { code: string, message: string }, fromCache: boolean }
  */
-export async function showTaskDirect(args, log) {
+export async function showTaskDirect(args, log, { session }) {
 	let tasksPath;
 	try {
 		// Find the tasks path first - needed for cache key and execution
-		tasksPath = findTasksJsonPath(args, log);
+		tasksPath = findTasksJsonPath(args, log, session);
 	} catch (error) {
 		log.error(`Tasks file not found: ${error.message}`);
 		return {

--- a/mcp-server/src/core/direct-functions/update-subtask-by-id.js
+++ b/mcp-server/src/core/direct-functions/update-subtask-by-id.js
@@ -22,9 +22,7 @@ import {
  * @param {Object} context - Context object containing session data.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
-export async function updateSubtaskByIdDirect(args, log, context = {}) {
-	const { session } = context; // Only extract session, not reportProgress
-
+export async function updateSubtaskByIdDirect(args, log, { session }) {
 	try {
 		log.info(`Updating subtask with args: ${JSON.stringify(args)}`);
 
@@ -77,7 +75,7 @@ export async function updateSubtaskByIdDirect(args, log, context = {}) {
 		// Get tasks file path
 		let tasksPath;
 		try {
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 		} catch (error) {
 			log.error(`Error finding tasks file: ${error.message}`);
 			return {

--- a/mcp-server/src/core/direct-functions/update-task-by-id.js
+++ b/mcp-server/src/core/direct-functions/update-task-by-id.js
@@ -22,9 +22,7 @@ import {
  * @param {Object} context - Context object containing session data.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
-export async function updateTaskByIdDirect(args, log, context = {}) {
-	const { session } = context; // Only extract session, not reportProgress
-
+export async function updateTaskByIdDirect(args, log, { session }) {
 	try {
 		log.info(`Updating task with args: ${JSON.stringify(args)}`);
 
@@ -77,7 +75,7 @@ export async function updateTaskByIdDirect(args, log, context = {}) {
 		// Get tasks file path
 		let tasksPath;
 		try {
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 		} catch (error) {
 			log.error(`Error finding tasks file: ${error.message}`);
 			return {

--- a/mcp-server/src/core/direct-functions/update-tasks.js
+++ b/mcp-server/src/core/direct-functions/update-tasks.js
@@ -22,9 +22,7 @@ import {
  * @param {Object} context - Context object containing session data.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
-export async function updateTasksDirect(args, log, context = {}) {
-	const { session } = context; // Only extract session, not reportProgress
-
+export async function updateTasksDirect(args, log, { session }) {
 	try {
 		log.info(`Updating tasks with args: ${JSON.stringify(args)}`);
 
@@ -88,7 +86,7 @@ export async function updateTasksDirect(args, log, context = {}) {
 		// Get tasks file path
 		let tasksPath;
 		try {
-			tasksPath = findTasksJsonPath(args, log);
+			tasksPath = findTasksJsonPath(args, log, session);
 		} catch (error) {
 			log.error(`Error finding tasks file: ${error.message}`);
 			return {

--- a/mcp-server/src/core/direct-functions/validate-dependencies.js
+++ b/mcp-server/src/core/direct-functions/validate-dependencies.js
@@ -18,12 +18,12 @@ import fs from 'fs';
  * @param {Object} log - Logger object
  * @returns {Promise<{success: boolean, data?: Object, error?: {code: string, message: string}}>}
  */
-export async function validateDependenciesDirect(args, log) {
+export async function validateDependenciesDirect(args, log, { session }) {
 	try {
 		log.info(`Validating dependencies in tasks...`);
 
 		// Find the tasks.json path
-		const tasksPath = findTasksJsonPath(args, log);
+		const tasksPath = findTasksJsonPath(args, log, session);
 
 		// Verify the file exists
 		if (!fs.existsSync(tasksPath)) {

--- a/mcp-server/src/tools/utils.js
+++ b/mcp-server/src/tools/utils.js
@@ -9,10 +9,7 @@ import fs from 'fs';
 import { contextManager } from '../core/context-manager.js'; // Import the singleton
 
 // Import path utilities to ensure consistent path resolution
-import {
-	lastFoundProjectRoot,
-	PROJECT_MARKERS
-} from '../core/utils/path-utils.js';
+import { PROJECT_MARKERS } from '../core/utils/path-utils.js';
 
 /**
  * Get normalized project root path

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -909,7 +909,7 @@ function setupMCPConfiguration(targetDir, projectName) {
 	const newMCPServer = {
 		'task-master-ai': {
 			command: 'npx',
-			args: ['-y', '--package', 'task-master-ai', 'task-master-mcp'],
+			args: ['-y', 'task-master-mcp'],
 			env: {
 				ANTHROPIC_API_KEY: '%ANTHROPIC_API_KEY%',
 				PERPLEXITY_API_KEY: '%PERPLEXITY_API_KEY%',


### PR DESCRIPTION
This commit refactors how project paths are handled in MCP direct functions to improve reliability, particularly when session context is incomplete or missing.

Key changes:

1.  **Made `projectRoot` required in MCP tools:**
    *   Updated `analyze_project_complexity` tool (`analyze.js`) Zod schema to require the `projectRoot` parameter.
    *   Removed logic in the tool's `execute` method that attempted to derive `projectRoot` from the session as a fallback.

2.  **Refactored `findTasksJsonPath` utility (`path-utils.js`):**
    *   Modified to return both `{ tasksPath, validatedProjectRoot }`.
    *   Added validation to ensure the determined `projectRoot` exists and is a directory.
    *   Requires the `session` object to be passed (for internal logic, even if root comes from args).

3.  **Updated all Direct Functions:**
    *   Modified signatures to accept `{ session }` from context: `async function fn(args, log, { session })`.
    *   Updated all calls to `findTasksJsonPath` to pass the `session` object: `findTasksJsonPath(args, log, session)`.

4.  **Updated `analyzeTaskComplexityDirect`:**
    *   Uses the `validatedProjectRoot` returned by `findTasksJsonPath` for resolving the output report path via `resolveProjectPath`.
    *   Uses `ensureDirectoryExists` for the output path directory.

This ensures that operations relying on project context receive an explicitly provided and validated project root directory, resolving errors caused by incorrect path resolution (e.g., falling back to '/').