### PR TITLE
Add feature custom response language with changeset

### DIFF
--- a/.changeset/true-vans-change.md
+++ b/.changeset/true-vans-change.md
@@ -1,0 +1,8 @@
+---
+'task-master-ai': patch
+---
+
+Add custom response language support
+Add response language setting in config manager
+Apply response language setting in PRD parsing
+Set default to English

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -61,7 +61,8 @@ const DEFAULTS = {
 		defaultSubtasks: 5,
 		defaultPriority: 'medium',
 		projectName: 'Task Master',
-		ollamaBaseUrl: 'http://localhost:11434/api'
+		ollamaBaseUrl: 'http://localhost:11434/api',
+		responseLanguage: 'English'
 	}
 };
 
@@ -364,6 +365,11 @@ function getProjectName(explicitRoot = null) {
 function getOllamaBaseUrl(explicitRoot = null) {
 	// Directly return value from config
 	return getGlobalConfig(explicitRoot).ollamaBaseUrl;
+}
+
+function getResponseLanguage(explicitRoot = null) {
+	// Directly return value from config
+	return getGlobalConfig(explicitRoot).responseLanguage;
 }
 
 /**
@@ -713,6 +719,7 @@ export {
 	getDefaultPriority,
 	getProjectName,
 	getOllamaBaseUrl,
+	getResponseLanguage,
 	getParametersForRole,
 
 	// API Key Checkers (still relevant)

--- a/scripts/modules/task-manager/parse-prd.js
+++ b/scripts/modules/task-manager/parse-prd.js
@@ -15,7 +15,7 @@ import {
 } from '../utils.js';
 
 import { generateObjectService } from '../ai-services-unified.js';
-import { getDebugFlag } from '../config-manager.js';
+import { getDebugFlag, getResponseLanguage } from '../config-manager.js';
 import generateTaskFiles from './generate-task-files.js';
 
 // Define the Zod schema for a SINGLE task object
@@ -179,7 +179,8 @@ Guidelines:
 8. Include detailed implementation guidance in the "details" field
 9. If the PRD contains specific requirements for libraries, database schemas, frameworks, tech stacks, or any other implementation details, STRICTLY ADHERE to these requirements in your task breakdown and do not discard them under any circumstance
 10. Focus on filling in any gaps left by the PRD or areas that aren't fully specified, while preserving all explicit requirements
-11. Always aim to provide the most direct path to implementation, avoiding over-engineering or roundabout approaches`;
+11. Always aim to provide the most direct path to implementation, avoiding over-engineering or roundabout approaches
+12. Always respond in ${getResponseLanguage(projectRoot)}`;
 
 		// Build user prompt with PRD content
 		const userPrompt = `Here's the Product Requirements Document (PRD) to break down into approximately ${numTasks} tasks, starting IDs from ${nextId}:\n\n${prdContent}\n\n


### PR DESCRIPTION
# Add Custom Response Language Support

## Feature Description
This PR adds the ability to configure AI response language, allowing Task Master to output results in different languages based on user settings.

## Implementation Details
- Added response language setting in the configuration manager (default is English)
- Applied response language setting in the PRD parser
- Added ability to customize AI output language through configuration file

## Testing Method
1. Modify the `responseLanguage` value in the configuration file
2. Run the parse-prd command
3. Verify the output uses the specified language

## Changeset
Includes a patch-level changeset documenting the feature update for custom response language support