### PR TITLE
Update .taskmasterconfig

### DIFF
--- a/.changeset/ten-ways-mate.md
+++ b/.changeset/ten-ways-mate.md
@@ -1,0 +1,5 @@
+---
+'task-master-ai': patch
+---
+
+Fix default fallback model and maxTokens in Taskmaster initialization

--- a/assets/.taskmasterconfig
+++ b/assets/.taskmasterconfig
@@ -15,7 +15,7 @@
 		"fallback": {
 			"provider": "anthropic",
 			"modelId": "claude-3.5-sonnet-20240620",
-			"maxTokens": 120000,
+			"maxTokens": 8192,
 			"temperature": 0.1
 		}
 	},

--- a/assets/.taskmasterconfig
+++ b/assets/.taskmasterconfig
@@ -14,7 +14,7 @@
 		},
 		"fallback": {
 			"provider": "anthropic",
-			"modelId": "claude-3.5-sonnet-20240620",
+			"modelId": "claude-3-5-sonnet-20240620",
 			"maxTokens": 8192,
 			"temperature": 0.1
 		}


### PR DESCRIPTION
Max tokens in 3.5 is lower.  With the current number get this error:

Service call failed for role fallback (Provider: anthropic, Model: claude-3-5-sonnet-20240620): max_tokens: 120000 > 8192, which is the maximum allowed number of output tokens for claude-3-5-sonnet-20240620

- Closes #463