### PR TITLE
fix: README bug not showing precise instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ A task management system for AI-driven development with Claude, designed to work
 
 MCP (Model Control Protocol) provides the easiest way to get started with Task Master directly in your editor.
 
-1. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
+1. **Install the package**
+
+```bash
+npm i -g task-master-ai
+```
+
+2. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
 
 ```json
 {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,7 +10,13 @@ There are two ways to set up Task Master: using MCP (recommended) or via npm ins
 
 MCP (Model Control Protocol) provides the easiest way to get started with Task Master directly in your editor.
 
-1. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
+1. **Install the package**
+
+```bash
+npm i -g task-master-ai
+```
+
+2. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
 
 ```json
 {


### PR DESCRIPTION
- Users who don't have the package `task-master-ai` installed, can't use npx -y task-master-mcp...