### PR TITLE
fix(update/update-task/update-subtask): 

### DIFF
--- a/.changeset/chubby-moose-stay.md
+++ b/.changeset/chubby-moose-stay.md
@@ -1,0 +1,5 @@
+---
+'task-master-ai': patch
+---
+
+Updates the parameter descriptions for update, update-task and update-subtask to ensure the MCP server correctly reaches for the right update command based on what is being updated -- all tasks, one task, or a subtask.

--- a/mcp-server/src/tools/update-subtask.js
+++ b/mcp-server/src/tools/update-subtask.js
@@ -20,12 +20,12 @@ export function registerUpdateSubtaskTool(server) {
 	server.addTool({
 		name: 'update_subtask',
 		description:
-			'Appends additional information to a specific subtask without replacing existing content',
+			'Appends timestamped information to a specific subtask without replacing existing content',
 		parameters: z.object({
 			id: z
 				.string()
 				.describe(
-					'ID of the subtask to update in format "parentId.subtaskId" (e.g., "5.2")'
+					'ID of the subtask to update in format "parentId.subtaskId" (e.g., "5.2"). Parent ID is the ID of the task that contains the subtask.'
 				),
 			prompt: z.string().describe('Information to add to the subtask'),
 			research: z

--- a/mcp-server/src/tools/update-task.js
+++ b/mcp-server/src/tools/update-task.js
@@ -24,7 +24,9 @@ export function registerUpdateTaskTool(server) {
 		parameters: z.object({
 			id: z
 				.string()
-				.describe("ID of the task or subtask (e.g., '15', '15.2') to update"),
+				.describe(
+					"ID of the task (e.g., '15') to update. Subtasks are supported using the update-subtask tool."
+				),
 			prompt: z
 				.string()
 				.describe('New information or context to incorporate into the task'),

--- a/mcp-server/src/tools/update.js
+++ b/mcp-server/src/tools/update.js
@@ -20,7 +20,7 @@ export function registerUpdateTool(server) {
 	server.addTool({
 		name: 'update',
 		description:
-			"Update multiple upcoming tasks (with ID >= 'from' ID) based on new context or changes provided in the prompt. Use 'update_task' instead for a single specific task.",
+			"Update multiple upcoming tasks (with ID >= 'from' ID) based on new context or changes provided in the prompt. Use 'update_task' instead for a single specific task or 'update_subtask' for subtasks.",
 		parameters: z.object({
 			from: z
 				.string()


### PR DESCRIPTION
Updates the parameter descriptions for update, update-task and update-subtask to ensure the MCP server correctly reaches for the right update command based on what is being updated -- all tasks, one task, or a subtask.