### PR TITLE
Docs: Add section on enhanced 🦘 Roo Code integration via community patch

### DIFF
--- a/README-task-master.md
+++ b/README-task-master.md
@@ -187,7 +187,7 @@ task-master generate
 
 This creates individual task files in the `tasks/` directory (e.g., `task_001.txt`, `task_002.txt`), making it easier to reference specific tasks.
 
-## Integrating with Roo Code
+## 🦘 Integrating with Roo Code 
 
 While the standard [MCP setup](#setting-up-mcp-in-cursor) allows Taskmaster AI to work effectively with AI agents like Roo Code (used by Cursor AI), some users may desire more explicit control over the rules and guidelines the AI follows, especially in team environments or for complex projects. Standard Roo Code setups might rely on default rules that may not perfectly align with Taskmaster's specific workflow or your project's unique standards.
 

--- a/README-task-master.md
+++ b/README-task-master.md
@@ -187,6 +187,36 @@ task-master generate
 
 This creates individual task files in the `tasks/` directory (e.g., `task_001.txt`, `task_002.txt`), making it easier to reference specific tasks.
 
+## Integrating with Roo Code
+
+While the standard [MCP setup](#setting-up-mcp-in-cursor) allows Taskmaster AI to work effectively with AI agents like Roo Code (used by Cursor AI), some users may desire more explicit control over the rules and guidelines the AI follows, especially in team environments or for complex projects. Standard Roo Code setups might rely on default rules that may not perfectly align with Taskmaster's specific workflow or your project's unique standards.
+
+For users seeking this enhanced control, a community-driven approach provides a way to manage Roo Code's behavior by fetching specific modes and rules from a dedicated repository:
+
+**Repository:** [neno-is-ooo/roo-taskmaster-patch](https://github.com/neno-is-ooo/roo-taskmaster-patch)
+
+This repository contains:
+1.  An installation script (`install_taskmaster.py`) to automate the setup.
+2.  A set of pre-configured Roo Code modes (`.roomodes`).
+3.  Custom Roo Code rules (`.roo/rules-*/*`) specifically designed to guide Roo agents (like Boomerang and Code) when interacting with Taskmaster tasks and workflows.
+
+**How it Works:**
+
+The `install_taskmaster.py` script (found in the patch repository above) automates the following:
+*   Installs `task-master-ai` (globally or locally).
+*   Helps configure the `taskmaster-ai` MCP server within Roo Code's settings.
+*   **Crucially, it fetches the specific `.roomodes` and `.roo/rules-*` files from the `roo-taskmaster-patch` repository and places them directly into your project.** This ensures Roo Code uses these specific guidelines for this project.
+
+**Benefits of this Approach:**
+
+*   **Enhanced Safety & Control:** Roo Code operates based on rules fetched from a *specific, known repository* rather than potentially unpredictable defaults. This gives you direct control over the AI's operational guidelines for your project.
+*   **Consistency:** Ensures all developers using Roo Code within the project are guided by the *same* set of rules and modes, leading to more predictable and standardized AI behavior.
+*   **Workflow Alignment:** The custom rules are tailored to understand and follow Taskmaster concepts like task dependencies, status updates, and breakdown strategies.
+*   **Streamlined Setup:** Simplifies the integration process for developers adopting this specific controlled workflow.
+
+This method provides a robust way to ensure Roo Code agents work safely and effectively within the Taskmaster framework, adhering to project-specific guidelines defined in the patch repository. You can fork the `roo-taskmaster-patch` repository to maintain and evolve your own custom set of rules for your projects. This approach is recommended for teams or individuals seeking fine-grained control over AI agent behavior within Taskmaster.
+
+
 ## AI-Driven Development Workflow
 
 The Cursor agent is pre-configured (via the rules file) to follow this workflow:

--- a/README-task-master.md
+++ b/README-task-master.md
@@ -193,7 +193,7 @@ While the standard [MCP setup](#setting-up-mcp-in-cursor) allows Taskmaster AI t
 
 For users seeking this enhanced control, a community-driven approach provides a way to manage Roo Code's behavior by fetching specific modes and rules from a dedicated repository:
 
-**Repository:** [neno-is-ooo/roo-taskmaster-patch](https://github.com/neno-is-ooo/roo-taskmaster-patch)
+**Repository:** [</> neno-is-ooo/roo-taskmaster-patch](https://github.com/neno-is-ooo/roo-taskmaster-patch)
 
 This repository contains:
 1.  An installation script (`install_taskmaster.py`) to automate the setup.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/eyaltoledano?style=flat)](https://x.com/eyaltoledano)
 [![Twitter Follow](https://img.shields.io/twitter/follow/RalphEcom?style=flat)](https://x.com/RalphEcom)
 
-A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI [Now also on Roo Code 🦘](https://github.com/eyaltoledano/claude-task-master#integrating-with-roo-code).
+A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI [Now also on Roo Code 🦘](/README-task-master.md#integrating-with-roo-code).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/eyaltoledano?style=flat)](https://x.com/eyaltoledano)
 [![Twitter Follow](https://img.shields.io/twitter/follow/RalphEcom?style=flat)](https://x.com/RalphEcom)
 
-A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI.
+A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI [Now also on Roo Code 🦘](https://github.com/eyaltoledano/claude-task-master#integrating-with-roo-code).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/eyaltoledano?style=flat)](https://x.com/eyaltoledano)
 [![Twitter Follow](https://img.shields.io/twitter/follow/RalphEcom?style=flat)](https://x.com/RalphEcom)
 
-A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI [Now also on Roo Code 🦘](/README-task-master.md#integrating-with-roo-code).
+A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI [Now also on Roo Code 🦘](/README-task-master.md#-integrating-with-roo-code).
 
 ## Requirements
 


### PR DESCRIPTION
Adds documentation for an enhanced integration method between Taskmaster AI and Roo Code.

Instead of touching TM codebase, this method uses a community-driven approach via the neno-is-ooo/roo-taskmaster-patch repository to provide tailored Roo rules [for all modes] and modes [a custom Boomerang for TM] specifically for Taskmaster workflows. An installation script automates fetching these rules into the user's project.

This approach offers improved safety, consistency, and better workflow alignment compared to using generic Roo rules.

The new section is suggested for placement in README-task-master.md or docs/integrations.md. Feel free to change the place where you advertise this integration. Also feel free to reuse the code for the next iterations of tm installer.

I plan to maintain these basic modes for Roo and their custom rules as a reference to create other setups that integrate Roo Code and Taskmaster.

Edit from Eyal: Mind your links please