### PR TITLE
fix/211 linux container init

### DIFF
--- a/.changeset/true-adults-build.md
+++ b/.changeset/true-adults-build.md
@@ -1,0 +1,5 @@
+---
+'task-master-ai': patch
+---
+
+fixing bug can not run task-master in linux container

--- a/.changeset/true-adults-build.md
+++ b/.changeset/true-adults-build.md
@@ -2,4 +2,4 @@
 'task-master-ai': patch
 ---
 
-fixing bug can not run task-master in linux container
+Fixed a bug that prevented the task-master from running in a Linux container

--- a/index.js
+++ b/index.js
@@ -46,22 +46,18 @@ export const initProject = async (options = {}) => {
 };
 
 // Export a function to run init as a CLI command
-export const runInitCLI = async () => {
-	// Using spawn to ensure proper handling of stdio and process exit
-	const child = spawn('node', [resolve(__dirname, './scripts/init.js')], {
-		stdio: 'inherit',
-		cwd: process.cwd()
-	});
-
-	return new Promise((resolve, reject) => {
-		child.on('close', (code) => {
-			if (code === 0) {
-				resolve();
-			} else {
-				reject(new Error(`Init script exited with code ${code}`));
-			}
-		});
-	});
+export const runInitCLI = async (options = {}) => {
+	try {
+		const init = await import('./scripts/init.js');
+		const result = await init.initializeProject(options);
+		return result;
+	} catch (error) {
+		console.error('Initialization failed:', error.message);
+		if (process.env.DEBUG === 'true') {
+			console.error('Debug stack trace:', error.stack);
+		}
+		throw error; // Re-throw to be handled by the command handler
+	}
 };
 
 // Export version information
@@ -79,11 +75,21 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 	program
 		.command('init')
 		.description('Initialize a new project')
-		.action(() => {
-			runInitCLI().catch((err) => {
+		.option('-y, --yes', 'Skip prompts and use default values')
+		.option('-n, --name <n>', 'Project name')
+		.option('-d, --description <description>', 'Project description')
+		.option('-v, --version <version>', 'Project version', '0.1.0')
+		.option('-a, --author <author>', 'Author name')
+		.option('--skip-install', 'Skip installing dependencies')
+		.option('--dry-run', 'Show what would be done without making changes')
+		.option('--aliases', 'Add shell aliases (tm, taskmaster)')
+		.action(async (cmdOptions) => {
+			try {
+				await runInitCLI(cmdOptions);
+			} catch (err) {
 				console.error('Init failed:', err.message);
 				process.exit(1);
-			});
+			}
 		});
 
 	program


### PR DESCRIPTION
   ## Description
   This PR fixes issue #211 where task-master init doesn't respond in Linux containers. The fix improves error handling and provides better debugging capabilities.

   ## Changes
   - Enhanced error handling in `runInitCLI` function
   - Added debug stack trace output when `DEBUG=true` is set
   - Improved error messaging for initialization failures
   - Added changeset for version tracking

   ## Testing
   Tested in Linux container environment with:
   - Basic initialization
   - Error scenarios with DEBUG=true
   - Various command options

   ## Related Issues
   Fixes #211

   ## Checklist
   - [x] Added proper error handling
   - [x] Added debug logging capabilities
   - [x] Created changeset
   - [x] Tested in Linux container environment