### PR TITLE
   feat: Add --append flag to parsePRD command

### DIFF
--- a/.changeset/cold-bats-fly.md
+++ b/.changeset/cold-bats-fly.md
@@ -1,0 +1,5 @@
+---
+'task-master-ai': patch
+---
+
+Enhance the `parsePRD` to inclide `--append` flag

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -88,7 +88,10 @@ function registerCommands(programInstance) {
 		.option('-o, --output <file>', 'Output file path', 'tasks/tasks.json')
 		.option('-n, --num-tasks <number>', 'Number of tasks to generate', '10')
 		.option('-f, --force', 'Skip confirmation when overwriting existing tasks')
-		.option('--append', 'Append new tasks to existing tasks.json instead of overwriting')
+		.option(
+			'--append',
+			'Append new tasks to existing tasks.json instead of overwriting'
+		)
 		.action(async (file, options) => {
 			// Use input option if file argument not provided
 			const inputFile = file || options.input;
@@ -131,30 +134,30 @@ function registerCommands(programInstance) {
 				console.log(
 					boxen(
 						chalk.white.bold('Parse PRD Help') +
-						'\n\n' +
-						chalk.cyan('Usage:') +
-						'\n' +
-						`  task-master parse-prd <prd-file.txt> [options]\n\n` +
-						chalk.cyan('Options:') +
-						'\n' +
-						'  -i, --input <file>       Path to the PRD file (alternative to positional argument)\n' +
-						'  -o, --output <file>      Output file path (default: "tasks/tasks.json")\n' +
-						'  -n, --num-tasks <number> Number of tasks to generate (default: 10)\n' +
-						'  -f, --force              Skip confirmation when overwriting existing tasks\n' +
-						'  --append                 Append new tasks to existing tasks.json instead of overwriting\n\n' +
-						chalk.cyan('Example:') +
-						'\n' +
-						'  task-master parse-prd requirements.txt --num-tasks 15\n' +
-						'  task-master parse-prd --input=requirements.txt\n' +
-						'  task-master parse-prd --force\n' +
-						'  task-master parse-prd requirements_v2.txt --append\n\n' +
-						chalk.yellow('Note: This command will:') +
-						'\n' +
-						'  1. Look for a PRD file at scripts/prd.txt by default\n' +
-						'  2. Use the file specified by --input or positional argument if provided\n' +
-						'  3. Generate tasks from the PRD and either:\n' +
-						'     - Overwrite any existing tasks.json file (default)\n' +
-						'     - Append to existing tasks.json if --append is used',
+							'\n\n' +
+							chalk.cyan('Usage:') +
+							'\n' +
+							`  task-master parse-prd <prd-file.txt> [options]\n\n` +
+							chalk.cyan('Options:') +
+							'\n' +
+							'  -i, --input <file>       Path to the PRD file (alternative to positional argument)\n' +
+							'  -o, --output <file>      Output file path (default: "tasks/tasks.json")\n' +
+							'  -n, --num-tasks <number> Number of tasks to generate (default: 10)\n' +
+							'  -f, --force              Skip confirmation when overwriting existing tasks\n' +
+							'  --append                 Append new tasks to existing tasks.json instead of overwriting\n\n' +
+							chalk.cyan('Example:') +
+							'\n' +
+							'  task-master parse-prd requirements.txt --num-tasks 15\n' +
+							'  task-master parse-prd --input=requirements.txt\n' +
+							'  task-master parse-prd --force\n' +
+							'  task-master parse-prd requirements_v2.txt --append\n\n' +
+							chalk.yellow('Note: This command will:') +
+							'\n' +
+							'  1. Look for a PRD file at scripts/prd.txt by default\n' +
+							'  2. Use the file specified by --input or positional argument if provided\n' +
+							'  3. Generate tasks from the PRD and either:\n' +
+							'     - Overwrite any existing tasks.json file (default)\n' +
+							'     - Append to existing tasks.json if --append is used',
 						{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 					)
 				);
@@ -1141,25 +1144,25 @@ function registerCommands(programInstance) {
 							chalk.white.bold(
 								`Subtask ${parentId}.${subtask.id} Added Successfully`
 							) +
-							'\n\n' +
-							chalk.white(`Title: ${subtask.title}`) +
-							'\n' +
-							chalk.white(`Status: ${getStatusWithColor(subtask.status)}`) +
-							'\n' +
-							(dependencies.length > 0
-								? chalk.white(`Dependencies: ${dependencies.join(', ')}`) +
-								'\n'
-								: '') +
-							'\n' +
-							chalk.white.bold('Next Steps:') +
-							'\n' +
-							chalk.cyan(
-								`1. Run ${chalk.yellow(`task-master show ${parentId}`)} to see the parent task with all subtasks`
-							) +
-							'\n' +
-							chalk.cyan(
-								`2. Run ${chalk.yellow(`task-master set-status --id=${parentId}.${subtask.id} --status=in-progress`)} to start working on it`
-							),
+								'\n\n' +
+								chalk.white(`Title: ${subtask.title}`) +
+								'\n' +
+								chalk.white(`Status: ${getStatusWithColor(subtask.status)}`) +
+								'\n' +
+								(dependencies.length > 0
+									? chalk.white(`Dependencies: ${dependencies.join(', ')}`) +
+										'\n'
+									: '') +
+								'\n' +
+								chalk.white.bold('Next Steps:') +
+								'\n' +
+								chalk.cyan(
+									`1. Run ${chalk.yellow(`task-master show ${parentId}`)} to see the parent task with all subtasks`
+								) +
+								'\n' +
+								chalk.cyan(
+									`2. Run ${chalk.yellow(`task-master set-status --id=${parentId}.${subtask.id} --status=in-progress`)} to start working on it`
+								),
 							{
 								padding: 1,
 								borderColor: 'green',
@@ -1175,19 +1178,19 @@ function registerCommands(programInstance) {
 					console.log(
 						boxen(
 							chalk.white.bold('Usage Examples:') +
-							'\n\n' +
-							chalk.white('Convert existing task to subtask:') +
-							'\n' +
-							chalk.yellow(
-								`  task-master add-subtask --parent=5 --task-id=8`
-							) +
-							'\n\n' +
-							chalk.white('Create new subtask:') +
-							'\n' +
-							chalk.yellow(
-								`  task-master add-subtask --parent=5 --title="Implement login UI" --description="Create the login form"`
-							) +
-							'\n\n',
+								'\n\n' +
+								chalk.white('Convert existing task to subtask:') +
+								'\n' +
+								chalk.yellow(
+									`  task-master add-subtask --parent=5 --task-id=8`
+								) +
+								'\n\n' +
+								chalk.white('Create new subtask:') +
+								'\n' +
+								chalk.yellow(
+									`  task-master add-subtask --parent=5 --title="Implement login UI" --description="Create the login form"`
+								) +
+								'\n\n',
 							{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 						)
 					);
@@ -1209,25 +1212,25 @@ function registerCommands(programInstance) {
 		console.log(
 			boxen(
 				chalk.white.bold('Add Subtask Command Help') +
-				'\n\n' +
-				chalk.cyan('Usage:') +
-				'\n' +
-				`  task-master add-subtask --parent=<id> [options]\n\n` +
-				chalk.cyan('Options:') +
-				'\n' +
-				'  -p, --parent <id>         Parent task ID (required)\n' +
-				'  -i, --task-id <id>        Existing task ID to convert to subtask\n' +
-				'  -t, --title <title>       Title for the new subtask\n' +
-				'  -d, --description <text>  Description for the new subtask\n' +
-				'  --details <text>          Implementation details for the new subtask\n' +
-				'  --dependencies <ids>      Comma-separated list of dependency IDs\n' +
-				'  -s, --status <status>     Status for the new subtask (default: "pending")\n' +
-				'  -f, --file <file>         Path to the tasks file (default: "tasks/tasks.json")\n' +
-				'  --skip-generate           Skip regenerating task files\n\n' +
-				chalk.cyan('Examples:') +
-				'\n' +
-				'  task-master add-subtask --parent=5 --task-id=8\n' +
-				'  task-master add-subtask -p 5 -t "Implement login UI" -d "Create the login form"',
+					'\n\n' +
+					chalk.cyan('Usage:') +
+					'\n' +
+					`  task-master add-subtask --parent=<id> [options]\n\n` +
+					chalk.cyan('Options:') +
+					'\n' +
+					'  -p, --parent <id>         Parent task ID (required)\n' +
+					'  -i, --task-id <id>        Existing task ID to convert to subtask\n' +
+					'  -t, --title <title>       Title for the new subtask\n' +
+					'  -d, --description <text>  Description for the new subtask\n' +
+					'  --details <text>          Implementation details for the new subtask\n' +
+					'  --dependencies <ids>      Comma-separated list of dependency IDs\n' +
+					'  -s, --status <status>     Status for the new subtask (default: "pending")\n' +
+					'  -f, --file <file>         Path to the tasks file (default: "tasks/tasks.json")\n' +
+					'  --skip-generate           Skip regenerating task files\n\n' +
+					chalk.cyan('Examples:') +
+					'\n' +
+					'  task-master add-subtask --parent=5 --task-id=8\n' +
+					'  task-master add-subtask -p 5 -t "Implement login UI" -d "Create the login form"',
 				{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 			)
 		);
@@ -1300,24 +1303,24 @@ function registerCommands(programInstance) {
 								chalk.white.bold(
 									`Subtask ${subtaskId} Converted to Task #${result.id}`
 								) +
-								'\n\n' +
-								chalk.white(`Title: ${result.title}`) +
-								'\n' +
-								chalk.white(`Status: ${getStatusWithColor(result.status)}`) +
-								'\n' +
-								chalk.white(
-									`Dependencies: ${result.dependencies.join(', ')}`
-								) +
-								'\n\n' +
-								chalk.white.bold('Next Steps:') +
-								'\n' +
-								chalk.cyan(
-									`1. Run ${chalk.yellow(`task-master show ${result.id}`)} to see details of the new task`
-								) +
-								'\n' +
-								chalk.cyan(
-									`2. Run ${chalk.yellow(`task-master set-status --id=${result.id} --status=in-progress`)} to start working on it`
-								),
+									'\n\n' +
+									chalk.white(`Title: ${result.title}`) +
+									'\n' +
+									chalk.white(`Status: ${getStatusWithColor(result.status)}`) +
+									'\n' +
+									chalk.white(
+										`Dependencies: ${result.dependencies.join(', ')}`
+									) +
+									'\n\n' +
+									chalk.white.bold('Next Steps:') +
+									'\n' +
+									chalk.cyan(
+										`1. Run ${chalk.yellow(`task-master show ${result.id}`)} to see details of the new task`
+									) +
+									'\n' +
+									chalk.cyan(
+										`2. Run ${chalk.yellow(`task-master set-status --id=${result.id} --status=in-progress`)} to start working on it`
+									),
 								{
 									padding: 1,
 									borderColor: 'green',
@@ -1331,8 +1334,8 @@ function registerCommands(programInstance) {
 						console.log(
 							boxen(
 								chalk.white.bold(`Subtask ${subtaskId} Removed`) +
-								'\n\n' +
-								chalk.white('The subtask has been successfully deleted.'),
+									'\n\n' +
+									chalk.white('The subtask has been successfully deleted.'),
 								{
 									padding: 1,
 									borderColor: 'green',
@@ -1360,21 +1363,21 @@ function registerCommands(programInstance) {
 		console.log(
 			boxen(
 				chalk.white.bold('Remove Subtask Command Help') +
-				'\n\n' +
-				chalk.cyan('Usage:') +
-				'\n' +
-				`  task-master remove-subtask --id=<parentId.subtaskId> [options]\n\n` +
-				chalk.cyan('Options:') +
-				'\n' +
-				'  -i, --id <id>       Subtask ID(s) to remove in format "parentId.subtaskId" (can be comma-separated, required)\n' +
-				'  -c, --convert       Convert the subtask to a standalone task instead of deleting it\n' +
-				'  -f, --file <file>   Path to the tasks file (default: "tasks/tasks.json")\n' +
-				'  --skip-generate     Skip regenerating task files\n\n' +
-				chalk.cyan('Examples:') +
-				'\n' +
-				'  task-master remove-subtask --id=5.2\n' +
-				'  task-master remove-subtask --id=5.2,6.3,7.1\n' +
-				'  task-master remove-subtask --id=5.2 --convert',
+					'\n\n' +
+					chalk.cyan('Usage:') +
+					'\n' +
+					`  task-master remove-subtask --id=<parentId.subtaskId> [options]\n\n` +
+					chalk.cyan('Options:') +
+					'\n' +
+					'  -i, --id <id>       Subtask ID(s) to remove in format "parentId.subtaskId" (can be comma-separated, required)\n' +
+					'  -c, --convert       Convert the subtask to a standalone task instead of deleting it\n' +
+					'  -f, --file <file>   Path to the tasks file (default: "tasks/tasks.json")\n' +
+					'  --skip-generate     Skip regenerating task files\n\n' +
+					chalk.cyan('Examples:') +
+					'\n' +
+					'  task-master remove-subtask --id=5.2\n' +
+					'  task-master remove-subtask --id=5.2,6.3,7.1\n' +
+					'  task-master remove-subtask --id=5.2 --convert',
 				{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 			)
 		);
@@ -1728,7 +1731,7 @@ function compareVersions(v1, v2) {
 function displayUpgradeNotification(currentVersion, latestVersion) {
 	const message = boxen(
 		`${chalk.blue.bold('Update Available!')} ${chalk.dim(currentVersion)} → ${chalk.green(latestVersion)}\n\n` +
-		`Run ${chalk.cyan('npm i task-master-ai@latest -g')} to update to the latest version with new features and bug fixes.`,
+			`Run ${chalk.cyan('npm i task-master-ai@latest -g')} to update to the latest version with new features and bug fixes.`,
 		{
 			padding: 1,
 			margin: { top: 1, bottom: 1 },

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -88,6 +88,7 @@ function registerCommands(programInstance) {
 		.option('-o, --output <file>', 'Output file path', 'tasks/tasks.json')
 		.option('-n, --num-tasks <number>', 'Number of tasks to generate', '10')
 		.option('-f, --force', 'Skip confirmation when overwriting existing tasks')
+		.option('--append', 'Append new tasks to existing tasks.json instead of overwriting')
 		.action(async (file, options) => {
 			// Use input option if file argument not provided
 			const inputFile = file || options.input;
@@ -95,10 +96,11 @@ function registerCommands(programInstance) {
 			const numTasks = parseInt(options.numTasks, 10);
 			const outputPath = options.output;
 			const force = options.force || false;
+			const append = options.append || false;
 
 			// Helper function to check if tasks.json exists and confirm overwrite
 			async function confirmOverwriteIfNeeded() {
-				if (fs.existsSync(outputPath) && !force) {
+				if (fs.existsSync(outputPath) && !force && !append) {
 					const shouldContinue = await confirmTaskOverwrite(outputPath);
 					if (!shouldContinue) {
 						console.log(chalk.yellow('Operation cancelled by user.'));
@@ -117,7 +119,7 @@ function registerCommands(programInstance) {
 					if (!(await confirmOverwriteIfNeeded())) return;
 
 					console.log(chalk.blue(`Generating ${numTasks} tasks...`));
-					await parsePRD(defaultPrdPath, outputPath, numTasks);
+					await parsePRD(defaultPrdPath, outputPath, numTasks, { append });
 					return;
 				}
 
@@ -129,26 +131,30 @@ function registerCommands(programInstance) {
 				console.log(
 					boxen(
 						chalk.white.bold('Parse PRD Help') +
-							'\n\n' +
-							chalk.cyan('Usage:') +
-							'\n' +
-							`  task-master parse-prd <prd-file.txt> [options]\n\n` +
-							chalk.cyan('Options:') +
-							'\n' +
-							'  -i, --input <file>       Path to the PRD file (alternative to positional argument)\n' +
-							'  -o, --output <file>      Output file path (default: "tasks/tasks.json")\n' +
-							'  -n, --num-tasks <number> Number of tasks to generate (default: 10)\n' +
-							'  -f, --force              Skip confirmation when overwriting existing tasks\n\n' +
-							chalk.cyan('Example:') +
-							'\n' +
-							'  task-master parse-prd requirements.txt --num-tasks 15\n' +
-							'  task-master parse-prd --input=requirements.txt\n' +
-							'  task-master parse-prd --force\n\n' +
-							chalk.yellow('Note: This command will:') +
-							'\n' +
-							'  1. Look for a PRD file at scripts/prd.txt by default\n' +
-							'  2. Use the file specified by --input or positional argument if provided\n' +
-							'  3. Generate tasks from the PRD and overwrite any existing tasks.json file',
+						'\n\n' +
+						chalk.cyan('Usage:') +
+						'\n' +
+						`  task-master parse-prd <prd-file.txt> [options]\n\n` +
+						chalk.cyan('Options:') +
+						'\n' +
+						'  -i, --input <file>       Path to the PRD file (alternative to positional argument)\n' +
+						'  -o, --output <file>      Output file path (default: "tasks/tasks.json")\n' +
+						'  -n, --num-tasks <number> Number of tasks to generate (default: 10)\n' +
+						'  -f, --force              Skip confirmation when overwriting existing tasks\n' +
+						'  --append                 Append new tasks to existing tasks.json instead of overwriting\n\n' +
+						chalk.cyan('Example:') +
+						'\n' +
+						'  task-master parse-prd requirements.txt --num-tasks 15\n' +
+						'  task-master parse-prd --input=requirements.txt\n' +
+						'  task-master parse-prd --force\n' +
+						'  task-master parse-prd requirements_v2.txt --append\n\n' +
+						chalk.yellow('Note: This command will:') +
+						'\n' +
+						'  1. Look for a PRD file at scripts/prd.txt by default\n' +
+						'  2. Use the file specified by --input or positional argument if provided\n' +
+						'  3. Generate tasks from the PRD and either:\n' +
+						'     - Overwrite any existing tasks.json file (default)\n' +
+						'     - Append to existing tasks.json if --append is used',
 						{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 					)
 				);
@@ -160,8 +166,11 @@ function registerCommands(programInstance) {
 
 			console.log(chalk.blue(`Parsing PRD file: ${inputFile}`));
 			console.log(chalk.blue(`Generating ${numTasks} tasks...`));
+			if (append) {
+				console.log(chalk.blue('Appending to existing tasks...'));
+			}
 
-			await parsePRD(inputFile, outputPath, numTasks);
+			await parsePRD(inputFile, outputPath, numTasks, { append });
 		});
 
 	// update command
@@ -1132,25 +1141,25 @@ function registerCommands(programInstance) {
 							chalk.white.bold(
 								`Subtask ${parentId}.${subtask.id} Added Successfully`
 							) +
-								'\n\n' +
-								chalk.white(`Title: ${subtask.title}`) +
-								'\n' +
-								chalk.white(`Status: ${getStatusWithColor(subtask.status)}`) +
-								'\n' +
-								(dependencies.length > 0
-									? chalk.white(`Dependencies: ${dependencies.join(', ')}`) +
-										'\n'
-									: '') +
-								'\n' +
-								chalk.white.bold('Next Steps:') +
-								'\n' +
-								chalk.cyan(
-									`1. Run ${chalk.yellow(`task-master show ${parentId}`)} to see the parent task with all subtasks`
-								) +
-								'\n' +
-								chalk.cyan(
-									`2. Run ${chalk.yellow(`task-master set-status --id=${parentId}.${subtask.id} --status=in-progress`)} to start working on it`
-								),
+							'\n\n' +
+							chalk.white(`Title: ${subtask.title}`) +
+							'\n' +
+							chalk.white(`Status: ${getStatusWithColor(subtask.status)}`) +
+							'\n' +
+							(dependencies.length > 0
+								? chalk.white(`Dependencies: ${dependencies.join(', ')}`) +
+								'\n'
+								: '') +
+							'\n' +
+							chalk.white.bold('Next Steps:') +
+							'\n' +
+							chalk.cyan(
+								`1. Run ${chalk.yellow(`task-master show ${parentId}`)} to see the parent task with all subtasks`
+							) +
+							'\n' +
+							chalk.cyan(
+								`2. Run ${chalk.yellow(`task-master set-status --id=${parentId}.${subtask.id} --status=in-progress`)} to start working on it`
+							),
 							{
 								padding: 1,
 								borderColor: 'green',
@@ -1166,19 +1175,19 @@ function registerCommands(programInstance) {
 					console.log(
 						boxen(
 							chalk.white.bold('Usage Examples:') +
-								'\n\n' +
-								chalk.white('Convert existing task to subtask:') +
-								'\n' +
-								chalk.yellow(
-									`  task-master add-subtask --parent=5 --task-id=8`
-								) +
-								'\n\n' +
-								chalk.white('Create new subtask:') +
-								'\n' +
-								chalk.yellow(
-									`  task-master add-subtask --parent=5 --title="Implement login UI" --description="Create the login form"`
-								) +
-								'\n\n',
+							'\n\n' +
+							chalk.white('Convert existing task to subtask:') +
+							'\n' +
+							chalk.yellow(
+								`  task-master add-subtask --parent=5 --task-id=8`
+							) +
+							'\n\n' +
+							chalk.white('Create new subtask:') +
+							'\n' +
+							chalk.yellow(
+								`  task-master add-subtask --parent=5 --title="Implement login UI" --description="Create the login form"`
+							) +
+							'\n\n',
 							{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 						)
 					);
@@ -1200,25 +1209,25 @@ function registerCommands(programInstance) {
 		console.log(
 			boxen(
 				chalk.white.bold('Add Subtask Command Help') +
-					'\n\n' +
-					chalk.cyan('Usage:') +
-					'\n' +
-					`  task-master add-subtask --parent=<id> [options]\n\n` +
-					chalk.cyan('Options:') +
-					'\n' +
-					'  -p, --parent <id>         Parent task ID (required)\n' +
-					'  -i, --task-id <id>        Existing task ID to convert to subtask\n' +
-					'  -t, --title <title>       Title for the new subtask\n' +
-					'  -d, --description <text>  Description for the new subtask\n' +
-					'  --details <text>          Implementation details for the new subtask\n' +
-					'  --dependencies <ids>      Comma-separated list of dependency IDs\n' +
-					'  -s, --status <status>     Status for the new subtask (default: "pending")\n' +
-					'  -f, --file <file>         Path to the tasks file (default: "tasks/tasks.json")\n' +
-					'  --skip-generate           Skip regenerating task files\n\n' +
-					chalk.cyan('Examples:') +
-					'\n' +
-					'  task-master add-subtask --parent=5 --task-id=8\n' +
-					'  task-master add-subtask -p 5 -t "Implement login UI" -d "Create the login form"',
+				'\n\n' +
+				chalk.cyan('Usage:') +
+				'\n' +
+				`  task-master add-subtask --parent=<id> [options]\n\n` +
+				chalk.cyan('Options:') +
+				'\n' +
+				'  -p, --parent <id>         Parent task ID (required)\n' +
+				'  -i, --task-id <id>        Existing task ID to convert to subtask\n' +
+				'  -t, --title <title>       Title for the new subtask\n' +
+				'  -d, --description <text>  Description for the new subtask\n' +
+				'  --details <text>          Implementation details for the new subtask\n' +
+				'  --dependencies <ids>      Comma-separated list of dependency IDs\n' +
+				'  -s, --status <status>     Status for the new subtask (default: "pending")\n' +
+				'  -f, --file <file>         Path to the tasks file (default: "tasks/tasks.json")\n' +
+				'  --skip-generate           Skip regenerating task files\n\n' +
+				chalk.cyan('Examples:') +
+				'\n' +
+				'  task-master add-subtask --parent=5 --task-id=8\n' +
+				'  task-master add-subtask -p 5 -t "Implement login UI" -d "Create the login form"',
 				{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 			)
 		);
@@ -1291,24 +1300,24 @@ function registerCommands(programInstance) {
 								chalk.white.bold(
 									`Subtask ${subtaskId} Converted to Task #${result.id}`
 								) +
-									'\n\n' +
-									chalk.white(`Title: ${result.title}`) +
-									'\n' +
-									chalk.white(`Status: ${getStatusWithColor(result.status)}`) +
-									'\n' +
-									chalk.white(
-										`Dependencies: ${result.dependencies.join(', ')}`
-									) +
-									'\n\n' +
-									chalk.white.bold('Next Steps:') +
-									'\n' +
-									chalk.cyan(
-										`1. Run ${chalk.yellow(`task-master show ${result.id}`)} to see details of the new task`
-									) +
-									'\n' +
-									chalk.cyan(
-										`2. Run ${chalk.yellow(`task-master set-status --id=${result.id} --status=in-progress`)} to start working on it`
-									),
+								'\n\n' +
+								chalk.white(`Title: ${result.title}`) +
+								'\n' +
+								chalk.white(`Status: ${getStatusWithColor(result.status)}`) +
+								'\n' +
+								chalk.white(
+									`Dependencies: ${result.dependencies.join(', ')}`
+								) +
+								'\n\n' +
+								chalk.white.bold('Next Steps:') +
+								'\n' +
+								chalk.cyan(
+									`1. Run ${chalk.yellow(`task-master show ${result.id}`)} to see details of the new task`
+								) +
+								'\n' +
+								chalk.cyan(
+									`2. Run ${chalk.yellow(`task-master set-status --id=${result.id} --status=in-progress`)} to start working on it`
+								),
 								{
 									padding: 1,
 									borderColor: 'green',
@@ -1322,8 +1331,8 @@ function registerCommands(programInstance) {
 						console.log(
 							boxen(
 								chalk.white.bold(`Subtask ${subtaskId} Removed`) +
-									'\n\n' +
-									chalk.white('The subtask has been successfully deleted.'),
+								'\n\n' +
+								chalk.white('The subtask has been successfully deleted.'),
 								{
 									padding: 1,
 									borderColor: 'green',
@@ -1351,21 +1360,21 @@ function registerCommands(programInstance) {
 		console.log(
 			boxen(
 				chalk.white.bold('Remove Subtask Command Help') +
-					'\n\n' +
-					chalk.cyan('Usage:') +
-					'\n' +
-					`  task-master remove-subtask --id=<parentId.subtaskId> [options]\n\n` +
-					chalk.cyan('Options:') +
-					'\n' +
-					'  -i, --id <id>       Subtask ID(s) to remove in format "parentId.subtaskId" (can be comma-separated, required)\n' +
-					'  -c, --convert       Convert the subtask to a standalone task instead of deleting it\n' +
-					'  -f, --file <file>   Path to the tasks file (default: "tasks/tasks.json")\n' +
-					'  --skip-generate     Skip regenerating task files\n\n' +
-					chalk.cyan('Examples:') +
-					'\n' +
-					'  task-master remove-subtask --id=5.2\n' +
-					'  task-master remove-subtask --id=5.2,6.3,7.1\n' +
-					'  task-master remove-subtask --id=5.2 --convert',
+				'\n\n' +
+				chalk.cyan('Usage:') +
+				'\n' +
+				`  task-master remove-subtask --id=<parentId.subtaskId> [options]\n\n` +
+				chalk.cyan('Options:') +
+				'\n' +
+				'  -i, --id <id>       Subtask ID(s) to remove in format "parentId.subtaskId" (can be comma-separated, required)\n' +
+				'  -c, --convert       Convert the subtask to a standalone task instead of deleting it\n' +
+				'  -f, --file <file>   Path to the tasks file (default: "tasks/tasks.json")\n' +
+				'  --skip-generate     Skip regenerating task files\n\n' +
+				chalk.cyan('Examples:') +
+				'\n' +
+				'  task-master remove-subtask --id=5.2\n' +
+				'  task-master remove-subtask --id=5.2,6.3,7.1\n' +
+				'  task-master remove-subtask --id=5.2 --convert',
 				{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
 			)
 		);
@@ -1719,7 +1728,7 @@ function compareVersions(v1, v2) {
 function displayUpgradeNotification(currentVersion, latestVersion) {
 	const message = boxen(
 		`${chalk.blue.bold('Update Available!')} ${chalk.dim(currentVersion)} → ${chalk.green(latestVersion)}\n\n` +
-			`Run ${chalk.cyan('npm i task-master-ai@latest -g')} to update to the latest version with new features and bug fixes.`,
+		`Run ${chalk.cyan('npm i task-master-ai@latest -g')} to update to the latest version with new features and bug fixes.`,
 		{
 			padding: 1,
 			margin: { top: 1, bottom: 1 },

--- a/scripts/modules/task-manager.js
+++ b/scripts/modules/task-manager.js
@@ -106,7 +106,7 @@ async function parsePRD(
 	aiClient = null,
 	modelConfig = null
 ) {
-	const { reportProgress, mcpLog, session } = options;
+	const { reportProgress, mcpLog, session, append } = options;
 
 	// Determine output format based on mcpLog presence (simplification)
 	const outputFormat = mcpLog ? 'json' : 'text';
@@ -127,26 +127,53 @@ async function parsePRD(
 		// Read the PRD content
 		const prdContent = fs.readFileSync(prdPath, 'utf8');
 
+		// If appending and tasks.json exists, read it first
+		let existingTasks = { tasks: [] };
+		let lastTaskId = 0;
+		if (append && fs.existsSync(tasksPath)) {
+			try {
+				existingTasks = readJSON(tasksPath);
+				if (existingTasks.tasks && existingTasks.tasks.length > 0) {
+					// Find the highest task ID
+					lastTaskId = Math.max(...existingTasks.tasks.map(task => {
+						const mainId = parseInt(task.id.toString().split('.')[0], 10);
+						return isNaN(mainId) ? 0 : mainId;
+					}));
+				}
+			} catch (error) {
+				report(`Warning: Could not read existing tasks file: ${error.message}`, 'warn');
+				existingTasks = { tasks: [] };
+			}
+		}
+
 		// Call Claude to generate tasks, passing the provided AI client if available
-		const tasksData = await callClaude(
+		const newTasksData = await callClaude(
 			prdContent,
 			prdPath,
 			numTasks,
-			0,
+			lastTaskId, // Pass the last task ID so new tasks continue the sequence
 			{ reportProgress, mcpLog, session },
 			aiClient,
 			modelConfig
 		);
+
+		// Merge tasks if appending
+		const tasksData = append ? {
+			...existingTasks,
+			tasks: [...existingTasks.tasks, ...newTasksData.tasks]
+		} : newTasksData;
 
 		// Create the directory if it doesn't exist
 		const tasksDir = path.dirname(tasksPath);
 		if (!fs.existsSync(tasksDir)) {
 			fs.mkdirSync(tasksDir, { recursive: true });
 		}
+
 		// Write the tasks to the file
 		writeJSON(tasksPath, tasksData);
+		const actionVerb = append ? 'appended' : 'generated';
 		report(
-			`Successfully generated ${tasksData.tasks.length} tasks from PRD`,
+			`Successfully ${actionVerb} ${newTasksData.tasks.length} tasks from PRD`,
 			'success'
 		);
 		report(`Tasks saved to: ${tasksPath}`, 'info');
@@ -166,7 +193,7 @@ async function parsePRD(
 			console.log(
 				boxen(
 					chalk.green(
-						`Successfully generated ${tasksData.tasks.length} tasks from PRD`
+						`Successfully ${actionVerb} ${newTasksData.tasks.length} tasks from PRD`
 					),
 					{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 				)
@@ -175,9 +202,9 @@ async function parsePRD(
 			console.log(
 				boxen(
 					chalk.white.bold('Next Steps:') +
-						'\n\n' +
-						`${chalk.cyan('1.')} Run ${chalk.yellow('task-master list')} to view all tasks\n` +
-						`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks`,
+					'\n\n' +
+					`${chalk.cyan('1.')} Run ${chalk.yellow('task-master list')} to view all tasks\n` +
+					`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks`,
 					{
 						padding: 1,
 						borderColor: 'cyan',
@@ -302,19 +329,19 @@ async function updateTasks(
 			console.log(
 				boxen(
 					chalk.cyan.bold('How Completed Subtasks Are Handled:') +
-						'\n\n' +
-						chalk.white(
-							'• Subtasks marked as "done" or "completed" will be preserved\n'
-						) +
-						chalk.white(
-							'• New subtasks will build upon what has already been completed\n'
-						) +
-						chalk.white(
-							'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
-						) +
-						chalk.white(
-							'• This approach maintains a clear record of completed work and new requirements'
-						),
+					'\n\n' +
+					chalk.white(
+						'• Subtasks marked as "done" or "completed" will be preserved\n'
+					) +
+					chalk.white(
+						'• New subtasks will build upon what has already been completed\n'
+					) +
+					chalk.white(
+						'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
+					) +
+					chalk.white(
+						'• This approach maintains a clear record of completed work and new requirements'
+					),
 					{
 						padding: 1,
 						borderColor: 'blue',
@@ -424,13 +451,13 @@ Return only the updated tasks as a valid JSON array.`
 							],
 							temperature: parseFloat(
 								process.env.TEMPERATURE ||
-									session?.env?.TEMPERATURE ||
-									CONFIG.temperature
+								session?.env?.TEMPERATURE ||
+								CONFIG.temperature
 							),
 							max_tokens: parseInt(
 								process.env.MAX_TOKENS ||
-									session?.env?.MAX_TOKENS ||
-									CONFIG.maxTokens
+								session?.env?.MAX_TOKENS ||
+								CONFIG.maxTokens
 							)
 						});
 
@@ -796,16 +823,16 @@ async function updateTaskById(
 						chalk.yellow(
 							`Task ${taskId} is already marked as ${taskToUpdate.status} and cannot be updated.`
 						) +
-							'\n\n' +
-							chalk.white(
-								'Completed tasks are locked to maintain consistency. To modify a completed task, you must first:'
-							) +
-							'\n' +
-							chalk.white(
-								'1. Change its status to "pending" or "in-progress"'
-							) +
-							'\n' +
-							chalk.white('2. Then run the update-task command'),
+						'\n\n' +
+						chalk.white(
+							'Completed tasks are locked to maintain consistency. To modify a completed task, you must first:'
+						) +
+						'\n' +
+						chalk.white(
+							'1. Change its status to "pending" or "in-progress"'
+						) +
+						'\n' +
+						chalk.white('2. Then run the update-task command'),
 						{ padding: 1, borderColor: 'yellow', borderStyle: 'round' }
 					)
 				);
@@ -846,19 +873,19 @@ async function updateTaskById(
 			console.log(
 				boxen(
 					chalk.cyan.bold('How Completed Subtasks Are Handled:') +
-						'\n\n' +
-						chalk.white(
-							'• Subtasks marked as "done" or "completed" will be preserved\n'
-						) +
-						chalk.white(
-							'• New subtasks will build upon what has already been completed\n'
-						) +
-						chalk.white(
-							'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
-						) +
-						chalk.white(
-							'• This approach maintains a clear record of completed work and new requirements'
-						),
+					'\n\n' +
+					chalk.white(
+						'• Subtasks marked as "done" or "completed" will be preserved\n'
+					) +
+					chalk.white(
+						'• New subtasks will build upon what has already been completed\n'
+					) +
+					chalk.white(
+						'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
+					) +
+					chalk.white(
+						'• This approach maintains a clear record of completed work and new requirements'
+					),
 					{
 						padding: 1,
 						borderColor: 'blue',
@@ -969,13 +996,13 @@ Return only the updated task as a valid JSON object.`
 							],
 							temperature: parseFloat(
 								process.env.TEMPERATURE ||
-									session?.env?.TEMPERATURE ||
-									CONFIG.temperature
+								session?.env?.TEMPERATURE ||
+								CONFIG.temperature
 							),
 							max_tokens: parseInt(
 								process.env.MAX_TOKENS ||
-									session?.env?.MAX_TOKENS ||
-									CONFIG.maxTokens
+								session?.env?.MAX_TOKENS ||
+								CONFIG.maxTokens
 							)
 						});
 
@@ -1297,10 +1324,10 @@ Return only the updated task as a valid JSON object.`
 				console.log(
 					boxen(
 						chalk.green(`Successfully updated task #${taskId}`) +
-							'\n\n' +
-							chalk.white.bold('Updated Title:') +
-							' ' +
-							updatedTask.title,
+						'\n\n' +
+						chalk.white.bold('Updated Title:') +
+						' ' +
+						updatedTask.title,
 						{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 					)
 				);
@@ -1568,9 +1595,9 @@ async function setTaskStatus(tasksPath, taskIdInput, newStatus, options = {}) {
 				console.log(
 					boxen(
 						chalk.white.bold(`Successfully updated task ${id} status:`) +
-							'\n' +
-							`From: ${chalk.yellow(task ? task.status : 'unknown')}\n` +
-							`To:   ${chalk.green(newStatus)}`,
+						'\n' +
+						`From: ${chalk.yellow(task ? task.status : 'unknown')}\n` +
+						`To:   ${chalk.green(newStatus)}`,
 						{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 					)
 				);
@@ -1754,10 +1781,10 @@ function listTasks(
 		const filteredTasks =
 			statusFilter && statusFilter.toLowerCase() !== 'all' // <-- Added check for 'all'
 				? data.tasks.filter(
-						(task) =>
-							task.status &&
-							task.status.toLowerCase() === statusFilter.toLowerCase()
-					)
+					(task) =>
+						task.status &&
+						task.status.toLowerCase() === statusFilter.toLowerCase()
+				)
 				: data.tasks; // Default to all tasks if no filter or filter is 'all'
 
 		// Calculate completion statistics
@@ -1974,10 +2001,10 @@ function listTasks(
 		const nextTask = findNextTask(data.tasks);
 		const nextTaskInfo = nextTask
 			? `ID: ${chalk.cyan(nextTask.id)} - ${chalk.white.bold(truncate(nextTask.title, 40))}\n` +
-				`Priority: ${chalk.white(nextTask.priority || 'medium')}  Dependencies: ${formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true)}`
+			`Priority: ${chalk.white(nextTask.priority || 'medium')}  Dependencies: ${formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true)}`
 			: chalk.yellow(
-					'No eligible tasks found. All tasks are either completed or have unsatisfied dependencies.'
-				);
+				'No eligible tasks found. All tasks are either completed or have unsatisfied dependencies.'
+			);
 
 		// Get terminal width - more reliable method
 		let terminalWidth;
@@ -2333,14 +2360,14 @@ function listTasks(
 						.bold(
 							`🔥 Next Task to Work On: #${nextTask.id} - ${nextTask.title}`
 						) +
-						'\n\n' +
-						`${chalk.white('Priority:')} ${priorityColors[nextTask.priority || 'medium'](nextTask.priority || 'medium')}   ${chalk.white('Status:')} ${getStatusWithColor(nextTask.status, true)}\n` +
-						`${chalk.white('Dependencies:')} ${nextTask.dependencies && nextTask.dependencies.length > 0 ? formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true) : chalk.gray('None')}\n\n` +
-						`${chalk.white('Description:')} ${nextTask.description}` +
-						subtasksSection +
-						'\n\n' +
-						`${chalk.cyan('Start working:')} ${chalk.yellow(`task-master set-status --id=${nextTask.id} --status=in-progress`)}\n` +
-						`${chalk.cyan('View details:')} ${chalk.yellow(`task-master show ${nextTask.id}`)}`,
+					'\n\n' +
+					`${chalk.white('Priority:')} ${priorityColors[nextTask.priority || 'medium'](nextTask.priority || 'medium')}   ${chalk.white('Status:')} ${getStatusWithColor(nextTask.status, true)}\n` +
+					`${chalk.white('Dependencies:')} ${nextTask.dependencies && nextTask.dependencies.length > 0 ? formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true) : chalk.gray('None')}\n\n` +
+					`${chalk.white('Description:')} ${nextTask.description}` +
+					subtasksSection +
+					'\n\n' +
+					`${chalk.cyan('Start working:')} ${chalk.yellow(`task-master set-status --id=${nextTask.id} --status=in-progress`)}\n` +
+					`${chalk.cyan('View details:')} ${chalk.yellow(`task-master show ${nextTask.id}`)}`,
 					{
 						padding: { left: 2, right: 2, top: 1, bottom: 1 },
 						borderColor: '#FF8800',
@@ -2357,8 +2384,8 @@ function listTasks(
 			console.log(
 				boxen(
 					chalk.hex('#FF8800').bold('No eligible next task found') +
-						'\n\n' +
-						'All pending tasks have dependencies that are not yet completed, or all tasks are done.',
+					'\n\n' +
+					'All pending tasks have dependencies that are not yet completed, or all tasks are done.',
 					{
 						padding: 1,
 						borderColor: '#FF8800',
@@ -2376,10 +2403,10 @@ function listTasks(
 		console.log(
 			boxen(
 				chalk.white.bold('Suggested Next Steps:') +
-					'\n\n' +
-					`${chalk.cyan('1.')} Run ${chalk.yellow('task-master next')} to see what to work on next\n` +
-					`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks\n` +
-					`${chalk.cyan('3.')} Run ${chalk.yellow('task-master set-status --id=<id> --status=done')} to mark a task as complete`,
+				'\n\n' +
+				`${chalk.cyan('1.')} Run ${chalk.yellow('task-master next')} to see what to work on next\n` +
+				`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks\n` +
+				`${chalk.cyan('3.')} Run ${chalk.yellow('task-master set-status --id=<id> --status=done')} to mark a task as complete`,
 				{
 					padding: 1,
 					borderColor: 'gray',
@@ -2943,14 +2970,14 @@ async function expandAllTasks(
 			console.log(
 				boxen(
 					chalk.white.bold(`Task Expansion Completed`) +
-						'\n\n' +
-						chalk.white(
-							`Expanded ${expandedCount} out of ${tasksToExpand.length} tasks`
-						) +
-						'\n' +
-						chalk.white(
-							`Each task now has detailed subtasks to guide implementation`
-						),
+					'\n\n' +
+					chalk.white(
+						`Expanded ${expandedCount} out of ${tasksToExpand.length} tasks`
+					) +
+					'\n' +
+					chalk.white(
+						`Each task now has detailed subtasks to guide implementation`
+					),
 					{
 						padding: 1,
 						borderColor: 'green',
@@ -3094,9 +3121,9 @@ function clearSubtasks(tasksPath, taskIds) {
 		console.log(
 			boxen(
 				chalk.white.bold('Next Steps:') +
-					'\n\n' +
-					`${chalk.cyan('1.')} Run ${chalk.yellow('task-master expand --id=<id>')} to generate new subtasks\n` +
-					`${chalk.cyan('2.')} Run ${chalk.yellow('task-master list --with-subtasks')} to verify changes`,
+				'\n\n' +
+				`${chalk.cyan('1.')} Run ${chalk.yellow('task-master expand --id=<id>')} to generate new subtasks\n` +
+				`${chalk.cyan('2.')} Run ${chalk.yellow('task-master list --with-subtasks')} to verify changes`,
 				{
 					padding: 1,
 					borderColor: 'cyan',
@@ -3299,13 +3326,13 @@ async function addTask(
 								],
 								temperature: parseFloat(
 									process.env.TEMPERATURE ||
-										session?.env?.TEMPERATURE ||
-										CONFIG.temperature
+									session?.env?.TEMPERATURE ||
+									CONFIG.temperature
 								),
 								max_tokens: parseInt(
 									process.env.MAX_TOKENS ||
-										session?.env?.MAX_TOKENS ||
-										CONFIG.maxTokens
+									session?.env?.MAX_TOKENS ||
+									CONFIG.maxTokens
 								)
 							});
 
@@ -3501,32 +3528,32 @@ async function addTask(
 			console.log(
 				boxen(
 					chalk.white.bold(`Task ${newTaskId} Created Successfully`) +
-						'\n\n' +
-						chalk.white(`Title: ${newTask.title}`) +
-						'\n' +
-						chalk.white(`Status: ${getStatusWithColor(newTask.status)}`) +
-						'\n' +
-						chalk.white(
-							`Priority: ${chalk.keyword(getPriorityColor(newTask.priority))(newTask.priority)}`
-						) +
-						'\n' +
-						(dependencies.length > 0
-							? chalk.white(`Dependencies: ${dependencies.join(', ')}`) + '\n'
-							: '') +
-						'\n' +
-						chalk.white.bold('Next Steps:') +
-						'\n' +
-						chalk.cyan(
-							`1. Run ${chalk.yellow(`task-master show ${newTaskId}`)} to see complete task details`
-						) +
-						'\n' +
-						chalk.cyan(
-							`2. Run ${chalk.yellow(`task-master set-status --id=${newTaskId} --status=in-progress`)} to start working on it`
-						) +
-						'\n' +
-						chalk.cyan(
-							`3. Run ${chalk.yellow(`task-master expand --id=${newTaskId}`)} to break it down into subtasks`
-						),
+					'\n\n' +
+					chalk.white(`Title: ${newTask.title}`) +
+					'\n' +
+					chalk.white(`Status: ${getStatusWithColor(newTask.status)}`) +
+					'\n' +
+					chalk.white(
+						`Priority: ${chalk.keyword(getPriorityColor(newTask.priority))(newTask.priority)}`
+					) +
+					'\n' +
+					(dependencies.length > 0
+						? chalk.white(`Dependencies: ${dependencies.join(', ')}`) + '\n'
+						: '') +
+					'\n' +
+					chalk.white.bold('Next Steps:') +
+					'\n' +
+					chalk.cyan(
+						`1. Run ${chalk.yellow(`task-master show ${newTaskId}`)} to see complete task details`
+					) +
+					'\n' +
+					chalk.cyan(
+						`2. Run ${chalk.yellow(`task-master set-status --id=${newTaskId} --status=in-progress`)} to start working on it`
+					) +
+					'\n' +
+					chalk.cyan(
+						`3. Run ${chalk.yellow(`task-master expand --id=${newTaskId}`)} to break it down into subtasks`
+					),
 					{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 				)
 			);
@@ -4387,10 +4414,10 @@ DO NOT include any text before or after the JSON array. No explanations, no mark
 					console.log(
 						boxen(
 							chalk.white.bold('Suggested Next Steps:') +
-								'\n\n' +
-								`${chalk.cyan('1.')} Run ${chalk.yellow('task-master complexity-report')} to review detailed findings\n` +
-								`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down complex tasks\n` +
-								`${chalk.cyan('3.')} Run ${chalk.yellow('task-master expand --all')} to expand all pending tasks based on complexity`,
+							'\n\n' +
+							`${chalk.cyan('1.')} Run ${chalk.yellow('task-master complexity-report')} to review detailed findings\n` +
+							`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down complex tasks\n` +
+							`${chalk.cyan('3.')} Run ${chalk.yellow('task-master expand --all')} to expand all pending tasks based on complexity`,
 							{
 								padding: 1,
 								borderColor: 'cyan',
@@ -4951,16 +4978,16 @@ async function updateSubtaskById(
 						chalk.yellow(
 							`Subtask ${subtaskId} is already marked as ${subtask.status} and cannot be updated.`
 						) +
-							'\n\n' +
-							chalk.white(
-								'Completed subtasks are locked to maintain consistency. To modify a completed subtask, you must first:'
-							) +
-							'\n' +
-							chalk.white(
-								'1. Change its status to "pending" or "in-progress"'
-							) +
-							'\n' +
-							chalk.white('2. Then run the update-subtask command'),
+						'\n\n' +
+						chalk.white(
+							'Completed subtasks are locked to maintain consistency. To modify a completed subtask, you must first:'
+						) +
+						'\n' +
+						chalk.white(
+							'1. Change its status to "pending" or "in-progress"'
+						) +
+						'\n' +
+						chalk.white('2. Then run the update-subtask command'),
 						{ padding: 1, borderColor: 'yellow', borderStyle: 'round' }
 					)
 				);
@@ -5061,13 +5088,13 @@ Provide concrete examples, code snippets, or implementation details when relevan
 						],
 						temperature: parseFloat(
 							process.env.TEMPERATURE ||
-								session?.env?.TEMPERATURE ||
-								CONFIG.temperature
+							session?.env?.TEMPERATURE ||
+							CONFIG.temperature
 						),
 						max_tokens: parseInt(
 							process.env.MAX_TOKENS ||
-								session?.env?.MAX_TOKENS ||
-								CONFIG.maxTokens
+							session?.env?.MAX_TOKENS ||
+							CONFIG.maxTokens
 						)
 					});
 					additionalInformation = response.choices[0].message.content.trim();
@@ -5318,14 +5345,14 @@ Provide concrete examples, code snippets, or implementation details when relevan
 			console.log(
 				boxen(
 					chalk.green(`Successfully updated subtask #${subtaskId}`) +
-						'\n\n' +
-						chalk.white.bold('Title:') +
-						' ' +
-						subtask.title +
-						'\n\n' +
-						chalk.white.bold('Information Added:') +
-						'\n' +
-						chalk.white(truncate(additionalInformation, 300, true)),
+					'\n\n' +
+					chalk.white.bold('Title:') +
+					' ' +
+					subtask.title +
+					'\n\n' +
+					chalk.white.bold('Information Added:') +
+					'\n' +
+					chalk.white(truncate(additionalInformation, 300, true)),
 					{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 				)
 			);

--- a/scripts/modules/task-manager.js
+++ b/scripts/modules/task-manager.js
@@ -135,13 +135,18 @@ async function parsePRD(
 				existingTasks = readJSON(tasksPath);
 				if (existingTasks.tasks && existingTasks.tasks.length > 0) {
 					// Find the highest task ID
-					lastTaskId = Math.max(...existingTasks.tasks.map(task => {
-						const mainId = parseInt(task.id.toString().split('.')[0], 10);
-						return isNaN(mainId) ? 0 : mainId;
-					}));
+					lastTaskId = Math.max(
+						...existingTasks.tasks.map((task) => {
+							const mainId = parseInt(task.id.toString().split('.')[0], 10);
+							return isNaN(mainId) ? 0 : mainId;
+						})
+					);
 				}
 			} catch (error) {
-				report(`Warning: Could not read existing tasks file: ${error.message}`, 'warn');
+				report(
+					`Warning: Could not read existing tasks file: ${error.message}`,
+					'warn'
+				);
 				existingTasks = { tasks: [] };
 			}
 		}
@@ -158,10 +163,12 @@ async function parsePRD(
 		);
 
 		// Merge tasks if appending
-		const tasksData = append ? {
-			...existingTasks,
-			tasks: [...existingTasks.tasks, ...newTasksData.tasks]
-		} : newTasksData;
+		const tasksData = append
+			? {
+					...existingTasks,
+					tasks: [...existingTasks.tasks, ...newTasksData.tasks]
+				}
+			: newTasksData;
 
 		// Create the directory if it doesn't exist
 		const tasksDir = path.dirname(tasksPath);
@@ -202,9 +209,9 @@ async function parsePRD(
 			console.log(
 				boxen(
 					chalk.white.bold('Next Steps:') +
-					'\n\n' +
-					`${chalk.cyan('1.')} Run ${chalk.yellow('task-master list')} to view all tasks\n` +
-					`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks`,
+						'\n\n' +
+						`${chalk.cyan('1.')} Run ${chalk.yellow('task-master list')} to view all tasks\n` +
+						`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks`,
 					{
 						padding: 1,
 						borderColor: 'cyan',
@@ -329,19 +336,19 @@ async function updateTasks(
 			console.log(
 				boxen(
 					chalk.cyan.bold('How Completed Subtasks Are Handled:') +
-					'\n\n' +
-					chalk.white(
-						'• Subtasks marked as "done" or "completed" will be preserved\n'
-					) +
-					chalk.white(
-						'• New subtasks will build upon what has already been completed\n'
-					) +
-					chalk.white(
-						'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
-					) +
-					chalk.white(
-						'• This approach maintains a clear record of completed work and new requirements'
-					),
+						'\n\n' +
+						chalk.white(
+							'• Subtasks marked as "done" or "completed" will be preserved\n'
+						) +
+						chalk.white(
+							'• New subtasks will build upon what has already been completed\n'
+						) +
+						chalk.white(
+							'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
+						) +
+						chalk.white(
+							'• This approach maintains a clear record of completed work and new requirements'
+						),
 					{
 						padding: 1,
 						borderColor: 'blue',
@@ -451,13 +458,13 @@ Return only the updated tasks as a valid JSON array.`
 							],
 							temperature: parseFloat(
 								process.env.TEMPERATURE ||
-								session?.env?.TEMPERATURE ||
-								CONFIG.temperature
+									session?.env?.TEMPERATURE ||
+									CONFIG.temperature
 							),
 							max_tokens: parseInt(
 								process.env.MAX_TOKENS ||
-								session?.env?.MAX_TOKENS ||
-								CONFIG.maxTokens
+									session?.env?.MAX_TOKENS ||
+									CONFIG.maxTokens
 							)
 						});
 
@@ -823,16 +830,16 @@ async function updateTaskById(
 						chalk.yellow(
 							`Task ${taskId} is already marked as ${taskToUpdate.status} and cannot be updated.`
 						) +
-						'\n\n' +
-						chalk.white(
-							'Completed tasks are locked to maintain consistency. To modify a completed task, you must first:'
-						) +
-						'\n' +
-						chalk.white(
-							'1. Change its status to "pending" or "in-progress"'
-						) +
-						'\n' +
-						chalk.white('2. Then run the update-task command'),
+							'\n\n' +
+							chalk.white(
+								'Completed tasks are locked to maintain consistency. To modify a completed task, you must first:'
+							) +
+							'\n' +
+							chalk.white(
+								'1. Change its status to "pending" or "in-progress"'
+							) +
+							'\n' +
+							chalk.white('2. Then run the update-task command'),
 						{ padding: 1, borderColor: 'yellow', borderStyle: 'round' }
 					)
 				);
@@ -873,19 +880,19 @@ async function updateTaskById(
 			console.log(
 				boxen(
 					chalk.cyan.bold('How Completed Subtasks Are Handled:') +
-					'\n\n' +
-					chalk.white(
-						'• Subtasks marked as "done" or "completed" will be preserved\n'
-					) +
-					chalk.white(
-						'• New subtasks will build upon what has already been completed\n'
-					) +
-					chalk.white(
-						'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
-					) +
-					chalk.white(
-						'• This approach maintains a clear record of completed work and new requirements'
-					),
+						'\n\n' +
+						chalk.white(
+							'• Subtasks marked as "done" or "completed" will be preserved\n'
+						) +
+						chalk.white(
+							'• New subtasks will build upon what has already been completed\n'
+						) +
+						chalk.white(
+							'• If completed work needs revision, a new subtask will be created instead of modifying done items\n'
+						) +
+						chalk.white(
+							'• This approach maintains a clear record of completed work and new requirements'
+						),
 					{
 						padding: 1,
 						borderColor: 'blue',
@@ -996,13 +1003,13 @@ Return only the updated task as a valid JSON object.`
 							],
 							temperature: parseFloat(
 								process.env.TEMPERATURE ||
-								session?.env?.TEMPERATURE ||
-								CONFIG.temperature
+									session?.env?.TEMPERATURE ||
+									CONFIG.temperature
 							),
 							max_tokens: parseInt(
 								process.env.MAX_TOKENS ||
-								session?.env?.MAX_TOKENS ||
-								CONFIG.maxTokens
+									session?.env?.MAX_TOKENS ||
+									CONFIG.maxTokens
 							)
 						});
 
@@ -1324,10 +1331,10 @@ Return only the updated task as a valid JSON object.`
 				console.log(
 					boxen(
 						chalk.green(`Successfully updated task #${taskId}`) +
-						'\n\n' +
-						chalk.white.bold('Updated Title:') +
-						' ' +
-						updatedTask.title,
+							'\n\n' +
+							chalk.white.bold('Updated Title:') +
+							' ' +
+							updatedTask.title,
 						{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 					)
 				);
@@ -1595,9 +1602,9 @@ async function setTaskStatus(tasksPath, taskIdInput, newStatus, options = {}) {
 				console.log(
 					boxen(
 						chalk.white.bold(`Successfully updated task ${id} status:`) +
-						'\n' +
-						`From: ${chalk.yellow(task ? task.status : 'unknown')}\n` +
-						`To:   ${chalk.green(newStatus)}`,
+							'\n' +
+							`From: ${chalk.yellow(task ? task.status : 'unknown')}\n` +
+							`To:   ${chalk.green(newStatus)}`,
 						{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 					)
 				);
@@ -1781,10 +1788,10 @@ function listTasks(
 		const filteredTasks =
 			statusFilter && statusFilter.toLowerCase() !== 'all' // <-- Added check for 'all'
 				? data.tasks.filter(
-					(task) =>
-						task.status &&
-						task.status.toLowerCase() === statusFilter.toLowerCase()
-				)
+						(task) =>
+							task.status &&
+							task.status.toLowerCase() === statusFilter.toLowerCase()
+					)
 				: data.tasks; // Default to all tasks if no filter or filter is 'all'
 
 		// Calculate completion statistics
@@ -2001,10 +2008,10 @@ function listTasks(
 		const nextTask = findNextTask(data.tasks);
 		const nextTaskInfo = nextTask
 			? `ID: ${chalk.cyan(nextTask.id)} - ${chalk.white.bold(truncate(nextTask.title, 40))}\n` +
-			`Priority: ${chalk.white(nextTask.priority || 'medium')}  Dependencies: ${formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true)}`
+				`Priority: ${chalk.white(nextTask.priority || 'medium')}  Dependencies: ${formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true)}`
 			: chalk.yellow(
-				'No eligible tasks found. All tasks are either completed or have unsatisfied dependencies.'
-			);
+					'No eligible tasks found. All tasks are either completed or have unsatisfied dependencies.'
+				);
 
 		// Get terminal width - more reliable method
 		let terminalWidth;
@@ -2360,14 +2367,14 @@ function listTasks(
 						.bold(
 							`🔥 Next Task to Work On: #${nextTask.id} - ${nextTask.title}`
 						) +
-					'\n\n' +
-					`${chalk.white('Priority:')} ${priorityColors[nextTask.priority || 'medium'](nextTask.priority || 'medium')}   ${chalk.white('Status:')} ${getStatusWithColor(nextTask.status, true)}\n` +
-					`${chalk.white('Dependencies:')} ${nextTask.dependencies && nextTask.dependencies.length > 0 ? formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true) : chalk.gray('None')}\n\n` +
-					`${chalk.white('Description:')} ${nextTask.description}` +
-					subtasksSection +
-					'\n\n' +
-					`${chalk.cyan('Start working:')} ${chalk.yellow(`task-master set-status --id=${nextTask.id} --status=in-progress`)}\n` +
-					`${chalk.cyan('View details:')} ${chalk.yellow(`task-master show ${nextTask.id}`)}`,
+						'\n\n' +
+						`${chalk.white('Priority:')} ${priorityColors[nextTask.priority || 'medium'](nextTask.priority || 'medium')}   ${chalk.white('Status:')} ${getStatusWithColor(nextTask.status, true)}\n` +
+						`${chalk.white('Dependencies:')} ${nextTask.dependencies && nextTask.dependencies.length > 0 ? formatDependenciesWithStatus(nextTask.dependencies, data.tasks, true) : chalk.gray('None')}\n\n` +
+						`${chalk.white('Description:')} ${nextTask.description}` +
+						subtasksSection +
+						'\n\n' +
+						`${chalk.cyan('Start working:')} ${chalk.yellow(`task-master set-status --id=${nextTask.id} --status=in-progress`)}\n` +
+						`${chalk.cyan('View details:')} ${chalk.yellow(`task-master show ${nextTask.id}`)}`,
 					{
 						padding: { left: 2, right: 2, top: 1, bottom: 1 },
 						borderColor: '#FF8800',
@@ -2384,8 +2391,8 @@ function listTasks(
 			console.log(
 				boxen(
 					chalk.hex('#FF8800').bold('No eligible next task found') +
-					'\n\n' +
-					'All pending tasks have dependencies that are not yet completed, or all tasks are done.',
+						'\n\n' +
+						'All pending tasks have dependencies that are not yet completed, or all tasks are done.',
 					{
 						padding: 1,
 						borderColor: '#FF8800',
@@ -2403,10 +2410,10 @@ function listTasks(
 		console.log(
 			boxen(
 				chalk.white.bold('Suggested Next Steps:') +
-				'\n\n' +
-				`${chalk.cyan('1.')} Run ${chalk.yellow('task-master next')} to see what to work on next\n` +
-				`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks\n` +
-				`${chalk.cyan('3.')} Run ${chalk.yellow('task-master set-status --id=<id> --status=done')} to mark a task as complete`,
+					'\n\n' +
+					`${chalk.cyan('1.')} Run ${chalk.yellow('task-master next')} to see what to work on next\n` +
+					`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down a task into subtasks\n` +
+					`${chalk.cyan('3.')} Run ${chalk.yellow('task-master set-status --id=<id> --status=done')} to mark a task as complete`,
 				{
 					padding: 1,
 					borderColor: 'gray',
@@ -2970,14 +2977,14 @@ async function expandAllTasks(
 			console.log(
 				boxen(
 					chalk.white.bold(`Task Expansion Completed`) +
-					'\n\n' +
-					chalk.white(
-						`Expanded ${expandedCount} out of ${tasksToExpand.length} tasks`
-					) +
-					'\n' +
-					chalk.white(
-						`Each task now has detailed subtasks to guide implementation`
-					),
+						'\n\n' +
+						chalk.white(
+							`Expanded ${expandedCount} out of ${tasksToExpand.length} tasks`
+						) +
+						'\n' +
+						chalk.white(
+							`Each task now has detailed subtasks to guide implementation`
+						),
 					{
 						padding: 1,
 						borderColor: 'green',
@@ -3121,9 +3128,9 @@ function clearSubtasks(tasksPath, taskIds) {
 		console.log(
 			boxen(
 				chalk.white.bold('Next Steps:') +
-				'\n\n' +
-				`${chalk.cyan('1.')} Run ${chalk.yellow('task-master expand --id=<id>')} to generate new subtasks\n` +
-				`${chalk.cyan('2.')} Run ${chalk.yellow('task-master list --with-subtasks')} to verify changes`,
+					'\n\n' +
+					`${chalk.cyan('1.')} Run ${chalk.yellow('task-master expand --id=<id>')} to generate new subtasks\n` +
+					`${chalk.cyan('2.')} Run ${chalk.yellow('task-master list --with-subtasks')} to verify changes`,
 				{
 					padding: 1,
 					borderColor: 'cyan',
@@ -3326,13 +3333,13 @@ async function addTask(
 								],
 								temperature: parseFloat(
 									process.env.TEMPERATURE ||
-									session?.env?.TEMPERATURE ||
-									CONFIG.temperature
+										session?.env?.TEMPERATURE ||
+										CONFIG.temperature
 								),
 								max_tokens: parseInt(
 									process.env.MAX_TOKENS ||
-									session?.env?.MAX_TOKENS ||
-									CONFIG.maxTokens
+										session?.env?.MAX_TOKENS ||
+										CONFIG.maxTokens
 								)
 							});
 
@@ -3528,32 +3535,32 @@ async function addTask(
 			console.log(
 				boxen(
 					chalk.white.bold(`Task ${newTaskId} Created Successfully`) +
-					'\n\n' +
-					chalk.white(`Title: ${newTask.title}`) +
-					'\n' +
-					chalk.white(`Status: ${getStatusWithColor(newTask.status)}`) +
-					'\n' +
-					chalk.white(
-						`Priority: ${chalk.keyword(getPriorityColor(newTask.priority))(newTask.priority)}`
-					) +
-					'\n' +
-					(dependencies.length > 0
-						? chalk.white(`Dependencies: ${dependencies.join(', ')}`) + '\n'
-						: '') +
-					'\n' +
-					chalk.white.bold('Next Steps:') +
-					'\n' +
-					chalk.cyan(
-						`1. Run ${chalk.yellow(`task-master show ${newTaskId}`)} to see complete task details`
-					) +
-					'\n' +
-					chalk.cyan(
-						`2. Run ${chalk.yellow(`task-master set-status --id=${newTaskId} --status=in-progress`)} to start working on it`
-					) +
-					'\n' +
-					chalk.cyan(
-						`3. Run ${chalk.yellow(`task-master expand --id=${newTaskId}`)} to break it down into subtasks`
-					),
+						'\n\n' +
+						chalk.white(`Title: ${newTask.title}`) +
+						'\n' +
+						chalk.white(`Status: ${getStatusWithColor(newTask.status)}`) +
+						'\n' +
+						chalk.white(
+							`Priority: ${chalk.keyword(getPriorityColor(newTask.priority))(newTask.priority)}`
+						) +
+						'\n' +
+						(dependencies.length > 0
+							? chalk.white(`Dependencies: ${dependencies.join(', ')}`) + '\n'
+							: '') +
+						'\n' +
+						chalk.white.bold('Next Steps:') +
+						'\n' +
+						chalk.cyan(
+							`1. Run ${chalk.yellow(`task-master show ${newTaskId}`)} to see complete task details`
+						) +
+						'\n' +
+						chalk.cyan(
+							`2. Run ${chalk.yellow(`task-master set-status --id=${newTaskId} --status=in-progress`)} to start working on it`
+						) +
+						'\n' +
+						chalk.cyan(
+							`3. Run ${chalk.yellow(`task-master expand --id=${newTaskId}`)} to break it down into subtasks`
+						),
 					{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 				)
 			);
@@ -4414,10 +4421,10 @@ DO NOT include any text before or after the JSON array. No explanations, no mark
 					console.log(
 						boxen(
 							chalk.white.bold('Suggested Next Steps:') +
-							'\n\n' +
-							`${chalk.cyan('1.')} Run ${chalk.yellow('task-master complexity-report')} to review detailed findings\n` +
-							`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down complex tasks\n` +
-							`${chalk.cyan('3.')} Run ${chalk.yellow('task-master expand --all')} to expand all pending tasks based on complexity`,
+								'\n\n' +
+								`${chalk.cyan('1.')} Run ${chalk.yellow('task-master complexity-report')} to review detailed findings\n` +
+								`${chalk.cyan('2.')} Run ${chalk.yellow('task-master expand --id=<id>')} to break down complex tasks\n` +
+								`${chalk.cyan('3.')} Run ${chalk.yellow('task-master expand --all')} to expand all pending tasks based on complexity`,
 							{
 								padding: 1,
 								borderColor: 'cyan',
@@ -4978,16 +4985,16 @@ async function updateSubtaskById(
 						chalk.yellow(
 							`Subtask ${subtaskId} is already marked as ${subtask.status} and cannot be updated.`
 						) +
-						'\n\n' +
-						chalk.white(
-							'Completed subtasks are locked to maintain consistency. To modify a completed subtask, you must first:'
-						) +
-						'\n' +
-						chalk.white(
-							'1. Change its status to "pending" or "in-progress"'
-						) +
-						'\n' +
-						chalk.white('2. Then run the update-subtask command'),
+							'\n\n' +
+							chalk.white(
+								'Completed subtasks are locked to maintain consistency. To modify a completed subtask, you must first:'
+							) +
+							'\n' +
+							chalk.white(
+								'1. Change its status to "pending" or "in-progress"'
+							) +
+							'\n' +
+							chalk.white('2. Then run the update-subtask command'),
 						{ padding: 1, borderColor: 'yellow', borderStyle: 'round' }
 					)
 				);
@@ -5088,13 +5095,13 @@ Provide concrete examples, code snippets, or implementation details when relevan
 						],
 						temperature: parseFloat(
 							process.env.TEMPERATURE ||
-							session?.env?.TEMPERATURE ||
-							CONFIG.temperature
+								session?.env?.TEMPERATURE ||
+								CONFIG.temperature
 						),
 						max_tokens: parseInt(
 							process.env.MAX_TOKENS ||
-							session?.env?.MAX_TOKENS ||
-							CONFIG.maxTokens
+								session?.env?.MAX_TOKENS ||
+								CONFIG.maxTokens
 						)
 					});
 					additionalInformation = response.choices[0].message.content.trim();
@@ -5345,14 +5352,14 @@ Provide concrete examples, code snippets, or implementation details when relevan
 			console.log(
 				boxen(
 					chalk.green(`Successfully updated subtask #${subtaskId}`) +
-					'\n\n' +
-					chalk.white.bold('Title:') +
-					' ' +
-					subtask.title +
-					'\n\n' +
-					chalk.white.bold('Information Added:') +
-					'\n' +
-					chalk.white(truncate(additionalInformation, 300, true)),
+						'\n\n' +
+						chalk.white.bold('Title:') +
+						' ' +
+						subtask.title +
+						'\n\n' +
+						chalk.white.bold('Information Added:') +
+						'\n' +
+						chalk.white(truncate(additionalInformation, 300, true)),
 					{ padding: 1, borderColor: 'green', borderStyle: 'round' }
 				)
 			);


### PR DESCRIPTION
   ## Description
   This PR adds the `--append` flag to the `parse-prd` command, allowing users to append newly generated tasks to their existing task list when parsing multiple PRDs. This enables a more flexible and incremental workflow.

   ## Changes
   - Added `--append` flag to `parse-prd` command
   - Modified `parsePRD` function to support appending tasks
   - Added logic to handle task ID sequencing when appending
   - Updated help text and documentation
   - Added appropriate error handling and user feedback

   ## Features
   - Append new tasks to existing tasks.json instead of overwriting
   - Automatically continue task ID sequence from last existing task
   - Maintain existing tasks and their status
   - Clear user feedback about append operations

   ## Example Usage
   ```bash
   # Generate initial tasks
   task-master parse-prd requirements_v1.txt

   # Append more tasks from a second PRD
   task-master parse-prd requirements_v2.txt --append
   ```

   ## Testing
   Tested with:
   - Empty tasks.json
   - Existing tasks.json with various task states
   - Multiple append operations
   - Error cases (missing files, invalid JSON)

   ## Related Issues
   Fixes #207

   ## Checklist
   - [x] Added `--append` flag
   - [x] Implemented append functionality
   - [x] Added proper task ID sequencing
   - [x] Updated help documentation
   - [x] Created changeset
   - [x] Tested with various scenarios