### PR TITLE
fix(update-tasks): Improve AI response parsing for 'update' command

### DIFF
--- a/scripts/modules/task-manager/update-task-by-id.js
+++ b/scripts/modules/task-manager/update-task-by-id.js
@@ -380,7 +380,7 @@ The changes described in the prompt should be thoughtfully applied to make the t
 		let loadingIndicator = null;
 		if (outputFormat === 'text') {
 			loadingIndicator = startLoadingIndicator(
-				useResearch ? 'Updating task with research...' : 'Updating task...'
+				useResearch ? 'Updating task with research...\n' : 'Updating task...\n'
 			);
 		}
 


### PR DESCRIPTION
Refactors the JSON array parsing logic within
in .

The previous logic primarily relied on extracting content from markdown code blocks (json or javascript), which proved brittle when the AI response included comments or non-JSON text within the block, leading to parsing errors for the  command.

This change modifies the parsing strategy to first attempt extracting content directly between the outermost '[' and ']' brackets. This is more robust as it targets the expected array structure directly. If bracket extraction fails, it falls back to looking for a strict json code block, then prefix stripping, before attempting a raw parse.

This approach aligns with the successful parsing strategy used for single-object responses in  and resolves the
parsing errors previously observed with the  command.