### PR TITLE
Fix shebang line for node options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ A task management system for AI-driven development with Claude, designed to work
 
 MCP (Model Control Protocol) provides the easiest way to get started with Task Master directly in your editor.
 
-1. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
+1. **Install the package**
+
+```bash
+npm i -g task-master-ai
+```
+
+2. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
 
 ```json
 {

--- a/bin/task-master.js
+++ b/bin/task-master.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --trace-deprecation
+#!/usr/bin/env -S node --trace-deprecation
 
 /**
  * Task Master

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,7 +10,13 @@ There are two ways to set up Task Master: using MCP (recommended) or via npm ins
 
 MCP (Model Control Protocol) provides the easiest way to get started with Task Master directly in your editor.
 
-1. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
+1. **Install the package**
+
+```bash
+npm i -g task-master-ai
+```
+
+2. **Add the MCP config to your editor** (Cursor recommended, but it works with other text editors):
 
 ```json
 {


### PR DESCRIPTION
Use `-S` flag with `/usr/bin/env` to properly pass options to node.

Addresses - #184 