### PR TITLE
only ignore `/tasks` folder that is in the main folder 

### DIFF
--- a/assets/gitignore
+++ b/assets/gitignore
@@ -26,4 +26,4 @@ node_modules/
 
 # Task files
 tasks.json
-tasks/ 
+/tasks/ 


### PR DESCRIPTION
* `/tasks` directory is created by claude-task-master.
* This PR prevent other `tasks/` directories in the repo not getting gitignored