### PR TITLE
Remove external claude usage for MCP 

### DIFF
--- a/.changeset/gentle-meals-hunt.md
+++ b/.changeset/gentle-meals-hunt.md
@@ -1,0 +1,5 @@
+---
+'task-master-ai': minor
+---
+
+Use FastMCP sampling to forward mcp LLM calls to client instead of using external LLM.

--- a/.cursor/rules/mcp.mdc
+++ b/.cursor/rules/mcp.mdc
@@ -3,7 +3,6 @@ description: Guidelines for implementing and interacting with the Task Master MC
 globs: mcp-server/src/**/*, scripts/modules/**/*
 alwaysApply: false
 ---
-
 # Task Master MCP Server Guidelines
 
 This document outlines the architecture and implementation patterns for the Task Master Model Context Protocol (MCP) server, designed for integration with tools like Cursor.
@@ -116,11 +115,11 @@ When implementing a new direct function in `mcp-server/src/core/direct-functions
      );
      ```
    - **Critical For JSON Output Format**: Passing the `logWrapper` as `mcpLog` serves a dual purpose:
-     1. **Prevents Runtime Errors**: It ensures the `mcpLog[level](...)` calls within the core function succeed
+     1. **Prevents Runtime Errors**: It ensures the `mcpLog[level](mdc:...)` calls within the core function succeed
      2. **Controls Output Format**: In functions like `updateTaskById` and `updateSubtaskById`, the presence of `mcpLog` in the options triggers setting `outputFormat = 'json'` (instead of 'text'). This prevents UI elements (spinners, boxes) from being generated, which would break the JSON response.
    - **Proven Solution**: This pattern has successfully fixed multiple issues in our MCP tools (including `update-task` and `update-subtask`), where direct passing of the `log` object or omitting `mcpLog` led to either runtime errors or JSON parsing failures from UI output.
    - **When To Use**: Implement this wrapper in any direct function that calls a core function with an `options` object that might use `mcpLog` for logging or output format control.
-   - **Why it Works**: The `logWrapper` explicitly defines the `.info()`, `.warn()`, `.error()`, etc., methods that the core function's `report` helper needs, ensuring the `mcpLog[level](...)` call succeeds. It simply forwards the logging calls to the actual FastMCP `log` object.
+   - **Why it Works**: The `logWrapper` explicitly defines the `.info()`, `.warn()`, `.error()`, etc., methods that the core function's `report` helper needs, ensuring the `mcpLog[level](mdc:...)` call succeeds. It simply forwards the logging calls to the actual FastMCP `log` object.
    - **Combined with Silent Mode**: Remember that using the `logWrapper` for `mcpLog` is **necessary *in addition* to using `enableSilentMode()` / `disableSilentMode()`** (see next point). The wrapper handles structured logging *within* the core function, while silent mode suppresses direct `console.log` and UI elements (spinners, boxes) that would break the MCP JSON response.
 
 6. **Silent Mode Implementation**:
@@ -174,20 +173,58 @@ Direct functions that interact with AI (e.g., `addTaskDirect`, `expandTaskDirect
     // ...
   }
   ```
-- **AI Client Initialization**:
-  - ✅ **DO**: Use the utilities from [`mcp-server/src/core/utils/ai-client-utils.js`](mdc:mcp-server/src/core/utils/ai-client-utils.js) (e.g., `getAnthropicClientForMCP(session, log)`) to get AI client instances. These correctly use the `session` object to resolve API keys.
-  - ✅ **DO**: Wrap client initialization in a try/catch block and return a specific `AI_CLIENT_ERROR` on failure.
-- **AI Interaction**:
-  - ✅ **DO**: Build prompts using helper functions where appropriate (e.g., from `ai-prompt-helpers.js`).
-  - ✅ **DO**: Make the AI API call using appropriate helpers (e.g., `_handleAnthropicStream`). Pass the `log` object to these helpers for internal logging. **Do NOT pass `reportProgress`**.
-  - ✅ **DO**: Parse the AI response using helpers (e.g., `parseTaskJsonResponse`) and handle parsing errors with a specific code (e.g., `RESPONSE_PARSING_ERROR`).
-- **Calling Core Logic**:
-  - ✅ **DO**: After successful AI interaction, call the relevant core Task Master function (from `scripts/modules/`) if needed (e.g., `addTaskDirect` calls `addTask`).
-  - ✅ **DO**: Pass necessary data, including potentially the parsed AI results, to the core function.
-  - ✅ **DO**: If the core function can produce console output, call it with an `outputFormat: 'json'` argument (or similar, depending on the function) to suppress CLI output. Ensure the core function is updated to respect this. Use `enableSilentMode/disableSilentMode` around the core function call as a fallback if `outputFormat` is not supported or insufficient.
+- **AI Interaction via Sampling**: **DEPRECATED: Server-Side Calls.** The previous pattern involved initializing an AI client (Anthropic, Perplexity) within the direct function using utilities like `getAnthropicClientForMCP` and making direct API calls (e.g., using `_handleAnthropicStream`). **This is no longer the correct approach for MCP interaction.**
+
+  - ✅ **DO**: Use the **FastMCP LLM Sampling mechanism** provided via the `session` object. Construct the necessary prompt(s) (system and user) using helpers from `ai-services.js`.
+  - ✅ **DO**: Call the sampling method (e.g., `await session.llm.complete(userPrompt, { system: systemPrompt })`) to delegate LLM execution to the connected client.
+  - ✅ **DO**: Process the completion result returned by the sampling mechanism.
+  - ✅ **DO**: Use helper functions (e.g., `parseTaskJsonResponse`, `parseTasksFromCompletion`) to parse the structured data (like tasks or subtasks) from the completion text.
+  - ❌ **DON'T**: Initialize `Anthropic` or `Perplexity` clients directly within the direct function for MCP calls.
+  - ❌ **DON'T**: Call external LLM APIs directly (e.g., using `_handleAnthropicStream` or `client.chat.completions.create`) from within the direct function when operating via MCP.
+
+  ```javascript
+  // Example Refactored AI Direct Function using Sampling
+  import { _buildSomePrompt, parseSomeResult } from '../../../../scripts/modules/ai-services.js';
+
+  export async function someAIDirect(args, log, context = {}) {
+    const { session } = context;
+    // ... argument validation ...
+
+    try {
+      // 1. Prepare Data & Build Prompt
+      const taskData = readJSON(args.tasksJsonPath);
+      const { systemPrompt, userPrompt } = _buildSomePrompt(taskData, args.input);
+
+      // 2. Call FastMCP Sampling
+      log.info('Initiating LLM sampling via client...');
+      const completion = await session.llm.complete(userPrompt, { system: systemPrompt });
+      const completionText = completion?.content;
+      if (!completionText) throw new Error('Empty completion from client LLM.');
+
+      // 3. Parse Result
+      const processedData = parseSomeResult(completionText);
+
+      // 4. Perform Actions with Result (e.g., save data)
+      await saveProcessedData(args.tasksJsonPath, processedData);
+
+      // 5. Return Success
+      return { success: true, data: { message: "Operation successful via sampling.", ... } };
+
+    } catch (error) {
+      log.error(`Error in someAIDirect: ${error.message}`);
+      return { success: false, error: { code: 'SAMPLING_ERROR', message: error.message } };
+    }
+  }
+  ```
+
+- **Calling Core Logic**: 
+  - **DEPRECATED Pattern**: Previously, AI direct functions might call core logic functions (e.g., `addTask`) passing the *result* of a server-side AI call.
+  - ✅ **DO**: After getting the result from **FastMCP sampling**, call the relevant core Task Master function (from `scripts/modules/`) if needed *to perform the final action* (e.g., `addTaskDirect` calls the core `addTask` function to save the task data obtained from sampling).
+  - ✅ **DO**: Pass the necessary data obtained from the sampling completion to the core function.
+  - ✅ **DO**: If the core function might produce console output, ensure it's handled correctly (either via `outputFormat: 'json'` or `enableSilentMode/disableSilentMode` around the core call).
+
 - **Progress Indication**:
   - ❌ **DON'T**: Call `reportProgress` within the direct function.
-  - ✅ **DO**: If intermediate progress status is needed *within* the long-running direct function, use standard logging: `log.info('Progress: Processing AI response...')`.
 
 ## Tool Definition and Execution
 
@@ -470,7 +507,7 @@ Resources provide LLMs with static or dynamic data without executing tools.
 
 - **Implementation**: Use `@mcp.resource()` decorator pattern or `server.addResource`/`server.addResourceTemplate` in `mcp-server/src/core/resources/`.
 - **Registration**: Register resources during server initialization in [`mcp-server/src/index.js`](mdc:mcp-server/src/index.js).
-- **Best Practices**: Organize resources, validate parameters, use consistent URIs, handle errors. See [`fastmcp-core.txt`](docs/fastmcp-core.txt) for underlying SDK details.
+- **Best Practices**: Organize resources, validate parameters, use consistent URIs, handle errors. See [`fastmcp-core.txt`](mdc:docs/fastmcp-core.txt) for underlying SDK details.
 
 *(Self-correction: Removed detailed Resource implementation examples as they were less relevant to the current user focus on tool execution flow and project roots. Kept the overview.)*
 
@@ -494,7 +531,6 @@ Follow these steps to add MCP support for an existing Task Master command (see [
             - Handle errors from the core function.
         - Format the return as `{ success: true/false, data/error, fromCache?: boolean }`.
         - ❌ **DON'T**: Call `reportProgress`.
-    - Export the wrapper function.
 
 3.  **Update `task-master-core.js` with Import/Export**: Import and re-export your `*Direct` function and add it to the `directFunctions` map.
 

--- a/.cursor/rules/taskmaster.mdc
+++ b/.cursor/rules/taskmaster.mdc
@@ -3,14 +3,14 @@ description: Comprehensive reference for Taskmaster MCP tools and CLI commands.
 globs: **/*
 alwaysApply: true
 ---
-
 # Taskmaster Tool & Command Reference
 
 This document provides a detailed reference for interacting with Taskmaster, covering both the recommended MCP tools (for integrations like Cursor) and the corresponding `task-master` CLI commands (for direct user interaction or fallback).
 
 **Note:** For interacting with Taskmaster programmatically or via integrated tools, using the **MCP tools is strongly recommended** due to better performance, structured data, and error handling. The CLI commands serve as a user-friendly alternative and fallback. See [`mcp.mdc`](mdc:.cursor/rules/mcp.mdc) for MCP implementation details and [`commands.mdc`](mdc:.cursor/rules/commands.mdc) for CLI implementation guidelines.
 
-**Important:** Several MCP tools involve AI processing and are long-running operations that may take up to a minute to complete. When using these tools, always inform users that the operation is in progress and to wait patiently for results. The AI-powered tools include: `parse_prd`, `analyze_project_complexity`, `update_subtask`, `update_task`, `update`, `expand_all`, `expand_task`, and `add_task`.
+**Important: AI-Driven MCP Tools & Client-Side Sampling** 
+Several MCP tools involve AI processing (task generation, expansion, updates, analysis). These tools leverage the **FastMCP LLM Sampling mechanism**, meaning the actual LLM call is delegated to the connected client (e.g., Cursor) rather than being executed server-side. This process can still take time depending on the client's LLM response speed. Always inform users that these operations (`parse_prd`, `analyze_project_complexity`, `update_subtask`, `update_task`, `update`, `expand_all`, `expand_task`, `add_task`) are in progress and require client-side LLM execution.
 
 ---
 
@@ -43,7 +43,8 @@ This document provides a detailed reference for interacting with Taskmaster, cov
 
 *   **MCP Tool:** `parse_prd`
 *   **CLI Command:** `task-master parse-prd [file] [options]`
-*   **Description:** `Parse a Product Requirements Document (PRD) or text file with Taskmaster to automatically generate an initial set of tasks in tasks.json.`
+*   **MCP Description:** `Parses a Product Requirements Document (PRD) using the connected client's LLM (via FastMCP sampling) to automatically generate an initial set of tasks.`
+*   **CLI Description:** `Parse a Product Requirements Document (PRD) or text file with Taskmaster to automatically generate an initial set of tasks in tasks.json.`
 *   **Key Parameters/Options:**
     *   `input`: `Path to your PRD or requirements text file that Taskmaster should parse for tasks.` (CLI: `[file]` positional or `-i, --input <file>`)
     *   `output`: `Specify where Taskmaster should save the generated 'tasks.json' file (default: 'tasks/tasks.json').` (CLI: `-o, --output <file>`)
@@ -51,7 +52,8 @@ This document provides a detailed reference for interacting with Taskmaster, cov
     *   `force`: `Use this to allow Taskmaster to overwrite an existing 'tasks.json' without asking for confirmation.` (CLI: `-f, --force`)
 *   **Usage:** Useful for bootstrapping a project from an existing requirements document.
 *   **Notes:** Task Master will strictly adhere to any specific requirements mentioned in the PRD (libraries, database schemas, frameworks, tech stacks, etc.) while filling in any gaps where the PRD isn't fully specified. Tasks are designed to provide the most direct implementation path while avoiding over-engineering.
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress. If the user does not have a PRD, suggest discussing their idea and then use the example PRD in scripts/example_prd.txt as a template for creating the PRD based on their idea, for use with parse-prd.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ---
 
@@ -95,14 +97,16 @@ This document provides a detailed reference for interacting with Taskmaster, cov
 
 *   **MCP Tool:** `add_task`
 *   **CLI Command:** `task-master add-task [options]`
-*   **Description:** `Add a new task to Taskmaster by describing it; AI will structure it.`
+*   **MCP Description:** `Adds a new task by generating its structure using the connected client's LLM (via FastMCP sampling) based on the provided prompt.`
+*   **CLI Description:** `Add a new task to Taskmaster by describing it; AI will structure it.`
 *   **Key Parameters/Options:**
     *   `prompt`: `Required. Describe the new task you want Taskmaster to create (e.g., "Implement user authentication using JWT").` (CLI: `-p, --prompt <text>`)
     *   `dependencies`: `Specify the IDs of any Taskmaster tasks that must be completed before this new one can start (e.g., '12,14').` (CLI: `-d, --dependencies <ids>`)
     *   `priority`: `Set the priority for the new task ('high', 'medium', 'low'; default: 'medium').` (CLI: `--priority <priority>`)
     *   `file`: `Path to your Taskmaster 'tasks.json' file (default relies on auto-detection).` (CLI: `-f, --file <file>`)
 *   **Usage:** Quickly add newly identified tasks during development.
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ### 7. Add Subtask (`add_subtask`)
 
@@ -125,40 +129,46 @@ This document provides a detailed reference for interacting with Taskmaster, cov
 
 *   **MCP Tool:** `update`
 *   **CLI Command:** `task-master update [options]`
-*   **Description:** `Update multiple upcoming tasks in Taskmaster based on new context or changes, starting from a specific task ID.`
+*   **MCP Description:** `Updates multiple upcoming tasks based on new context using the connected client's LLM (via FastMCP sampling).`
+*   **CLI Description:** `Update multiple upcoming tasks in Taskmaster based on new context or changes, starting from a specific task ID.`
 *   **Key Parameters/Options:**
     *   `from`: `Required. The ID of the first task Taskmaster should update. All tasks with this ID or higher (and not 'done') will be considered.` (CLI: `--from <id>`)
     *   `prompt`: `Required. Explain the change or new context for Taskmaster to apply to the tasks (e.g., "We are now using React Query instead of Redux Toolkit for data fetching").` (CLI: `-p, --prompt <text>`)
-    *   `research`: `Enable Taskmaster to use Perplexity AI for more informed updates based on external knowledge (requires PERPLEXITY_API_KEY).` (CLI: `-r, --research`)
+    *   `research`: `Hint for the client's LLM to perform research during the update.` (CLI: `-r, --research`)
     *   `file`: `Path to your Taskmaster 'tasks.json' file (default relies on auto-detection).` (CLI: `-f, --file <file>`)
 *   **Usage:** Handle significant implementation changes or pivots that affect multiple future tasks. Example CLI: `task-master update --from='18' --prompt='Switching to React Query.\nNeed to refactor data fetching...'`
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ### 9. Update Task (`update_task`)
 
 *   **MCP Tool:** `update_task`
 *   **CLI Command:** `task-master update-task [options]`
-*   **Description:** `Modify a specific Taskmaster task (or subtask) by its ID, incorporating new information or changes.`
+*   **MCP Description:** `Modifies a specific task by incorporating new information using the connected client's LLM (via FastMCP sampling).`
+*   **CLI Description:** `Modify a specific Taskmaster task (or subtask) by its ID, incorporating new information or changes.`
 *   **Key Parameters/Options:**
     *   `id`: `Required. The specific ID of the Taskmaster task (e.g., '15') or subtask (e.g., '15.2') you want to update.` (CLI: `-i, --id <id>`)
     *   `prompt`: `Required. Explain the specific changes or provide the new information Taskmaster should incorporate into this task.` (CLI: `-p, --prompt <text>`)
-    *   `research`: `Enable Taskmaster to use Perplexity AI for more informed updates (requires PERPLEXITY_API_KEY).` (CLI: `-r, --research`)
+    *   `research`: `Hint for the client's LLM to perform research during the update.` (CLI: `-r, --research`)
     *   `file`: `Path to your Taskmaster 'tasks.json' file (default relies on auto-detection).` (CLI: `-f, --file <file>`)
 *   **Usage:** Refine a specific task based on new understanding or feedback. Example CLI: `task-master update-task --id='15' --prompt='Clarification: Use PostgreSQL instead of MySQL.\nUpdate schema details...'`
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ### 10. Update Subtask (`update_subtask`)
 
 *   **MCP Tool:** `update_subtask`
 *   **CLI Command:** `task-master update-subtask [options]`
-*   **Description:** `Append timestamped notes or details to a specific Taskmaster subtask without overwriting existing content. Intended for iterative implementation logging.`
+*   **MCP Description:** `Appends timestamped notes/details to a specific subtask, potentially using the connected client's LLM (via FastMCP sampling) to refine or format the update.`
+*   **CLI Description:** `Append timestamped notes or details to a specific Taskmaster subtask without overwriting existing content. Intended for iterative implementation logging.`
 *   **Key Parameters/Options:**
     *   `id`: `Required. The specific ID of the Taskmaster subtask (e.g., '15.2') you want to add information to.` (CLI: `-i, --id <id>`)
     *   `prompt`: `Required. Provide the information or notes Taskmaster should append to the subtask's details. Ensure this adds *new* information not already present.` (CLI: `-p, --prompt <text>`)
-    *   `research`: `Enable Taskmaster to use Perplexity AI for more informed updates (requires PERPLEXITY_API_KEY).` (CLI: `-r, --research`)
+    *   `research`: `Hint for the client's LLM to perform research during the update.` (CLI: `-r, --research`)
     *   `file`: `Path to your Taskmaster 'tasks.json' file (default relies on auto-detection).` (CLI: `-f, --file <file>`)
 *   **Usage:** Add implementation notes, code snippets, or clarifications to a subtask during development. Before calling, review the subtask's current details to append only fresh insights, helping to build a detailed log of the implementation journey and avoid redundancy. Example CLI: `task-master update-subtask --id='15.2' --prompt='Discovered that the API requires header X.\nImplementation needs adjustment...'`
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ### 11. Set Task Status (`set_task_status`)
 
@@ -191,30 +201,34 @@ This document provides a detailed reference for interacting with Taskmaster, cov
 
 *   **MCP Tool:** `expand_task`
 *   **CLI Command:** `task-master expand [options]`
-*   **Description:** `Use Taskmaster's AI to break down a complex task (or all tasks) into smaller, manageable subtasks.`
+*   **MCP Description:** `Breaks down a complex task into smaller, manageable subtasks using the connected client's LLM (via FastMCP sampling).`
+*   **CLI Description:** `Use Taskmaster's AI to break down a complex task (or all tasks) into smaller, manageable subtasks.`
 *   **Key Parameters/Options:**
     *   `id`: `The ID of the specific Taskmaster task you want to break down into subtasks.` (CLI: `-i, --id <id>`)
     *   `num`: `Suggests how many subtasks Taskmaster should aim to create (uses complexity analysis by default).` (CLI: `-n, --num <number>`)
-    *   `research`: `Enable Taskmaster to use Perplexity AI for more informed subtask generation (requires PERPLEXITY_API_KEY).` (CLI: `-r, --research`)
+    *   `research`: `Hint for the client's LLM to perform research during subtask generation.` (CLI: `-r, --research`)
     *   `prompt`: `Provide extra context or specific instructions to Taskmaster for generating the subtasks.` (CLI: `-p, --prompt <text>`)
     *   `force`: `Use this to make Taskmaster replace existing subtasks with newly generated ones.` (CLI: `--force`)
     *   `file`: `Path to your Taskmaster 'tasks.json' file (default relies on auto-detection).` (CLI: `-f, --file <file>`)
 *   **Usage:** Generate a detailed implementation plan for a complex task before starting coding.
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ### 14. Expand All Tasks (`expand_all`)
 
 *   **MCP Tool:** `expand_all`
 *   **CLI Command:** `task-master expand --all [options]` (Note: CLI uses the `expand` command with the `--all` flag)
-*   **Description:** `Tell Taskmaster to automatically expand all 'pending' tasks based on complexity analysis.`
+*   **MCP Description:** `Automatically expands all eligible 'pending' tasks into subtasks using the connected client's LLM (via FastMCP sampling).`
+*   **CLI Description:** `Tell Taskmaster to automatically expand all 'pending' tasks based on complexity analysis.`
 *   **Key Parameters/Options:**
     *   `num`: `Suggests how many subtasks Taskmaster should aim to create per task.` (CLI: `-n, --num <number>`)
-    *   `research`: `Enable Perplexity AI for more informed subtask generation (requires PERPLEXITY_API_KEY).` (CLI: `-r, --research`)
+    *   `research`: `Hint for the client's LLM to perform research during subtask generation.` (CLI: `-r, --research`)
     *   `prompt`: `Provide extra context for Taskmaster to apply generally during expansion.` (CLI: `-p, --prompt <text>`)
     *   `force`: `Make Taskmaster replace existing subtasks.` (CLI: `--force`)
     *   `file`: `Path to your Taskmaster 'tasks.json' file (default relies on auto-detection).` (CLI: `-f, --file <file>`)
 *   **Usage:** Useful after initial task generation or complexity analysis to break down multiple tasks at once.
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ### 15. Clear Subtasks (`clear_subtasks`)
 
@@ -291,14 +305,16 @@ This document provides a detailed reference for interacting with Taskmaster, cov
 
 *   **MCP Tool:** `analyze_project_complexity`
 *   **CLI Command:** `task-master analyze-complexity [options]`
-*   **Description:** `Have Taskmaster analyze your tasks to determine their complexity and suggest which ones need to be broken down further.`
+*   **MCP Description:** `Analyzes tasks to determine complexity using the connected client's LLM (via FastMCP sampling) and saves a report.`
+*   **CLI Description:** `Have Taskmaster analyze your tasks to determine their complexity and suggest which ones need to be broken down further.`
 *   **Key Parameters/Options:**
     *   `output`: `Where to save the complexity analysis report (default: 'scripts/task-complexity-report.json').` (CLI: `-o, --output <file>`)
     *   `threshold`: `The minimum complexity score (1-10) that should trigger a recommendation to expand a task.` (CLI: `-t, --threshold <number>`)
-    *   `research`: `Enable Perplexity AI for more accurate complexity analysis (requires PERPLEXITY_API_KEY).` (CLI: `-r, --research`)
+    *   `research`: `Hint for the client's LLM to perform research during complexity analysis.` (CLI: `-r, --research`)
     *   `file`: `Path to your Taskmaster 'tasks.json' file (default relies on auto-detection).` (CLI: `-f, --file <file>`)
 *   **Usage:** Used before breaking down tasks to identify which ones need the most attention.
-*   **Important:** This MCP tool makes AI calls and can take up to a minute to complete. Please inform users to hang tight while the operation is in progress.
+*   **Important (MCP):** This tool uses the client's LLM via sampling. Execution time depends on the client. Inform users to wait.
+*   **Important (CLI):** This command makes direct server-side AI calls and can take time.
 
 ### 22. View Complexity Report (`complexity_report`)
 

--- a/mcp-server/src/core/direct-functions/add-task.js
+++ b/mcp-server/src/core/direct-functions/add-task.js
@@ -16,7 +16,7 @@ import {
 	_buildAddTaskPrompt,
 	parseTaskJsonResponse
 	// Removed: _handleAnthropicStream
-} from '../../../../scripts/modules/ai-services.js';
+} from '../utils/ai-client-utils.js';
 
 /**
  * Direct function wrapper for adding a new task with error handling.
@@ -184,6 +184,15 @@ export async function addTaskDirect(args, log, context = {}) {
 			// --- End of Refactored AI Path ---
 		}
 
+		// Create logger wrapper before calling core function
+		const logWrapper = {
+			info: (message, ...args) => log.info(message, ...args),
+			warn: (message, ...args) => log.warn(message, ...args),
+			error: (message, ...args) => log.error(message, ...args),
+			debug: (message, ...args) => log.debug && log.debug(message, ...args),
+			success: (message, ...args) => log.info(message, ...args) // Map success to info
+		};
+
 		// Call the core addTask function with either manual data or AI-generated data
 		const newTaskId = await addTask(
 			tasksPath,
@@ -191,7 +200,7 @@ export async function addTaskDirect(args, log, context = {}) {
 			taskDependencies,
 			taskPriority,
 			{
-				mcpLog: log, // Pass logger wrapper
+				mcpLog: logWrapper, // Use the wrapper
 				session
 			},
 			'json', // Request JSON output format

--- a/mcp-server/src/core/direct-functions/analyze-task-complexity.js
+++ b/mcp-server/src/core/direct-functions/analyze-task-complexity.js
@@ -9,11 +9,11 @@ import {
 	readJSON,
 	writeJSON // Needed to write the report
 } from '../../../../scripts/modules/utils.js';
-// Import necessary AI prompt/parsing helpers
+// Import necessary AI prompt/parsing helpers from the correct location
 import {
-	generateComplexityAnalysisPrompt, // Assuming exists
-	parseComplexityAnalysis // Assuming exists
-} from '../../../../scripts/modules/ai-services.js';
+	generateComplexityAnalysisPrompt,
+	parseComplexityAnalysis
+} from '../utils/ai-client-utils.js'; // Updated path
 import fs from 'fs';
 import path from 'path';
 

--- a/mcp-server/src/core/direct-functions/expand-all-tasks.js
+++ b/mcp-server/src/core/direct-functions/expand-all-tasks.js
@@ -11,11 +11,12 @@ import {
 	writeJSON
 } from '../../../../scripts/modules/utils.js';
 // Removed AI client utils: import { getAnthropicClientForMCP } from '../utils/ai-client-utils.js';
-// Import necessary AI prompt/parsing helpers
+// Import necessary AI prompt/parsing helpers from the correct location
 import {
 	generateSubtaskPrompt,
 	parseSubtasksFromText
-} from '../../../../scripts/modules/ai-services.js';
+} from '../utils/ai-client-utils.js'; // Updated path
+// Removed import from ai-services.js
 import path from 'path';
 import fs from 'fs';
 
@@ -134,9 +135,17 @@ export async function expandAllTasksDirect(args, log, context = {}) {
 			log.info(`Saved updates to ${tasksPath} after expanding ${tasksExpandedCount} tasks.`);
 
 			// 6. Generate Individual Task Files (in silent mode)
+			// Create logger wrapper
+			const logWrapper = {
+				info: (message, ...args) => log.info(message, ...args),
+				warn: (message, ...args) => log.warn(message, ...args),
+				error: (message, ...args) => log.error(message, ...args),
+				debug: (message, ...args) => log.debug && log.debug(message, ...args),
+				success: (message, ...args) => log.info(message, ...args)
+			};
 			enableSilentMode();
 			try {
-				await generateTaskFiles(tasksPath, path.dirname(tasksPath), { mcpLog: log });
+				await generateTaskFiles(tasksPath, path.dirname(tasksPath), { mcpLog: logWrapper }); // Use wrapper
 				log.info('Generated individual task files.');
 			} finally {
 				disableSilentMode();

--- a/mcp-server/src/core/direct-functions/expand-all-tasks.js
+++ b/mcp-server/src/core/direct-functions/expand-all-tasks.js
@@ -1,142 +1,171 @@
 /**
- * Direct function wrapper for expandAllTasks
+ * Direct function wrapper for expandAllTasks using FastMCP sampling.
  */
 
-import { expandAllTasks } from '../../../../scripts/modules/task-manager.js';
+// Removed: import { expandAllTasks } from '../../../../scripts/modules/task-manager.js';
+import { generateTaskFiles } from '../../../../scripts/modules/task-manager.js'; // Keep for generating files
 import {
 	enableSilentMode,
 	disableSilentMode,
-	isSilentMode
+	readJSON,
+	writeJSON
 } from '../../../../scripts/modules/utils.js';
-import { getAnthropicClientForMCP } from '../utils/ai-client-utils.js';
+// Removed AI client utils: import { getAnthropicClientForMCP } from '../utils/ai-client-utils.js';
+// Import necessary AI prompt/parsing helpers
+import {
+	generateSubtaskPrompt,
+	parseSubtasksFromText
+} from '../../../../scripts/modules/ai-services.js';
 import path from 'path';
 import fs from 'fs';
 
 /**
- * Expand all pending tasks with subtasks
+ * Expand all pending tasks with subtasks using FastMCP sampling.
  * @param {Object} args - Function arguments
  * @param {string} args.tasksJsonPath - Explicit path to the tasks.json file.
- * @param {number|string} [args.num] - Number of subtasks to generate
- * @param {boolean} [args.research] - Enable Perplexity AI for research-backed subtask generation
- * @param {string} [args.prompt] - Additional context to guide subtask generation
- * @param {boolean} [args.force] - Force regeneration of subtasks for tasks that already have them
+ * @param {number|string} [args.num] - Number of subtasks to generate per task.
+ * @param {boolean} [args.research] - Research hint (handled by client LLM).
+ * @param {string} [args.prompt] - Additional context to guide subtask generation.
+ * @param {boolean} [args.force] - Force regeneration of subtasks.
  * @param {Object} log - Logger object
- * @param {Object} context - Context object containing session
+ * @param {Object} context - Context object containing session for sampling.
  * @returns {Promise<{success: boolean, data?: Object, error?: {code: string, message: string}}>}
  */
 export async function expandAllTasksDirect(args, log, context = {}) {
-	const { session } = context; // Only extract session, not reportProgress
-	// Destructure expected args
+	const { session } = context; // Session is needed for sampling
 	const { tasksJsonPath, num, research, prompt, force } = args;
 
+	// --- Input Validation ---
+	if (!tasksJsonPath) {
+		log.error('expandAllTasksDirect called without tasksJsonPath');
+		return { success: false, error: { code: 'MISSING_ARGUMENT', message: 'tasksJsonPath is required' }, fromCache: false };
+	}
+	if (!session || typeof session.llm?.complete !== 'function') {
+		const errorMessage = 'FastMCP sampling function (session.llm.complete) is not available.';
+		log.error(errorMessage);
+		return { success: false, error: { code: 'SAMPLING_UNAVAILABLE', message: errorMessage }, fromCache: false };
+	}
+
+	const tasksPath = tasksJsonPath;
+	const numSubtasks = num ? parseInt(num, 10) : undefined;
+	const additionalContext = prompt || '';
+	const forceFlag = force === true;
+	const useResearch = research === true; // Note: Research needs to be handled by client LLM
+
+	log.info(`Expanding all tasks via MCP sampling. NumSubtasks=${numSubtasks || 'default'}, Force=${forceFlag}, Research hint: ${useResearch}`);
+
 	try {
-		log.info(`Expanding all tasks with args: ${JSON.stringify(args)}`);
-
-		// Check if tasksJsonPath was provided
-		if (!tasksJsonPath) {
-			log.error('expandAllTasksDirect called without tasksJsonPath');
-			return {
-				success: false,
-				error: {
-					code: 'MISSING_ARGUMENT',
-					message: 'tasksJsonPath is required'
-				}
-			};
+		// --- Read Task Data ---
+		const data = readJSON(tasksPath);
+		if (!data || !Array.isArray(data.tasks)) {
+			return { success: false, error: { code: 'INVALID_TASKS_FILE', message: `Invalid tasks data in ${tasksPath}` }, fromCache: false };
 		}
 
-		// Enable silent mode early to prevent any console output
-		enableSilentMode();
+		// --- Filter Tasks for Expansion ---
+		const tasksToExpand = data.tasks.filter((task) => {
+			const isPending = task.status !== 'done' && task.status !== 'completed';
+			const hasSubtasks = task.subtasks && task.subtasks.length > 0;
+			return isPending && (!hasSubtasks || forceFlag);
+		});
 
-		try {
-			// Remove internal path finding
-			/*
-			const tasksPath = findTasksJsonPath(args, log);
-			*/
-			// Use provided path
-			const tasksPath = tasksJsonPath;
+		if (tasksToExpand.length === 0) {
+			log.info('No eligible pending tasks found for expansion.');
+			return { success: true, data: { message: 'No eligible tasks to expand.', tasksExpanded: 0 }, fromCache: false };
+		}
+		log.info(`Found ${tasksToExpand.length} eligible tasks for expansion.`);
 
-			// Parse parameters
-			const numSubtasks = num ? parseInt(num, 10) : undefined;
-			const useResearch = research === true;
-			const additionalContext = prompt || '';
-			const forceFlag = force === true;
+		// --- Start of Refactored Logic ---
+		let tasksExpandedCount = 0;
+		const totalTasksToProcess = tasksToExpand.length;
 
-			log.info(
-				`Expanding all tasks with ${numSubtasks || 'default'} subtasks each...`
-			);
+		for (let i = 0; i < totalTasksToProcess; i++) {
+			const task = tasksToExpand[i];
+			const taskIndexInData = data.tasks.findIndex(t => t.id === task.id);
+			if (taskIndexInData === -1) continue; // Should not happen, but safeguard
 
-			if (useResearch) {
-				log.info('Using Perplexity AI for research-backed subtask generation');
+			log.info(`[${i + 1}/${totalTasksToProcess}] Expanding task ${task.id}: ${task.title}`);
 
-				// Initialize AI client for research-backed expansion
+			try {
+				// 1. Construct Prompt
+				const subtaskPrompt = generateSubtaskPrompt(task, numSubtasks, additionalContext);
+				if (!subtaskPrompt) {
+					log.warn(`Skipping task ${task.id}: Failed to generate subtask prompt.`);
+					continue;
+				}
+
+				// 2. Call Sampling
+				log.info(`   Initiating sampling for task ${task.id}...`);
+				const completion = await session.llm.complete(subtaskPrompt);
+				const completionText = completion?.content;
+				if (!completionText) {
+					log.warn(`Skipping task ${task.id}: Received empty completion from sampling.`);
+					continue;
+				}
+
+				// 3. Parse Completion
+				let newSubtasks;
 				try {
-					await getAnthropicClientForMCP(session, log);
-				} catch (error) {
-					// Ensure silent mode is disabled before returning error
-					disableSilentMode();
-
-					log.error(`Failed to initialize AI client: ${error.message}`);
-					return {
-						success: false,
-						error: {
-							code: 'AI_CLIENT_ERROR',
-							message: `Cannot initialize AI client: ${error.message}`
-						}
-					};
+					newSubtasks = parseSubtasksFromText(completionText);
+					if (!Array.isArray(newSubtasks)) throw new Error('Not an array');
+				} catch (parseError) {
+					log.warn(`Skipping task ${task.id}: Failed to parse subtasks from completion - ${parseError.message}`);
+					continue;
 				}
-			}
 
-			if (additionalContext) {
-				log.info(`Additional context: "${additionalContext}"`);
-			}
-			if (forceFlag) {
-				log.info('Force regeneration of subtasks is enabled');
-			}
+				// 4. Update Task Data
+				const nextSubtaskId = (data.tasks[taskIndexInData].subtasks?.length || 0) + 1;
+				newSubtasks.forEach((subtask, index) => {
+					subtask.id = nextSubtaskId + index;
+					subtask.status = subtask.status || 'pending';
+				});
+				data.tasks[taskIndexInData].subtasks = newSubtasks;
+				tasksExpandedCount++;
+				log.info(`   Successfully generated ${newSubtasks.length} subtasks for task ${task.id}.`);
 
-			// Call the core function with session context for AI operations
-			// and outputFormat as 'json' to prevent UI elements
-			const result = await expandAllTasks(
-				tasksPath,
-				numSubtasks,
-				useResearch,
-				additionalContext,
-				forceFlag,
-				{ mcpLog: log, session },
-				'json' // Use JSON output format to prevent UI elements
-			);
+			} catch (taskError) {
+				log.error(`   Error processing task ${task.id}: ${taskError.message}`);
+				// Continue to the next task
+			}
+		} // End loop
 
-			// The expandAllTasks function now returns a result object
-			return {
-				success: true,
-				data: {
-					message: 'Successfully expanded all pending tasks with subtasks',
-					details: {
-						numSubtasks: numSubtasks,
-						research: useResearch,
-						prompt: additionalContext,
-						force: forceFlag,
-						tasksExpanded: result.expandedCount,
-						totalEligibleTasks: result.tasksToExpand
-					}
-				}
-			};
-		} finally {
-			// Restore normal logging in finally block to ensure it runs even if there's an error
-			disableSilentMode();
+		// 5. Save Updated Tasks (only if any were expanded)
+		if (tasksExpandedCount > 0) {
+			writeJSON(tasksPath, data);
+			log.info(`Saved updates to ${tasksPath} after expanding ${tasksExpandedCount} tasks.`);
+
+			// 6. Generate Individual Task Files (in silent mode)
+			enableSilentMode();
+			try {
+				await generateTaskFiles(tasksPath, path.dirname(tasksPath), { mcpLog: log });
+				log.info('Generated individual task files.');
+			} finally {
+				disableSilentMode();
+			}
 		}
+
+		// --- End of Refactored Logic ---
+
+		// 7. Return Success
+		return {
+			success: true,
+			data: {
+				message: `Successfully processed ${totalTasksToProcess} eligible tasks. Expanded ${tasksExpandedCount} tasks via sampling.`,
+				tasksExpanded: tasksExpandedCount,
+				totalEligibleTasks: totalTasksToProcess
+			},
+			fromCache: false
+		};
+
 	} catch (error) {
-		// Ensure silent mode is disabled if an error occurs
-		if (isSilentMode()) {
-			disableSilentMode();
-		}
-
-		log.error(`Error in expandAllTasksDirect: ${error.message}`);
+		log.error(`Error during MCP expandAllTasksDirect: ${error.message}`);
+		log.error(error.stack);
 		return {
 			success: false,
 			error: {
-				code: 'CORE_FUNCTION_ERROR',
-				message: error.message
-			}
+				code: 'EXPAND_ALL_SAMPLING_ERROR',
+				message: error.message || 'Unknown error during expand all tasks via sampling'
+			},
+			fromCache: false
 		};
 	}
 }

--- a/mcp-server/src/core/direct-functions/parse-prd.js
+++ b/mcp-server/src/core/direct-functions/parse-prd.js
@@ -1,87 +1,106 @@
 /**
  * parse-prd.js
- * Direct function implementation for parsing PRD documents
+ * Direct function implementation for parsing PRD documents using FastMCP sampling
  */
 
 import path from 'path';
 import fs from 'fs';
-import { parsePRD } from '../../../../scripts/modules/task-manager.js';
+// Removed: import { parsePRD } from '../../../../scripts/modules/task-manager.js';
+import { generateTaskFiles } from '../../../../scripts/modules/task-manager.js'; // Keep for generating files
 import {
 	enableSilentMode,
-	disableSilentMode
+	disableSilentMode,
+	readJSON, // Need readJSON for append mode
+	writeJSON // Need writeJSON to save result
 } from '../../../../scripts/modules/utils.js';
 import {
-	getAnthropicClientForMCP,
-	getModelConfig
+	// Removed: getAnthropicClientForMCP,
+	getModelConfig,
+	_generateParsePRDPrompt, // Assuming this helper exists or can be created/imported
+	parseTasksFromCompletion // Assuming this helper exists
 } from '../utils/ai-client-utils.js';
 
 /**
- * Direct function wrapper for parsing PRD documents and generating tasks.
+ * Direct function wrapper for parsing PRD documents and generating tasks using FastMCP sampling.
  *
  * @param {Object} args - Command arguments containing input, numTasks or tasks, and output options.
  * @param {Object} log - Logger object.
- * @param {Object} context - Context object containing session data.
+ * @param {Object} context - Context object containing session data for sampling.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
 export async function parsePRDDirect(args, log, context = {}) {
-	const { session } = context; // Only extract session, not reportProgress
+	const { session } = context; // Session is needed for sampling
+
+	// Validate required parameters first
+	if (!args.projectRoot) {
+		const errorMessage = 'Project root is required for parsePRDDirect';
+		log.error(errorMessage);
+		return {
+			success: false,
+			error: { code: 'MISSING_PROJECT_ROOT', message: errorMessage },
+			fromCache: false
+		};
+	}
+	if (!args.input) {
+		const errorMessage = 'Input file path is required for parsePRDDirect';
+		log.error(errorMessage);
+		return {
+			success: false,
+			error: { code: 'MISSING_INPUT_PATH', message: errorMessage },
+			fromCache: false
+		};
+	}
+	if (!args.output) {
+		const errorMessage = 'Output file path is required for parsePRDDirect';
+		log.error(errorMessage);
+		return {
+			success: false,
+			error: { code: 'MISSING_OUTPUT_PATH', message: errorMessage },
+			fromCache: false
+		};
+	}
+	if (!session || typeof session.llm?.complete !== 'function') {
+		const errorMessage = 'FastMCP sampling function (session.llm.complete) is not available.';
+		log.error(errorMessage);
+		return {
+			success: false,
+			error: { code: 'SAMPLING_UNAVAILABLE', message: errorMessage },
+			fromCache: false
+		};
+	}
+
+
+	// Resolve paths
+	const projectRoot = args.projectRoot;
+	const inputPath = path.isAbsolute(args.input)
+		? args.input
+		: path.resolve(projectRoot, args.input);
+	const outputPath = path.isAbsolute(args.output)
+		? args.output
+		: path.resolve(projectRoot, args.output);
+	const outputDir = path.dirname(outputPath);
+
+	// Parse numTasks
+	let numTasks = 10; // Default
+	if (args.numTasks) {
+		numTasks =
+			typeof args.numTasks === 'string'
+				? parseInt(args.numTasks, 10)
+				: args.numTasks;
+		if (isNaN(numTasks)) {
+			numTasks = 10; // Fallback
+			log.warn(`Invalid numTasks value: ${args.numTasks}. Using default: 10`);
+		}
+	}
+
+	const append = Boolean(args.append) === true;
+
+	log.info(
+		`Parsing PRD via MCP sampling: Input=${inputPath}, Output=${outputPath}, NumTasks=${numTasks}, Append=${append}`
+	);
+
 
 	try {
-		log.info(`Parsing PRD document with args: ${JSON.stringify(args)}`);
-
-		// Initialize AI client for PRD parsing
-		let aiClient;
-		try {
-			aiClient = getAnthropicClientForMCP(session, log);
-		} catch (error) {
-			log.error(`Failed to initialize AI client: ${error.message}`);
-			return {
-				success: false,
-				error: {
-					code: 'AI_CLIENT_ERROR',
-					message: `Cannot initialize AI client: ${error.message}`
-				},
-				fromCache: false
-			};
-		}
-
-		// Validate required parameters
-		if (!args.projectRoot) {
-			const errorMessage = 'Project root is required for parsePRDDirect';
-			log.error(errorMessage);
-			return {
-				success: false,
-				error: { code: 'MISSING_PROJECT_ROOT', message: errorMessage },
-				fromCache: false
-			};
-		}
-
-		if (!args.input) {
-			const errorMessage = 'Input file path is required for parsePRDDirect';
-			log.error(errorMessage);
-			return {
-				success: false,
-				error: { code: 'MISSING_INPUT_PATH', message: errorMessage },
-				fromCache: false
-			};
-		}
-
-		if (!args.output) {
-			const errorMessage = 'Output file path is required for parsePRDDirect';
-			log.error(errorMessage);
-			return {
-				success: false,
-				error: { code: 'MISSING_OUTPUT_PATH', message: errorMessage },
-				fromCache: false
-			};
-		}
-
-		// Resolve input path (expecting absolute path or path relative to project root)
-		const projectRoot = args.projectRoot;
-		const inputPath = path.isAbsolute(args.input)
-			? args.input
-			: path.resolve(projectRoot, args.input);
-
 		// Verify input file exists
 		if (!fs.existsSync(inputPath)) {
 			const errorMessage = `Input file not found: ${inputPath}`;
@@ -91,123 +110,124 @@ export async function parsePRDDirect(args, log, context = {}) {
 				error: {
 					code: 'INPUT_FILE_NOT_FOUND',
 					message: errorMessage,
-					details: `Checked path: ${inputPath}\nProject root: ${projectRoot}\nInput argument: ${args.input}`
+					details: `Checked path: ${inputPath}\\nProject root: ${projectRoot}\\nInput argument: ${args.input}`
 				},
 				fromCache: false
 			};
 		}
 
-		// Resolve output path (expecting absolute path or path relative to project root)
-		const outputPath = path.isAbsolute(args.output)
-			? args.output
-			: path.resolve(projectRoot, args.output);
+		// Read PRD content
+		const prdContent = fs.readFileSync(inputPath, 'utf8');
 
-		// Ensure output directory exists
-		const outputDir = path.dirname(outputPath);
+		// --- Start of Refactored Logic ---
+
+		// 1. Construct the Prompt
+		// Assuming a helper function _generateParsePRDPrompt exists and returns the correct prompt string
+		const parsePrompt = _generateParsePRDPrompt(prdContent, numTasks);
+		if (!parsePrompt) {
+			throw new Error('Failed to generate the prompt for PRD parsing.');
+		}
+		log.info('Generated PRD parsing prompt for sampling.');
+
+		// 2. Call FastMCP Sampling
+		log.info('Initiating FastMCP LLM sampling via client...');
+		const completion = await session.llm.complete(parsePrompt); // Use session for sampling
+		log.info('Received completion from client LLM.');
+
+		// Check if completion content exists (adjust based on actual FastMCP response structure)
+		const completionText = completion?.content; // Example access, adjust as needed
+		if (!completionText) {
+			throw new Error('Received empty completion from client LLM via sampling.');
+		}
+
+		// 3. Parse Completion
+		// Assuming parseTasksFromCompletion extracts the { tasks: [...] } structure
+		const newTasksData = parseTasksFromCompletion(completionText);
+		if (!newTasksData || !Array.isArray(newTasksData.tasks)) {
+			throw new Error('Failed to parse valid tasks JSON from LLM completion.');
+		}
+		log.info(`Parsed ${newTasksData.tasks.length} new tasks from completion.`);
+
+
+		// 4. Handle Appending
+		let existingTasks = { tasks: [] };
+		let lastTaskId = 0;
+		if (append && fs.existsSync(outputPath)) {
+			try {
+				existingTasks = readJSON(outputPath) || { tasks: [] }; // Use readJSON util
+				if (existingTasks.tasks?.length) {
+					lastTaskId = existingTasks.tasks.reduce((maxId, task) => {
+						const mainId = parseInt(task.id.toString().split('.')[0], 10) || 0;
+						return Math.max(maxId, mainId);
+					}, 0);
+					log.info(`Appending mode: Found existing tasks. Last ID: ${lastTaskId}`);
+				}
+			} catch (error) {
+				log.warn(`Could not read existing tasks file for append: ${error.message}`);
+				existingTasks = { tasks: [] };
+			}
+		}
+
+		// Update new task IDs if appending
+		if (append && lastTaskId > 0) {
+			log.info(`Updating new task IDs to continue from ID ${lastTaskId}`);
+			newTasksData.tasks.forEach((task, index) => {
+				task.id = lastTaskId + index + 1;
+			});
+		}
+
+		// Merge tasks if appending
+		const tasksData = append
+			? {
+					...existingTasks, // Preserve existing metadata if any
+					tasks: [...(existingTasks.tasks || []), ...newTasksData.tasks]
+				}
+			: newTasksData; // Assume newTasksData contains the full { tasks: [...] } structure
+
+		// 5. Save Tasks
+		// Ensure output directory exists before writing
 		if (!fs.existsSync(outputDir)) {
 			log.info(`Creating output directory: ${outputDir}`);
 			fs.mkdirSync(outputDir, { recursive: true });
 		}
+		writeJSON(outputPath, tasksData); // Use writeJSON util
+		const actionVerb = append ? 'appended' : 'generated';
+		log.info(`Tasks saved to: ${outputPath}`);
 
-		// Parse number of tasks - handle both string and number values
-		let numTasks = 10; // Default
-		if (args.numTasks) {
-			numTasks =
-				typeof args.numTasks === 'string'
-					? parseInt(args.numTasks, 10)
-					: args.numTasks;
-			if (isNaN(numTasks)) {
-				numTasks = 10; // Fallback to default if parsing fails
-				log.warn(`Invalid numTasks value: ${args.numTasks}. Using default: 10`);
-			}
-		}
 
-		// Extract the append flag from args
-		const append = Boolean(args.append) === true;
-
-		// Log key parameters including append flag
-		log.info(
-			`Preparing to parse PRD from ${inputPath} and output to ${outputPath} with ${numTasks} tasks, append mode: ${append}`
-		);
-
-		// Create the logger wrapper for proper logging in the core function
-		const logWrapper = {
-			info: (message, ...args) => log.info(message, ...args),
-			warn: (message, ...args) => log.warn(message, ...args),
-			error: (message, ...args) => log.error(message, ...args),
-			debug: (message, ...args) => log.debug && log.debug(message, ...args),
-			success: (message, ...args) => log.info(message, ...args) // Map success to info
-		};
-
-		// Get model config from session
-		const modelConfig = getModelConfig(session);
-
-		// Enable silent mode to prevent console logs from interfering with JSON response
+		// 6. Generate Individual Task Files (in silent mode)
 		enableSilentMode();
 		try {
-			// Make sure the output directory exists
-			const outputDir = path.dirname(outputPath);
-			if (!fs.existsSync(outputDir)) {
-				log.info(`Creating output directory: ${outputDir}`);
-				fs.mkdirSync(outputDir, { recursive: true });
-			}
-
-			// Execute core parsePRD function with AI client
-			await parsePRD(
-				inputPath,
-				outputPath,
-				numTasks,
-				{
-					mcpLog: logWrapper,
-					session,
-					append
-				},
-				aiClient,
-				modelConfig
-			);
-
-			// Since parsePRD doesn't return a value but writes to a file, we'll read the result
-			// to return it to the caller
-			if (fs.existsSync(outputPath)) {
-				const tasksData = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
-				const actionVerb = append ? 'appended' : 'generated';
-				const message = `Successfully ${actionVerb} ${tasksData.tasks?.length || 0} tasks from PRD`;
-
-				log.info(message);
-
-				return {
-					success: true,
-					data: {
-						message,
-						taskCount: tasksData.tasks?.length || 0,
-						outputPath,
-						appended: append
-					},
-					fromCache: false // This operation always modifies state and should never be cached
-				};
-			} else {
-				const errorMessage = `Tasks file was not created at ${outputPath}`;
-				log.error(errorMessage);
-				return {
-					success: false,
-					error: { code: 'OUTPUT_FILE_NOT_CREATED', message: errorMessage },
-					fromCache: false
-				};
-			}
+			await generateTaskFiles(outputPath, outputDir, { mcpLog: log }); // Pass log for potential internal reporting
+			log.info('Generated individual task files.');
 		} finally {
-			// Always restore normal logging
 			disableSilentMode();
 		}
-	} catch (error) {
-		// Make sure to restore normal logging even if there's an error
-		disableSilentMode();
 
-		log.error(`Error parsing PRD: ${error.message}`);
+		// --- End of Refactored Logic ---
+
+		// 7. Return Result
+		const message = `Successfully ${actionVerb} ${newTasksData.tasks.length} tasks from PRD using client LLM sampling.`;
+		log.info(message);
+		return {
+			success: true,
+			data: {
+				message,
+				taskCount: tasksData.tasks?.length || 0, // Count total tasks after potential merge
+				outputPath,
+				appended: append
+			},
+			fromCache: false // This operation always modifies state
+		};
+
+	} catch (error) {
+		log.error(`Error during MCP parsePRDDirect: ${error.message}`);
+		log.error(error.stack); // Log stack for debugging
 		return {
 			success: false,
 			error: {
-				code: 'PARSE_PRD_ERROR',
-				message: error.message || 'Unknown error parsing PRD'
+				code: 'PARSE_PRD_SAMPLING_ERROR',
+				message: error.message || 'Unknown error during PRD parsing via sampling'
 			},
 			fromCache: false
 		};

--- a/mcp-server/src/core/direct-functions/parse-prd.js
+++ b/mcp-server/src/core/direct-functions/parse-prd.js
@@ -25,11 +25,12 @@ import {
  *
  * @param {Object} args - Command arguments containing input, numTasks or tasks, and output options.
  * @param {Object} log - Logger object.
- * @param {Object} context - Context object containing session data for sampling.
+ * @param {Object} context - Context object containing session data and sampling function.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
 export async function parsePRDDirect(args, log, context = {}) {
-	const { session } = context; // Session is needed for sampling
+	// Remove the session destructuring and the check for session.llm.complete
+	// const { session } = context;
 
 	// Validate required parameters first
 	if (!args.projectRoot) {
@@ -59,8 +60,9 @@ export async function parsePRDDirect(args, log, context = {}) {
 			fromCache: false
 		};
 	}
-	if (!session || typeof session.llm?.complete !== 'function') {
-		const errorMessage = 'FastMCP sampling function (session.llm.complete) is not available.';
+	// Add check for context.sample
+	if (!context || typeof context.sample !== 'function') {
+		const errorMessage = 'FastMCP sampling function (context.sample) is not available.';
 		log.error(errorMessage);
 		return {
 			success: false,
@@ -68,7 +70,6 @@ export async function parsePRDDirect(args, log, context = {}) {
 			fromCache: false
 		};
 	}
-
 
 	// Resolve paths
 	const projectRoot = args.projectRoot;
@@ -94,11 +95,11 @@ export async function parsePRDDirect(args, log, context = {}) {
 	}
 
 	const append = Boolean(args.append) === true;
+	const force = Boolean(args.force) === true; // Make sure force is checked
 
 	log.info(
 		`Parsing PRD via MCP sampling: Input=${inputPath}, Output=${outputPath}, NumTasks=${numTasks}, Append=${append}`
 	);
-
 
 	try {
 		// Verify input file exists
@@ -119,92 +120,120 @@ export async function parsePRDDirect(args, log, context = {}) {
 		// Read PRD content
 		const prdContent = fs.readFileSync(inputPath, 'utf8');
 
-		// --- Start of Refactored Logic ---
-
-		// 1. Construct the Prompt
-		// Assuming a helper function _generateParsePRDPrompt exists and returns the correct prompt string
-		const parsePrompt = _generateParsePRDPrompt(prdContent, numTasks);
-		if (!parsePrompt) {
+		// 1. Construct the Prompt (Use correct helper)
+		const { systemPrompt, userPrompt } = _generateParsePRDPrompt(prdContent, numTasks, path.basename(inputPath));
+		if (!userPrompt) { // Check user prompt as it contains the main content
 			throw new Error('Failed to generate the prompt for PRD parsing.');
 		}
 		log.info('Generated PRD parsing prompt for sampling.');
 
-		// 2. Call FastMCP Sampling
-		log.info('Initiating FastMCP LLM sampling via client...');
-		const completion = await session.llm.complete(parsePrompt); // Use session for sampling
-		log.info('Received completion from client LLM.');
-
-		// Check if completion content exists (adjust based on actual FastMCP response structure)
-		const completionText = completion?.content; // Example access, adjust as needed
-		if (!completionText) {
-			throw new Error('Received empty completion from client LLM via sampling.');
+		// 2. Call context.sample
+		log.info('Initiating client-side LLM sampling via context.sample...');
+		let completion;
+		try {
+			completion = await context.sample(userPrompt, { system: systemPrompt });
+		} catch (sampleError) {
+			log.error(`context.sample failed: ${sampleError.message}`);
+			throw new Error(`Client-side sampling failed: ${sampleError.message}`);
 		}
 
-		// 3. Parse Completion
-		// Assuming parseTasksFromCompletion extracts the { tasks: [...] } structure
+		// Check if completion content exists
+		const completionText = completion?.text; // Adjust based on expected structure from context.sample
+		if (!completionText) {
+			throw new Error('Received empty completion from client LLM via context.sample.');
+		}
+		log.info('Received completion from client LLM.');
+
+		// 3. Parse Completion (Use correct helper)
 		const newTasksData = parseTasksFromCompletion(completionText);
 		if (!newTasksData || !Array.isArray(newTasksData.tasks)) {
 			throw new Error('Failed to parse valid tasks JSON from LLM completion.');
 		}
 		log.info(`Parsed ${newTasksData.tasks.length} new tasks from completion.`);
 
-
-		// 4. Handle Appending
-		let existingTasks = { tasks: [] };
+		// 4. Handle Appending/Overwriting (remains mostly the same, check force)
+		let existingTasks = { tasks: [], metadata: {} };
 		let lastTaskId = 0;
-		if (append && fs.existsSync(outputPath)) {
+		const outputExists = fs.existsSync(outputPath);
+
+		if (outputExists && !append && !force) {
+			throw new Error(`Output file ${outputPath} already exists. Use --force to overwrite or --append.`);
+		}
+
+		if (append && outputExists) {
 			try {
-				existingTasks = readJSON(outputPath) || { tasks: [] }; // Use readJSON util
+				existingTasks = readJSON(outputPath) || { tasks: [], metadata: {} };
 				if (existingTasks.tasks?.length) {
 					lastTaskId = existingTasks.tasks.reduce((maxId, task) => {
 						const mainId = parseInt(task.id.toString().split('.')[0], 10) || 0;
 						return Math.max(maxId, mainId);
 					}, 0);
 					log.info(`Appending mode: Found existing tasks. Last ID: ${lastTaskId}`);
+				} else {
+					existingTasks.tasks = [];
 				}
-			} catch (error) {
-				log.warn(`Could not read existing tasks file for append: ${error.message}`);
-				existingTasks = { tasks: [] };
+			} catch (readError) {
+				log.warn(`Could not read existing tasks file for append: ${readError.message}. Starting fresh.`);
+				existingTasks = { tasks: [], metadata: {} };
 			}
 		}
 
-		// Update new task IDs if appending
+		// Update new task IDs and dependencies if appending (remains the same logic)
 		if (append && lastTaskId > 0) {
-			log.info(`Updating new task IDs to continue from ID ${lastTaskId}`);
+			log.info(`Updating new task IDs and dependencies to continue from ID ${lastTaskId}`);
+			const idMapping = {};
 			newTasksData.tasks.forEach((task, index) => {
-				task.id = lastTaskId + index + 1;
+				const oldId = task.id;
+				const newId = lastTaskId + index + 1;
+				idMapping[oldId] = newId;
+				task.id = newId;
+			});
+			newTasksData.tasks.forEach(task => {
+				task.dependencies = (task.dependencies || [])
+					.map(depId => idMapping[depId] || 0)
+					.filter(depId => depId !== 0);
 			});
 		}
 
-		// Merge tasks if appending
+		// Merge tasks if appending (remains the same logic)
 		const tasksData = append
 			? {
-					...existingTasks, // Preserve existing metadata if any
-					tasks: [...(existingTasks.tasks || []), ...newTasksData.tasks]
-				}
-			: newTasksData; // Assume newTasksData contains the full { tasks: [...] } structure
+				...existingTasks.metadata,
+				...newTasksData.metadata,
+				tasks: [...(existingTasks.tasks || []), ...newTasksData.tasks]
+			}
+			: newTasksData;
 
-		// 5. Save Tasks
-		// Ensure output directory exists before writing
+		// 5. Save Tasks (remains the same)
 		if (!fs.existsSync(outputDir)) {
 			log.info(`Creating output directory: ${outputDir}`);
 			fs.mkdirSync(outputDir, { recursive: true });
 		}
-		writeJSON(outputPath, tasksData); // Use writeJSON util
+		writeJSON(outputPath, tasksData);
 		const actionVerb = append ? 'appended' : 'generated';
-		log.info(`Tasks saved to: ${outputPath}`);
+		log.info(`Tasks ${actionVerb} and saved to: ${outputPath}`);
 
-
-		// 6. Generate Individual Task Files (in silent mode)
-		enableSilentMode();
-		try {
-			await generateTaskFiles(outputPath, outputDir, { mcpLog: log }); // Pass log for potential internal reporting
-			log.info('Generated individual task files.');
-		} finally {
-			disableSilentMode();
+		// 6. Generate Individual Task Files (use logWrapper)
+		if (tasksData.tasks.length > 0) {
+			const logWrapper = {
+				info: (message, ...args) => log.info(message, ...args),
+				warn: (message, ...args) => log.warn(message, ...args),
+				error: (message, ...args) => log.error(message, ...args),
+				debug: (message, ...args) => log.debug && log.debug(message, ...args),
+				success: (message, ...args) => log.info(message, ...args)
+			};
+			enableSilentMode();
+			try {
+				// Pass outputPath (which is tasksJsonPath) and outputDir
+				await generateTaskFiles(outputPath, outputDir, { mcpLog: logWrapper });
+				log.info('Generated individual task files.');
+			} catch (genError) {
+				log.error(`Error generating task files: ${genError.message}`);
+				// Don't fail the whole operation, just log the error
+			} finally {
+				disableSilentMode();
+			}
 		}
-
-		// --- End of Refactored Logic ---
 
 		// 7. Return Result
 		const message = `Successfully ${actionVerb} ${newTasksData.tasks.length} tasks from PRD using client LLM sampling.`;
@@ -213,16 +242,16 @@ export async function parsePRDDirect(args, log, context = {}) {
 			success: true,
 			data: {
 				message,
-				taskCount: tasksData.tasks?.length || 0, // Count total tasks after potential merge
+				taskCount: tasksData.tasks?.length || 0,
 				outputPath,
 				appended: append
 			},
-			fromCache: false // This operation always modifies state
+			fromCache: false
 		};
 
 	} catch (error) {
 		log.error(`Error during MCP parsePRDDirect: ${error.message}`);
-		log.error(error.stack); // Log stack for debugging
+		log.error(error.stack);
 		return {
 			success: false,
 			error: {

--- a/mcp-server/src/core/direct-functions/update-task-by-id.js
+++ b/mcp-server/src/core/direct-functions/update-task-by-id.js
@@ -1,185 +1,207 @@
 /**
  * update-task-by-id.js
- * Direct function implementation for updating a single task by ID with new information
+ * Direct function implementation for updating a single task by ID using FastMCP sampling.
  */
 
-import { updateTaskById } from '../../../../scripts/modules/task-manager.js';
+// Removed: import { updateTaskById } from '../../../../scripts/modules/task-manager.js';
+import { generateTaskFiles } from '../../../../scripts/modules/task-manager.js'; // Keep for generating files
 import {
 	enableSilentMode,
-	disableSilentMode
+	disableSilentMode,
+	readJSON,
+	writeJSON
 } from '../../../../scripts/modules/utils.js';
 import {
-	getAnthropicClientForMCP,
-	getPerplexityClientForMCP
+	// Removed: getAnthropicClientForMCP,
+	// Removed: getPerplexityClientForMCP
 } from '../utils/ai-client-utils.js';
+// Import necessary AI prompt/parsing helpers
+import {
+	_buildUpdateTaskPrompt, // Assuming exists
+	parseTaskJsonResponse // Assuming exists
+} from '../../../../scripts/modules/ai-services.js';
 
 /**
- * Direct function wrapper for updateTaskById with error handling.
+ * Direct function wrapper for updating a task by ID using FastMCP sampling.
  *
  * @param {Object} args - Command arguments containing id, prompt, useResearch and tasksJsonPath.
  * @param {Object} log - Logger object.
- * @param {Object} context - Context object containing session data.
+ * @param {Object} context - Context object containing session data for sampling.
  * @returns {Promise<Object>} - Result object with success status and data/error information.
  */
 export async function updateTaskByIdDirect(args, log, context = {}) {
-	const { session } = context; // Only extract session, not reportProgress
-	// Destructure expected args, including the resolved tasksJsonPath
+	const { session } = context; // Session is needed for sampling
 	const { tasksJsonPath, id, prompt, research } = args;
 
+	// --- Input Validation ---
+	if (!tasksJsonPath) {
+		const errorMessage = 'tasksJsonPath is required';
+		log.error(errorMessage);
+		return { success: false, error: { code: 'MISSING_ARGUMENT', message: errorMessage }, fromCache: false };
+	}
+	if (!id) {
+		const errorMessage = 'Task ID is required';
+		log.error(errorMessage);
+		return { success: false, error: { code: 'MISSING_TASK_ID', message: errorMessage }, fromCache: false };
+	}
+	if (!prompt) {
+		const errorMessage = 'Update prompt is required';
+		log.error(errorMessage);
+		return { success: false, error: { code: 'MISSING_PROMPT', message: errorMessage }, fromCache: false };
+	}
+	if (!session || typeof session.llm?.complete !== 'function') {
+		const errorMessage = 'FastMCP sampling function (session.llm.complete) is not available.';
+		log.error(errorMessage);
+		return { success: false, error: { code: 'SAMPLING_UNAVAILABLE', message: errorMessage }, fromCache: false };
+	}
+
+	// Parse taskId (only handles top-level tasks for this function)
+	const taskId = parseInt(id, 10);
+	if (isNaN(taskId) || id.includes('.')) {
+		const errorMessage = `Invalid task ID: ${id}. updateTaskByIdDirect only supports top-level integer IDs. Use updateSubtaskByIdDirect for subtasks.`;
+		log.error(errorMessage);
+		return { success: false, error: { code: 'INVALID_TASK_ID', message: errorMessage }, fromCache: false };
+	}
+
+	const tasksPath = tasksJsonPath;
+	const useResearch = research === true; // Note: Research needs to be handled by client LLM
+
+	log.info(`Updating task ${taskId} via MCP sampling. Research hint: ${useResearch}`);
+
 	try {
-		log.info(`Updating task with args: ${JSON.stringify(args)}`);
+		// --- Read Task Data ---
+		const data = readJSON(tasksPath);
+		if (!data || !Array.isArray(data.tasks)) {
+			return { success: false, error: { code: 'INVALID_TASKS_FILE', message: `Invalid tasks data in ${tasksPath}` }, fromCache: false };
+		}
+		const taskIndex = data.tasks.findIndex((t) => t.id === taskId);
+		if (taskIndex === -1) {
+			return { success: false, error: { code: 'TASK_NOT_FOUND', message: `Task ${taskId} not found` }, fromCache: false };
+		}
+		const taskToUpdate = data.tasks[taskIndex];
 
-		// Check if tasksJsonPath was provided
-		if (!tasksJsonPath) {
-			const errorMessage = 'tasksJsonPath is required but was not provided.';
-			log.error(errorMessage);
-			return {
-				success: false,
-				error: { code: 'MISSING_ARGUMENT', message: errorMessage },
-				fromCache: false
-			};
+		// --- Pre-Update Checks ---
+		if (taskToUpdate.status === 'done' || taskToUpdate.status === 'completed') {
+			return { success: false, error: { code: 'TASK_COMPLETED', message: `Task ${taskId} is already completed` }, fromCache: false };
 		}
 
-		// Check required parameters (id and prompt)
-		if (!id) {
-			const errorMessage =
-				'No task ID specified. Please provide a task ID to update.';
-			log.error(errorMessage);
-			return {
-				success: false,
-				error: { code: 'MISSING_TASK_ID', message: errorMessage },
-				fromCache: false
-			};
+		// --- Start of Refactored Logic ---
+
+		// 1. Construct Prompt
+		// Assumes _buildUpdateTaskPrompt exists and takes task object + update instructions
+		const { systemPrompt, userPrompt } = _buildUpdateTaskPrompt(taskToUpdate, prompt);
+		if (!userPrompt) { // Check userPrompt as it's the main content
+			throw new Error('Failed to generate the prompt for task update.');
+		}
+		log.info('Generated task update prompt for sampling.');
+
+		// 2. Call FastMCP Sampling
+		let completionText;
+		try {
+			log.info('Initiating FastMCP LLM sampling via client...');
+			const completion = await session.llm.complete(userPrompt, { system: systemPrompt });
+			log.info('Received completion from client LLM.');
+			completionText = completion?.content;
+			if (!completionText) {
+				throw new Error('Received empty completion from client LLM via sampling.');
+			}
+		} catch (error) {
+			log.error(`LLM sampling failed: ${error.message}`);
+			throw new Error(`Failed to get completion via sampling: ${error.message}`);
 		}
 
-		if (!prompt) {
-			const errorMessage =
-				'No prompt specified. Please provide a prompt with new information for the task update.';
-			log.error(errorMessage);
-			return {
-				success: false,
-				error: { code: 'MISSING_PROMPT', message: errorMessage },
-				fromCache: false
-			};
+		// 3. Parse Completion
+		let updatedTaskDataFromAI;
+		try {
+			updatedTaskDataFromAI = parseTaskJsonResponse(completionText);
+			log.info('Parsed updated task data from LLM completion.');
+		} catch (error) {
+			log.error(`Failed to parse LLM completion: ${error.message}`);
+			throw new Error(`Failed to parse LLM completion: ${error.message}`);
 		}
 
-		// Parse taskId - handle both string and number values
-		let taskId;
-		if (typeof id === 'string') {
-			// Handle subtask IDs (e.g., "5.2")
-			if (id.includes('.')) {
-				taskId = id; // Keep as string for subtask IDs
-			} else {
-				// Parse as integer for main task IDs
-				taskId = parseInt(id, 10);
-				if (isNaN(taskId)) {
-					const errorMessage = `Invalid task ID: ${id}. Task ID must be a positive integer or subtask ID (e.g., "5.2").`;
-					log.error(errorMessage);
-					return {
-						success: false,
-						error: { code: 'INVALID_TASK_ID', message: errorMessage },
-						fromCache: false
-					};
+		// 4. Validation (Moved from core function)
+		if (!updatedTaskDataFromAI || typeof updatedTaskDataFromAI !== 'object') {
+			throw new Error('LLM completion did not contain a valid task object.');
+		}
+		if (!updatedTaskDataFromAI.title || !updatedTaskDataFromAI.description) {
+			throw new Error('Updated task from LLM is missing required fields (title or description).');
+		}
+		// --> Ensure ID is preserved <--
+		if (updatedTaskDataFromAI.id !== taskId) {
+			log.warn(`Task ID changed by AI. Restoring original ID ${taskId}.`);
+			updatedTaskDataFromAI.id = taskId;
+		}
+		// --> Ensure status is preserved unless explicitly changed <--
+		if (updatedTaskDataFromAI.status !== taskToUpdate.status && !prompt.toLowerCase().includes('status')) {
+			log.warn(`Task status changed by AI without explicit instruction. Restoring original status '${taskToUpdate.status}'.`);
+			updatedTaskDataFromAI.status = taskToUpdate.status;
+		}
+		// --> Ensure completed subtasks are preserved <--
+		if (taskToUpdate.subtasks?.length > 0) {
+			const completedOriginalSubtasks = taskToUpdate.subtasks.filter(st => st.status === 'done' || st.status === 'completed');
+			if (!updatedTaskDataFromAI.subtasks) updatedTaskDataFromAI.subtasks = [];
+
+			for (const completedSubtask of completedOriginalSubtasks) {
+				const updatedVersion = updatedTaskDataFromAI.subtasks.find(st => st.id === completedSubtask.id);
+				if (!updatedVersion) {
+					log.warn(`Completed subtask ${taskId}.${completedSubtask.id} removed by AI. Restoring.`);
+					updatedTaskDataFromAI.subtasks.push(completedSubtask);
+				} else if (JSON.stringify(updatedVersion) !== JSON.stringify(completedSubtask)) {
+					log.warn(`Completed subtask ${taskId}.${completedSubtask.id} modified by AI. Restoring.`);
+					const idx = updatedTaskDataFromAI.subtasks.findIndex(st => st.id === completedSubtask.id);
+					if (idx !== -1) updatedTaskDataFromAI.subtasks[idx] = completedSubtask;
 				}
 			}
-		} else {
-			taskId = id;
+			// Ensure unique subtask IDs after potential restoration
+			const subtaskIds = new Set();
+			updatedTaskDataFromAI.subtasks = updatedTaskDataFromAI.subtasks.filter(st => {
+				if (!subtaskIds.has(st.id)) {
+					subtaskIds.add(st.id);
+					return true;
+				}
+				log.warn(`Duplicate subtask ID ${taskId}.${st.id} detected after AI update/validation. Removing duplicate.`);
+				return false;
+			});
 		}
+		// --- End Validation logic --- //
 
-		// Use the provided path
-		const tasksPath = tasksJsonPath;
+		// 5. Update Task in Data
+		data.tasks[taskIndex] = updatedTaskDataFromAI; // Replace with validated data
 
-		// Get research flag
-		const useResearch = research === true;
+		// 6. Save Updated Task Data
+		writeJSON(tasksPath, data);
+		log.info(`Updated task ${taskId} in ${tasksPath}.`);
 
-		// Initialize appropriate AI client based on research flag
-		let aiClient;
+		// 7. Generate Individual Task Files (in silent mode)
+		enableSilentMode();
 		try {
-			if (useResearch) {
-				log.info('Using Perplexity AI for research-backed task update');
-				aiClient = await getPerplexityClientForMCP(session, log);
-			} else {
-				log.info('Using Claude AI for task update');
-				aiClient = getAnthropicClientForMCP(session, log);
-			}
-		} catch (error) {
-			log.error(`Failed to initialize AI client: ${error.message}`);
-			return {
-				success: false,
-				error: {
-					code: 'AI_CLIENT_ERROR',
-					message: `Cannot initialize AI client: ${error.message}`
-				},
-				fromCache: false
-			};
-		}
-
-		log.info(
-			`Updating task with ID ${taskId} with prompt "${prompt}" and research: ${useResearch}`
-		);
-
-		try {
-			// Enable silent mode to prevent console logs from interfering with JSON response
-			enableSilentMode();
-
-			// Create a logger wrapper that matches what updateTaskById expects
-			const logWrapper = {
-				info: (message) => log.info(message),
-				warn: (message) => log.warn(message),
-				error: (message) => log.error(message),
-				debug: (message) => log.debug && log.debug(message),
-				success: (message) => log.info(message) // Map success to info since many loggers don't have success
-			};
-
-			// Execute core updateTaskById function with proper parameters
-			await updateTaskById(
-				tasksPath,
-				taskId,
-				prompt,
-				useResearch,
-				{
-					mcpLog: logWrapper, // Use our wrapper object that has the expected method structure
-					session
-				},
-				'json'
-			);
-
-			// Since updateTaskById doesn't return a value but modifies the tasks file,
-			// we'll return a success message
-			return {
-				success: true,
-				data: {
-					message: `Successfully updated task with ID ${taskId} based on the prompt`,
-					taskId,
-					tasksPath: tasksPath, // Return the used path
-					useResearch
-				},
-				fromCache: false // This operation always modifies state and should never be cached
-			};
-		} catch (error) {
-			log.error(`Error updating task by ID: ${error.message}`);
-			return {
-				success: false,
-				error: {
-					code: 'UPDATE_TASK_ERROR',
-					message: error.message || 'Unknown error updating task'
-				},
-				fromCache: false
-			};
+			await generateTaskFiles(tasksPath, path.dirname(tasksPath), { mcpLog: log });
+			log.info('Generated individual task files.');
 		} finally {
-			// Make sure to restore normal logging even if there's an error
 			disableSilentMode();
 		}
-	} catch (error) {
-		// Ensure silent mode is disabled
-		disableSilentMode();
 
-		log.error(`Error updating task by ID: ${error.message}`);
+		// --- End of Refactored Logic ---
+
+		// 8. Return Success
+		return {
+			success: true,
+			data: {
+				message: `Successfully updated task ${taskId} using client LLM sampling.`,
+				task: updatedTaskDataFromAI // Return the updated task data
+			},
+			fromCache: false
+		};
+
+	} catch (error) {
+		log.error(`Error during MCP updateTaskByIdDirect: ${error.message}`);
+		log.error(error.stack);
 		return {
 			success: false,
 			error: {
-				code: 'UPDATE_TASK_ERROR',
-				message: error.message || 'Unknown error updating task'
+				code: 'UPDATE_TASK_SAMPLING_ERROR',
+				message: error.message || 'Unknown error during task update via sampling'
 			},
 			fromCache: false
 		};

--- a/mcp-server/src/core/task-master-core.js
+++ b/mcp-server/src/core/task-master-core.js
@@ -7,7 +7,6 @@
 // Import direct function implementations
 import { listTasksDirect } from './direct-functions/list-tasks.js';
 import { getCacheStatsDirect } from './direct-functions/cache-stats.js';
-import { parsePRDDirect } from './direct-functions/parse-prd.js';
 import { updateTasksDirect } from './direct-functions/update-tasks.js';
 import { updateTaskByIdDirect } from './direct-functions/update-task-by-id.js';
 import { updateSubtaskByIdDirect } from './direct-functions/update-subtask-by-id.js';
@@ -47,7 +46,7 @@ export {
 export const directFunctions = new Map([
 	['listTasksDirect', listTasksDirect],
 	['getCacheStatsDirect', getCacheStatsDirect],
-	['parsePRDDirect', parsePRDDirect],
+	['saveTasksAndGenerateFilesDirect', saveTasksAndGenerateFilesDirect],
 	['updateTasksDirect', updateTasksDirect],
 	['updateTaskByIdDirect', updateTaskByIdDirect],
 	['updateSubtaskByIdDirect', updateSubtaskByIdDirect],
@@ -74,7 +73,6 @@ export const directFunctions = new Map([
 export {
 	listTasksDirect,
 	getCacheStatsDirect,
-	parsePRDDirect,
 	updateTasksDirect,
 	updateTaskByIdDirect,
 	updateSubtaskByIdDirect,

--- a/mcp-server/src/core/task-master-core.js
+++ b/mcp-server/src/core/task-master-core.js
@@ -29,6 +29,7 @@ import { complexityReportDirect } from './direct-functions/complexity-report.js'
 import { addDependencyDirect } from './direct-functions/add-dependency.js';
 import { removeTaskDirect } from './direct-functions/remove-task.js';
 import { initializeProjectDirect } from './direct-functions/initialize-project-direct.js';
+import { saveTasksAndGenerateFilesDirect } from './direct-functions/parse-prd.js';
 
 // Re-export utility functions
 export { findTasksJsonPath } from './utils/path-utils.js';
@@ -94,5 +95,6 @@ export {
 	complexityReportDirect,
 	addDependencyDirect,
 	removeTaskDirect,
-	initializeProjectDirect
+	initializeProjectDirect,
+	saveTasksAndGenerateFilesDirect
 };

--- a/mcp-server/src/core/utils/ai-client-utils.js
+++ b/mcp-server/src/core/utils/ai-client-utils.js
@@ -211,3 +211,463 @@ export function handleClaudeError(error) {
 	// Default error message
 	return `Error communicating with Claude: ${error.message}`;
 }
+
+/**
+ * Generate the system prompt for parsing a PRD into tasks.
+ * @param {string} prdContent - The content of the PRD.
+ * @param {number} numTasks - The target number of tasks.
+ * @param {string} [prdPath=\'N/A\'] - The path to the PRD file (optional).
+ * @returns {string} The system prompt string.
+ */
+export function _generateParsePRDPrompt(prdContent, numTasks, prdPath = 'N/A') {
+	return `You are an AI assistant tasked with breaking down a Product Requirements Document (PRD) into a set of sequential development tasks. Your goal is to create exactly <num_tasks>${numTasks}</num_tasks> well-structured, actionable development tasks based on the PRD provided.
+
+First, carefully read and analyze the attached PRD:
+<prd_content>
+${prdContent}
+</prd_content>
+
+Before creating the task list, work through the following steps inside <prd_breakdown> tags in your thinking block:
+
+1. List the key components of the PRD
+2. Identify the main features and functionalities described
+3. Note any specific technical requirements or constraints mentioned
+4. Outline a high-level sequence of tasks that would be needed to implement the PRD
+
+Consider dependencies, maintainability, and the fact that you don\'t have access to any existing codebase. Balance between providing detailed task descriptions and maintaining a high-level perspective.
+
+After your breakdown, create a JSON object containing an array of tasks and a metadata object. Each task should follow this structure:
+
+{
+  "id": number,
+  "title": string,
+  "description": string,
+  "status": "pending",
+  "dependencies": number[] (IDs of tasks this depends on),
+  "priority": "high" | "medium" | "low",
+  "details": string (implementation details),
+  "testStrategy": string (validation approach)
+}
+
+Guidelines for creating tasks:
+1. Number tasks from 1 to <num_tasks>${numTasks}</num_tasks>.
+2. Make each task atomic and focused on a single responsibility.
+3. Order tasks logically, considering dependencies and implementation sequence.
+4. Start with setup and core functionality, then move to advanced features.
+5. Provide a clear validation/testing approach for each task.
+6. Set appropriate dependency IDs (tasks can only depend on lower-numbered tasks).
+7. Assign priority based on criticality and dependency order.
+8. Include detailed implementation guidance in the "details" field.
+9. Strictly adhere to any specific requirements for libraries, database schemas, frameworks, tech stacks, or other implementation details mentioned in the PRD.
+10. Fill in gaps left by the PRD while preserving all explicit requirements.
+11. Provide the most direct path to implementation, avoiding over-engineering.
+
+The final output should be valid JSON only, with no additional explanation or comments. Do not duplicate or rehash any of the work you did in the prd_breakdown section in your final output. The JSON must start with { and end with }. Example structure:
+
+{
+  "tasks": [
+    {
+      "id": 1,
+      "title": "Example Task Title",
+      "description": "Brief description of the task",
+      "status": "pending",
+      "dependencies": [], // Root task usually has no dependencies
+      "priority": "high",
+      "details": "Detailed implementation guidance",
+      "testStrategy": "Approach for validating this task"
+    },
+    // ... more tasks ...
+  ],
+  "metadata": {
+    "projectName": "PRD Implementation",
+    "totalTasks": <num_tasks>${numTasks}</num_tasks>,
+    "sourceFile": "<prd_path>${prdPath}</prd_path>",
+    "generatedAt": "YYYY-MM-DD" // Use current date
+  }
+}
+
+Remember to provide comprehensive task details that are LLM-friendly, consider dependencies and maintainability carefully, and keep in mind that you don\'t have the existing codebase as context. Aim for a balance between detailed guidance and high-level planning. Ensure the final output is just the JSON object.`;
+}
+
+/**
+ * Parses the JSON task data from the LLM completion text.
+ * Expects the completion to contain a JSON block like:
+ * {
+ *   "tasks": [...],
+ *   "metadata": {...}
+ * }
+ * @param {string} completionText - The raw text response from the LLM.
+ * @returns {Object} The parsed task data object { tasks: [], metadata: {} } or null if parsing fails.
+ */
+export function parseTasksFromCompletion(completionText) {
+	try {
+		// Find the start and end of the JSON block
+		const jsonStart = completionText.indexOf('{');
+		const jsonEnd = completionText.lastIndexOf('}');
+
+		if (jsonStart === -1 || jsonEnd === -1 || jsonEnd < jsonStart) {
+			console.error('Could not find valid JSON block in completion text.');
+			return null;
+		}
+
+		const jsonString = completionText.substring(jsonStart, jsonEnd + 1);
+
+		// Parse the JSON string
+		const parsedData = JSON.parse(jsonString);
+
+		// Basic validation
+		if (!parsedData || !Array.isArray(parsedData.tasks)) {
+			console.error('Parsed JSON does not have the expected tasks array structure.');
+			return null;
+		}
+
+		// Add current date to metadata if not present
+		if (parsedData.metadata && !parsedData.metadata.generatedAt) {
+			parsedData.metadata.generatedAt = new Date().toISOString().split('T')[0];
+		} else if (!parsedData.metadata) {
+			// Initialize metadata if missing
+			parsedData.metadata = {
+				generatedAt: new Date().toISOString().split('T')[0]
+			};
+		}
+
+		return parsedData;
+	} catch (error) {
+		console.error(`Error parsing tasks from completion: ${error.message}`);
+		console.error(`Completion Text causing error: \n---\n${completionText}\n---`);
+		return null;
+	}
+}
+
+// --- Add prompt builder for add_task ---
+/**
+ * Builds the system and user prompts for adding a new task based on context.
+ *
+ * @param {string} userPrompt - The user's description of the task.
+ * @param {Array} contextTasks - Array of existing tasks for context.
+ * @param {Object} [options] - Additional options.
+ * @param {number} [options.newTaskId] - The potential ID for the new task.
+ * @returns {{systemPrompt: string, userPrompt: string}}
+ */
+export function _buildAddTaskPrompt(userPrompt, contextTasks = [], { newTaskId } = {}) {
+	const systemPrompt = `You are an AI assistant helping to structure a new development task based on a user's prompt. Your goal is to create a single, well-defined task object in JSON format.
+
+Analyze the user's request and the context of existing tasks (if provided) to create a task object with the following fields:
+
+{
+  "title": string,          // Concise, descriptive title
+  "description": string,    // Brief summary of the task's goal
+  "details": string,        // Detailed implementation guidance, steps, or considerations
+  "testStrategy": string    // How the task's completion can be verified
+}
+
+Guidelines:
+1.  Extract the core requirement from the user's prompt: <user_prompt>${userPrompt}</user_prompt>
+2.  Consider the existing tasks to avoid duplication and understand the project context:
+    <existing_tasks>
+    ${contextTasks.length > 0 ? JSON.stringify(contextTasks.map(t => ({ id: t.id, title: t.title, status: t.status })), null, 2) : 'None provided.'}
+    </existing_tasks>
+3.  Generate a clear title, description, detailed implementation steps (details), and a verification method (testStrategy).
+4.  The 'details' field should be comprehensive enough for another developer (or AI) to understand the implementation steps.
+5.  The 'testStrategy' should be specific and actionable.
+6.  Do NOT include fields like 'id', 'status', 'dependencies', or 'priority' in your response object. These are handled separately.
+7.  Your response MUST be only the JSON object, starting with { and ending with }, with no additional text, comments, or explanations before or after it.
+
+Example Output Format:
+{
+  "title": "Implement User Authentication",
+  "description": "Set up JWT-based authentication endpoints.",
+  "details": "1. Install necessary libraries (jsonwebtoken, bcrypt). \n2. Create '/register' endpoint: hash password, save user. \n3. Create '/login' endpoint: verify credentials, issue JWT. \n4. Implement middleware to protect routes.",
+  "testStrategy": "Use Postman/curl to test registration, login (success/failure), and access to protected routes with/without valid token."
+}`;
+
+	// The user prompt remains the same, the system prompt provides the instructions and context.
+	return { systemPrompt, userPrompt };
+}
+
+// --- Add JSON parser specifically for single task objects ---
+/**
+ * Parses a JSON response expected to contain a single task object
+ * (title, description, details, testStrategy).
+ *
+ * @param {string} completionText - The raw text response from the LLM.
+ * @returns {Object|null} The parsed task data object or null if parsing fails.
+ */
+export function parseTaskJsonResponse(completionText) {
+  try {
+    // Find the start and end of the JSON block
+    const jsonStart = completionText.indexOf('{');
+    const jsonEnd = completionText.lastIndexOf('}');
+
+    if (jsonStart === -1 || jsonEnd === -1 || jsonEnd < jsonStart) {
+      console.error('Could not find valid JSON block in completion text for single task.');
+      return null;
+    }
+
+    const jsonString = completionText.substring(jsonStart, jsonEnd + 1);
+    const parsedData = JSON.parse(jsonString);
+
+    // Basic validation for expected fields
+    if (!parsedData || typeof parsedData.title !== 'string' || typeof parsedData.description !== 'string') {
+        console.error('Parsed JSON does not have the expected structure (title, description, details, testStrategy).');
+        return null;
+    }
+    // Ensure optional fields are at least present as empty strings if missing
+    parsedData.details = parsedData.details || '';
+    parsedData.testStrategy = parsedData.testStrategy || '';
+
+    return parsedData;
+  } catch (error) {
+    console.error(`Error parsing single task JSON from completion: ${error.message}`);
+    console.error(`Completion Text causing error: \n---\n${completionText}\n---`);
+    return null;
+  }
+}
+
+// --- Add prompt builder for complexity analysis ---
+/**
+ * Generates the prompt for AI complexity analysis.
+ *
+ * @param {Array} tasksToAnalyze - Array of task objects to analyze.
+ * @param {number} thresholdScore - The score above which expansion is recommended.
+ * @param {boolean} useResearch - Hint whether research capabilities might be useful.
+ * @returns {string} The formatted prompt for the AI.
+ */
+export function generateComplexityAnalysisPrompt(tasksToAnalyze, thresholdScore = 8, useResearch = false) {
+    const taskDescriptions = tasksToAnalyze.map(task => (
+        `<task id="${task.id}" title="${task.title}" priority="${task.priority || 'N/A'}" dependencies="${task.dependencies?.join(', ') || 'none'}">
+<description>${task.description || 'No description provided.'}</description>
+<details>${task.details || 'No details provided.'}</details>
+</task>`
+    )).join('\n\n');
+
+    return `Analyze the complexity of the following development tasks. For each task, provide:
+1.  A complexity score (1-10), where 1 is trivial and 10 is highly complex, requiring significant effort or research.
+2.  A brief justification for the score.
+3.  A recommendation (boolean) on whether the task should be expanded into subtasks (true if score >= ${thresholdScore}, false otherwise).
+
+${useResearch ? 'Feel free to leverage external knowledge or research if needed to better estimate complexity, especially for tasks involving unfamiliar technologies or concepts.\n' : ''}
+Consider factors like: clarity of requirements, estimated implementation time, number of components involved, potential unknowns or risks, required testing effort, and dependencies.
+
+Please provide the response as a JSON array, where each object represents a task's analysis:
+[
+  {
+    "id": <task_id>,
+    "title": "<task_title>",
+    "complexityScore": <score_1_to_10>,
+    "justification": "<brief_reasoning>",
+    "recommendExpansion": <boolean_true_if_score_>=_${thresholdScore}>
+  },
+  ...
+]
+
+Ensure the output is only the JSON array, starting with [ and ending with ].
+
+Tasks to analyze:
+${taskDescriptions}`;
+}
+
+// --- Add parser for complexity analysis response ---
+/**
+ * Parses the JSON array response from complexity analysis.
+ *
+ * @param {string} completionText - The raw text response from the LLM.
+ * @returns {Array|null} An array of complexity analysis objects or null if parsing fails.
+ */
+export function parseComplexityAnalysis(completionText) {
+  try {
+    // Find the start and end of the JSON array
+    const jsonStart = completionText.indexOf('[');
+    const jsonEnd = completionText.lastIndexOf(']');
+
+    if (jsonStart === -1 || jsonEnd === -1 || jsonEnd < jsonStart) {
+      console.error('Could not find valid JSON array block in complexity analysis completion.');
+      return null;
+    }
+
+    const jsonString = completionText.substring(jsonStart, jsonEnd + 1);
+    const parsedData = JSON.parse(jsonString);
+
+    // Basic validation: Check if it's an array
+    if (!Array.isArray(parsedData)) {
+      console.error('Parsed complexity analysis is not an array.');
+      return null;
+    }
+
+    // Optional: Further validation of array items structure can be added here
+    // e.g., check if each item has id, complexityScore, etc.
+
+    return parsedData;
+  } catch (error) {
+    console.error(`Error parsing complexity analysis JSON: ${error.message}`);
+    console.error(`Completion Text causing error: \n---\n${completionText}\n---`);
+    return null;
+  }
+}
+
+// --- Add prompt builder for expanding tasks into subtasks ---
+/**
+ * Generates the prompt for expanding a task into subtasks.
+ *
+ * @param {Object} task - The parent task object.
+ * @param {number|undefined} numSubtasks - The target number of subtasks (or undefined for AI default).
+ * @param {string} [additionalContext=''] - Any extra user-provided context.
+ * @param {Object|null} [complexityReport=null] - Optional complexity report data.
+ * @returns {string} The formatted prompt for the AI.
+ */
+export function generateSubtaskPrompt(task, numSubtasks, additionalContext = '', complexityReport = null) {
+    // Determine the target number of subtasks
+    let targetNumSubtasks = numSubtasks;
+    if (targetNumSubtasks === undefined && complexityReport?.complexityAnalysis) {
+        const taskAnalysis = complexityReport.complexityAnalysis.find(a => a.id === task.id);
+        if (taskAnalysis && taskAnalysis.complexityScore >= 8) {
+            targetNumSubtasks = Math.max(3, Math.min(10, Math.ceil(taskAnalysis.complexityScore / 1.5))); // Example logic
+        } else {
+            targetNumSubtasks = 3; // Default if score is low or no analysis
+        }
+    } else if (targetNumSubtasks === undefined) {
+        targetNumSubtasks = 5; // Fallback default if no complexity report
+    }
+
+    const contextInfo = additionalContext ? `\n\nAdditional Context Provided:\n${additionalContext}` : '';
+    const complexityInfo = complexityReport?.complexityAnalysis?.find(a => a.id === task.id)
+        ? `\n\nComplexity Analysis for this task:\nScore: ${complexityReport.complexityAnalysis.find(a => a.id === task.id).complexityScore}/10\nJustification: ${complexityReport.complexityAnalysis.find(a => a.id === task.id).justification}`
+        : '';
+
+    return `You are tasked with breaking down the following development task into approximately ${targetNumSubtasks} smaller, actionable subtasks. The goal is to create a clear, step-by-step plan for implementing the parent task.
+
+Parent Task:
+<task id="${task.id}" title="${task.title}" priority="${task.priority || 'N/A'}">
+<description>${task.description || 'No description provided.'}</description>
+<details>${task.details || 'No details provided.'}</details>
+<testStrategy>${task.testStrategy || 'No test strategy provided.'}</testStrategy>
+</task>
+${contextInfo}${complexityInfo}
+
+Generate a JSON array of subtask objects. Each subtask object should have:
+- "title": string (Concise title for the subtask)
+- "description": string (Brief description of the subtask's objective)
+- "details": string (Specific implementation steps or guidance for *this* subtask)
+
+Guidelines:
+1.  Create approximately ${targetNumSubtasks} subtasks.
+2.  Ensure subtasks are logically sequenced and cover the parent task's requirements.
+3.  Make subtasks specific and actionable.
+4.  Avoid making subtasks too large or too small (aim for implementable units).
+5.  The 'details' field for each subtask should provide clear instructions for that specific step.
+6.  Do NOT include 'id', 'status', or 'dependencies' in the subtask objects; these will be added later.
+7.  Your response MUST be only the JSON array, starting with [ and ending with ], with no additional text or explanations.
+
+Example Output Format:
+[
+  {
+    "title": "Setup Database Schema",
+    "description": "Define and apply the necessary database migrations.",
+    "details": "1. Create migration file for 'users' table (id, email, password_hash). 2. Run migration script."
+  },
+  {
+    "title": "Implement Registration Endpoint",
+    "description": "Create the API endpoint for user registration.",
+    "details": "1. Define POST /api/register route. 2. Hash incoming password. 3. Save user to database. 4. Return success response or error."
+  },
+  ...
+]`;
+}
+
+// --- Add parser for subtask array response ---
+/**
+ * Parses a JSON array of subtasks from the LLM completion text.
+ *
+ * @param {string} completionText - The raw text response from the LLM.
+ * @param {number} [expectedCount] - Optional: Expected number of subtasks (for logging/validation).
+ * @param {string|number} [parentTaskId] - Optional: ID of the parent task (for logging).
+ * @returns {Array|null} An array of subtask objects ({title, description, details}) or null if parsing fails.
+ */
+export function parseSubtasksFromText(completionText, expectedCount, parentTaskId) {
+  try {
+    const jsonStart = completionText.indexOf('[');
+    const jsonEnd = completionText.lastIndexOf(']');
+
+    if (jsonStart === -1 || jsonEnd === -1 || jsonEnd < jsonStart) {
+      console.error(`Could not find valid JSON array block in subtask completion for parent task ${parentTaskId || 'N/A'}.`);
+      return null;
+    }
+
+    const jsonString = completionText.substring(jsonStart, jsonEnd + 1);
+    const parsedData = JSON.parse(jsonString);
+
+    if (!Array.isArray(parsedData)) {
+      console.error(`Parsed subtask data is not an array for parent task ${parentTaskId || 'N/A'}.`);
+      return null;
+    }
+
+    // Basic validation of subtask structure
+    if (parsedData.length > 0) {
+        const firstSubtask = parsedData[0];
+        if (typeof firstSubtask.title !== 'string' || typeof firstSubtask.description !== 'string') {
+            console.error(`Parsed subtasks do not have the expected structure (title, description, details) for parent task ${parentTaskId || 'N/A'}.`);
+            return null;
+        }
+        // Ensure details field exists
+        parsedData.forEach(st => { st.details = st.details || ''; });
+    }
+
+
+    if (expectedCount !== undefined && parsedData.length !== expectedCount) {
+      console.warn(`Expected ${expectedCount} subtasks but parsed ${parsedData.length} for parent task ${parentTaskId || 'N/A'}.`);
+    }
+
+    return parsedData;
+  } catch (error) {
+    console.error(`Error parsing subtasks JSON for parent task ${parentTaskId || 'N/A'}: ${error.message}`);
+    console.error(`Completion Text causing error: \n---\n${completionText}\n---`);
+    return null;
+  }
+}
+
+// --- Add prompt builder for updating a single task ---
+/**
+ * Builds the prompt for updating a single task based on user instructions.
+ *
+ * @param {Object} taskToUpdate - The original task object.
+ * @param {string} updatePrompt - The user's instructions for the update.
+ * @returns {{systemPrompt: string, userPrompt: string}}
+ */
+export function _buildUpdateTaskPrompt(taskToUpdate, updatePrompt) {
+  const systemPrompt = `You are an AI assistant updating a specific development task based on new instructions. Your goal is to modify the provided task object according to the user's prompt and return the *complete, updated* task object in JSON format.
+
+Original Task:
+${JSON.stringify(taskToUpdate, null, 2)}
+
+User's Update Instructions:
+<update_prompt>
+${updatePrompt}
+</update_prompt>
+
+Guidelines:
+1.  Carefully apply the changes requested in the <update_prompt> to the original task data.
+2.  Update fields like 'title', 'description', 'details', 'testStrategy', and potentially 'priority' or 'dependencies' if explicitly requested or clearly implied by the update.
+3.  If the update implies changes to subtasks, update the 'subtasks' array accordingly (preserving existing subtask IDs).
+4.  Preserve the original 'id' and 'status' unless the update prompt specifically requests changing them.
+5.  Maintain the overall structure of the task object.
+6.  Your response MUST be only the complete, updated JSON task object, starting with { and ending with }, with no additional text or explanations.
+
+Example Output Format (Updated Task Object):
+{
+  "id": ${taskToUpdate.id},
+  "title": "Updated Task Title based on Prompt",
+  "description": "Updated description.",
+  "status": "${taskToUpdate.status}", // Preserved unless changed
+  "dependencies": [/* updated dependencies */],
+  "priority": "medium", // Potentially updated
+  "details": "Updated implementation details...",
+  "testStrategy": "Updated test strategy...",
+  "subtasks": [/* updated subtasks if applicable */]
+}`;
+
+  // The user prompt is included in the system prompt for clarity
+  // The main 'user' message to the LLM can be simple
+  const userPrompt = `Please update the task based on the instructions provided in the system prompt and return the full updated JSON object.`;
+
+  return { systemPrompt, userPrompt };
+}

--- a/mcp-server/src/core/utils/ai-client-utils.js
+++ b/mcp-server/src/core/utils/ai-client-utils.js
@@ -217,15 +217,12 @@ export function handleClaudeError(error) {
  * @param {string} prdContent - The content of the PRD.
  * @param {number} numTasks - The target number of tasks.
  * @param {string} [prdPath=\'N/A\'] - The path to the PRD file (optional).
- * @returns {string} The system prompt string.
+ * @returns {Object} The system prompt object { systemPrompt, userPrompt }
  */
 export function _generateParsePRDPrompt(prdContent, numTasks, prdPath = 'N/A') {
-	return `You are an AI assistant tasked with breaking down a Product Requirements Document (PRD) into a set of sequential development tasks. Your goal is to create exactly <num_tasks>${numTasks}</num_tasks> well-structured, actionable development tasks based on the PRD provided.
+	const systemPrompt = `You are an AI assistant tasked with breaking down a Product Requirements Document (PRD) into a set of sequential development tasks. Your goal is to create exactly <num_tasks>${numTasks}</num_tasks> well-structured, actionable development tasks based on the PRD provided.
 
-First, carefully read and analyze the attached PRD:
-<prd_content>
-${prdContent}
-</prd_content>
+First, carefully read and analyze the attached PRD below in the user message.
 
 Before creating the task list, work through the following steps inside <prd_breakdown> tags in your thinking block:
 
@@ -287,6 +284,12 @@ The final output should be valid JSON only, with no additional explanation or co
 }
 
 Remember to provide comprehensive task details that are LLM-friendly, consider dependencies and maintainability carefully, and keep in mind that you don\'t have the existing codebase as context. Aim for a balance between detailed guidance and high-level planning. Ensure the final output is just the JSON object.`;
+
+	// The userPrompt should contain the actual PRD content
+	const userPrompt = prdContent;
+
+	// Return the object expected by the caller
+	return { systemPrompt, userPrompt };
 }
 
 /**

--- a/mcp-server/src/tools/parse-prd.js
+++ b/mcp-server/src/tools/parse-prd.js
@@ -81,7 +81,7 @@ export function registerParsePRDTool(server) {
 				// Check if PRD path was found
 				if (!prdPath) {
 					return createErrorResponse(
-						'No PRD document found or provided. Please ensure a PRD file exists (e.g., PRD.md or prd.txt) in the project or 'scripts' directory, or provide a valid input file path.'
+						'No PRD document found or provided. Please ensure a PRD file exists (e.g., PRD.md or prd.txt) in the project or "scripts" directory, or provide a valid input file path.'
 					);
 				}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "task-master-ai",
-	"version": "0.11.1",
+	"version": "0.12.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "task-master-ai",
-			"version": "0.11.1",
+			"version": "0.12.1",
 			"license": "MIT WITH Commons-Clause",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"cors": "^2.8.5",
 				"dotenv": "^16.3.1",
 				"express": "^4.21.2",
-				"fastmcp": "^1.20.5",
+				"fastmcp": "^1.23.1",
 				"figlet": "^1.8.0",
 				"fuse.js": "^7.0.0",
 				"gradient-string": "^3.0.0",
@@ -1832,10 +1832,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
-			"integrity": "sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==",
-			"license": "MIT",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
+			"integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
 			"dependencies": {
 				"content-type": "^1.0.5",
 				"cors": "^2.8.5",
@@ -1843,7 +1842,7 @@
 				"eventsource": "^3.0.2",
 				"express": "^5.0.1",
 				"express-rate-limit": "^7.5.0",
-				"pkce-challenge": "^4.1.0",
+				"pkce-challenge": "^5.0.0",
 				"raw-body": "^3.0.0",
 				"zod": "^3.23.8",
 				"zod-to-json-schema": "^3.24.1"
@@ -1856,7 +1855,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
 			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-			"license": "MIT",
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
@@ -1869,7 +1867,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
 			"integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
 				"content-type": "^1.0.5",
@@ -1889,7 +1886,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
 			"integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "5.2.1"
 			},
@@ -1901,97 +1897,55 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
 			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-			"license": "MIT",
 			"engines": {
 				"node": ">=6.6.0"
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
-			"integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
-			"license": "MIT",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
 			"dependencies": {
 				"accepts": "^2.0.0",
-				"body-parser": "^2.0.1",
+				"body-parser": "^2.2.0",
 				"content-disposition": "^1.0.0",
-				"content-type": "~1.0.4",
-				"cookie": "0.7.1",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
 				"cookie-signature": "^1.2.1",
-				"debug": "4.3.6",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "^2.0.0",
-				"fresh": "2.0.0",
-				"http-errors": "2.0.0",
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
 				"merge-descriptors": "^2.0.0",
-				"methods": "~1.1.2",
 				"mime-types": "^3.0.0",
-				"on-finished": "2.4.1",
-				"once": "1.4.0",
-				"parseurl": "~1.3.3",
-				"proxy-addr": "~2.0.7",
-				"qs": "6.13.0",
-				"range-parser": "~1.2.1",
-				"router": "^2.0.0",
-				"safe-buffer": "5.2.1",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
 				"send": "^1.1.0",
-				"serve-static": "^2.1.0",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"type-is": "^2.0.0",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"license": "MIT"
-		},
-		"node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
 			"integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.0",
 				"encodeurl": "^2.0.0",
@@ -2008,7 +1962,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
 			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -2017,7 +1970,6 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -2029,7 +1981,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
 			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -2038,7 +1989,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
 			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -2050,7 +2000,6 @@
 			"version": "1.54.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
 			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -2059,7 +2008,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
 			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -2071,7 +2019,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -2080,7 +2027,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
 			"integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-			"license": "MIT",
 			"dependencies": {
 				"bytes": "3.1.2",
 				"http-errors": "2.0.0",
@@ -2095,7 +2041,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
 			"integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.5",
 				"encodeurl": "^2.0.0",
@@ -2117,7 +2062,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
 			"integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-			"license": "MIT",
 			"dependencies": {
 				"encodeurl": "^2.0.0",
 				"escape-html": "^1.0.3",
@@ -2132,7 +2076,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
 			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-			"license": "MIT",
 			"dependencies": {
 				"content-type": "^1.0.5",
 				"media-typer": "^1.1.0",
@@ -2224,6 +2167,11 @@
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.0"
 			}
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
 		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.2.7",
@@ -3753,7 +3701,6 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
 			"integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
-			"license": "MIT",
 			"dependencies": {
 				"eventsource-parser": "^3.0.1"
 			},
@@ -3765,7 +3712,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
 			"integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
-			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
 			}
@@ -3893,7 +3839,6 @@
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
 			"integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
-			"license": "MIT",
 			"engines": {
 				"node": ">= 16"
 			},
@@ -3987,22 +3932,23 @@
 			"license": "MIT"
 		},
 		"node_modules/fastmcp": {
-			"version": "1.20.5",
-			"resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-1.20.5.tgz",
-			"integrity": "sha512-jwcPgMF9bcE9qsEG82YMlAG26/n5CSYsr95e60ntqWWd+3kgTBbUIasB3HfpqHLTNaQuoX6/jl18fpDcybBjcQ==",
-			"license": "MIT",
+			"version": "1.23.1",
+			"resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-1.23.1.tgz",
+			"integrity": "sha512-m7cx4ZzKSsWL3WXZQznbF0fYLlJzCcO/9g/JlwTnH9aDi76MqDYTosB0jCujsc/xy3gWvGsoIfGKjn6QAuWHUw==",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.6.0",
+				"@modelcontextprotocol/sdk": "^1.10.2",
+				"@standard-schema/spec": "^1.0.0",
 				"execa": "^9.5.2",
-				"file-type": "^20.3.0",
+				"file-type": "^20.4.1",
 				"fuse.js": "^7.1.0",
-				"mcp-proxy": "^2.10.4",
+				"mcp-proxy": "^2.12.2",
 				"strict-event-emitter-types": "^2.0.0",
-				"undici": "^7.4.0",
+				"undici": "^7.8.0",
 				"uri-templates": "^0.2.0",
+				"xsschema": "0.2.0-beta.3",
 				"yargs": "^17.7.2",
-				"zod": "^3.24.2",
-				"zod-to-json-schema": "^3.24.3"
+				"zod": "^3.24.3",
+				"zod-to-json-schema": "^3.24.5"
 			},
 			"bin": {
 				"fastmcp": "dist/bin/fastmcp.js"
@@ -4955,8 +4901,7 @@
 		"node_modules/is-promise": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-			"license": "MIT"
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
@@ -5995,13 +5940,12 @@
 			}
 		},
 		"node_modules/mcp-proxy": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-2.12.0.tgz",
-			"integrity": "sha512-hL2Y6EtK7vkgAOZxOQe9M4Z9g5xEnvR4ZYBKqFi/5tjhz/1jyNEz5NL87Uzv46k8iZQPVNEof/T6arEooBU5bQ==",
-			"license": "MIT",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-2.13.0.tgz",
+			"integrity": "sha512-NyoKzwRcfGMiGBNzwwA7zfAKf8h9UIeeqaRKGXFFi/VqG8iMv+Z5aADsZkbSv/eeErP4bWo+hY5tzK+6JcFasg==",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.6.0",
-				"eventsource": "^3.0.5",
+				"@modelcontextprotocol/sdk": "^1.10.1",
+				"eventsource": "^3.0.6",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -6632,10 +6576,9 @@
 			}
 		},
 		"node_modules/pkce-challenge": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-			"integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
-			"license": "MIT",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+			"integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
 			"engines": {
 				"node": ">=16.20.0"
 			}
@@ -6967,7 +6910,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
 			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.0",
 				"depd": "^2.0.0",
@@ -6983,7 +6925,6 @@
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
 			"integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-			"license": "MIT",
 			"engines": {
 				"node": ">=16"
 			}
@@ -7683,10 +7624,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.6.0.tgz",
-			"integrity": "sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA==",
-			"license": "MIT",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+			"integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
 			"engines": {
 				"node": ">=20.18.1"
 			}
@@ -7916,6 +7856,31 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/xsschema": {
+			"version": "0.2.0-beta.3",
+			"resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.2.0-beta.3.tgz",
+			"integrity": "sha512-ViOZ1a1kAPHvFjDJp4ITeutdlbnEs56lx/NotlvcitwN04eHnU3DhR+P5GvXT7A+69qKrXAx0YrccvmfwGnUGw==",
+			"peerDependencies": {
+				"@valibot/to-json-schema": "^1.0.0",
+				"arktype": "^2.1.16",
+				"effect": "^3.14.5",
+				"zod-to-json-schema": "^3.24.5"
+			},
+			"peerDependenciesMeta": {
+				"@valibot/to-json-schema": {
+					"optional": true
+				},
+				"arktype": {
+					"optional": true
+				},
+				"effect": {
+					"optional": true
+				},
+				"zod-to-json-schema": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8038,10 +8003,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.24.2",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-			"license": "MIT",
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+			"integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -8050,7 +8014,6 @@
 			"version": "3.24.5",
 			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
 			"integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-			"license": "ISC",
 			"peerDependencies": {
 				"zod": "^3.24.1"
 			}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"cors": "^2.8.5",
 		"dotenv": "^16.3.1",
 		"express": "^4.21.2",
-		"fastmcp": "^1.20.5",
+		"fastmcp": "^1.23.1",
 		"figlet": "^1.8.0",
 		"fuse.js": "^7.0.0",
 		"gradient-string": "^3.0.0",


### PR DESCRIPTION
If you're running task master as an MCP, you're already using an LLM. So why not just use whatever LLM agent calling the MCP to make the calls that you needed an Anthropic API key for? This PR does just that! We now utilize the capability of MCP to expose prompts and so that agent will know how to make the calls itself. No need for any API keys! And as a bonus you can use any LLM instead of just claude.