### PR TITLE
feat: Flexible Git Storage for Task Files (`tasks.json` and `tasks/`)

### DIFF
--- a/.changeset/twenty-candles-end.md
+++ b/.changeset/twenty-candles-end.md
@@ -1,0 +1,32 @@
+---
+'task-master-ai': patch
+---
+
+### Feature: Flexible Git Storage for tasks.json and Task Files
+
+This release introduces a robust, user-friendly mechanism for controlling whether `tasks.json` and the `tasks/` directory are stored in Git, with both CLI automation and interactive support.
+
+#### Highlights
+
+- **New CLI Flags:**
+  - `--git-tasks` / `--no-git-tasks` for the `init` command allow users to explicitly choose whether to store `tasks.json` and `tasks/` in Git, supporting both automation and scripting.
+  - These flags override the interactive prompt, enabling seamless CI/CD or non-interactive usage.
+
+- **Improved Interactive Flow:**
+  - If no flag is provided, the CLI prompts the user once, at the end of the setup sequence, for their Git storage preference.
+  - After all questions, a summary of all settings (including Git storage choice) is shown for confirmation before proceeding.
+
+- **.gitignore Merge Logic:**
+  - The `.gitignore` is updated non-destructively: existing entries are preserved, and only the relevant lines for `tasks.json` and `tasks/` are commented/uncommented based on user choice.
+  - The section header `# Task files` is always included above these lines for clarity and consistency, but never duplicated.
+
+- **Code Quality and Maintenance:**
+  - CLI argument handling is concise and robust, supporting both interactive and automated workflows.
+  - Error handling and code comments have been improved for maintainability.
+
+#### Usage Example
+- Store in Git: `task-master init --git-tasks`
+- Ignore in Git: `task-master init --no-git-tasks`
+- Interactive: Run `task-master init` and answer the prompt at the end.
+
+This change greatly improves the flexibility and professionalism of project initialization, and ensures that user preferences for Git storage are always respected and clearly reflected in `.gitignore`.

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -492,7 +492,7 @@ async function initializeProject(options = {}) {
 			);
 			const addAliasesPrompted = addAliasesInput.trim().toLowerCase() !== 'n';
 
-			// Prompt for storeTasksInGit at the end if not provided
+			// Prompt for storeTasksInGit if not provided
 			if (typeof resolvedStoreTasksInGit === 'undefined') {
 				const storeTasksAnswer = await promptQuestion(
 					rl,
@@ -507,7 +507,7 @@ async function initializeProject(options = {}) {
 			console.log('\nTask Master Project settings:');
 			console.log(
 				chalk.blue(
-					'Add shell aliases (so you can use "tm" instead of "task-master"): '
+					'Add shell aliases (so you can use "tm" instead of "task-master"):'
 				),
 				chalk.white(addAliasesPrompted ? 'Yes' : 'No')
 			);

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -174,7 +174,12 @@ alias taskmaster='task-master'
 }
 
 // Function to copy a file from the package to the target directory
-function copyTemplateFile(templateName, targetPath, replacements = {}, storeTasksInGit) {
+function copyTemplateFile(
+	templateName,
+	targetPath,
+	replacements = {},
+	storeTasksInGit
+) {
 	// Get the file content from the appropriate source directory
 	let sourcePath;
 
@@ -274,10 +279,18 @@ function copyTemplateFile(templateName, targetPath, replacements = {}, storeTask
 		// Split template lines
 		let templateLines = content.split('\n');
 		// Adjust last two lines
-		const taskJsonIdx = templateLines.findIndex(l => l.trim().replace(/^#/, '').trim() === 'tasks.json');
-		const tasksDirIdx = templateLines.findIndex(l => l.trim().replace(/^#/, '').trim() === 'tasks/');
-		if (taskJsonIdx !== -1) templateLines[taskJsonIdx] = (storeTasksInGit ? '# tasks.json' : 'tasks.json');
-		if (tasksDirIdx !== -1) templateLines[tasksDirIdx] = (storeTasksInGit ? '# tasks/' : 'tasks/');
+		const taskJsonIdx = templateLines.findIndex(
+			(l) => l.trim().replace(/^#/, '').trim() === 'tasks.json'
+		);
+		const tasksDirIdx = templateLines.findIndex(
+			(l) => l.trim().replace(/^#/, '').trim() === 'tasks/'
+		);
+		if (taskJsonIdx !== -1)
+			templateLines[taskJsonIdx] = storeTasksInGit
+				? '# tasks.json'
+				: 'tasks.json';
+		if (tasksDirIdx !== -1)
+			templateLines[tasksDirIdx] = storeTasksInGit ? '# tasks/' : 'tasks/';
 
 		// Read existing .gitignore
 		let existingLines = [];
@@ -285,23 +298,29 @@ function copyTemplateFile(templateName, targetPath, replacements = {}, storeTask
 			existingLines = fs.readFileSync(targetPath, 'utf8').split('\n');
 		}
 		// Remove any version (commented or not) of the two lines from existingLines
-		existingLines = existingLines.filter(l => {
+		existingLines = existingLines.filter((l) => {
 			const trimmed = l.trim().replace(/^#/, '').trim();
 			return trimmed !== 'tasks.json' && trimmed !== 'tasks/';
 		});
 		// Prepare the correct lines from templateLines
-		const taskLines = templateLines.filter(l => {
-			const trimmed = l.trim().replace(/^#/, '').trim();
-			return trimmed === 'tasks.json' || trimmed === 'tasks/';
-		}).filter(l => {
-			const trimmed = l.trim().replace(/^#/, '').trim();
-			return !existingLines.some(e => e.trim().replace(/^#/, '').trim() === trimmed);
-		});
+		const taskLines = templateLines
+			.filter((l) => {
+				const trimmed = l.trim().replace(/^#/, '').trim();
+				return trimmed === 'tasks.json' || trimmed === 'tasks/';
+			})
+			.filter((l) => {
+				const trimmed = l.trim().replace(/^#/, '').trim();
+				return !existingLines.some(
+					(e) => e.trim().replace(/^#/, '').trim() === trimmed
+				);
+			});
 		// Only add the comment if at least one line is being added
 		let finalLines = [...existingLines];
 		if (taskLines.length > 0) {
 			// Only add the comment if not already present
-			const hasTaskFilesComment = finalLines.some(l => l.trim() === '# Task files');
+			const hasTaskFilesComment = finalLines.some(
+				(l) => l.trim() === '# Task files'
+			);
 			if (!hasTaskFilesComment) {
 				finalLines.push('# Task files');
 			}
@@ -409,7 +428,7 @@ async function initializeProject(options = {}) {
 
 	let resolvedStoreTasksInGit = options.storeTasksInGit;
 
-if (skipPrompts) {
+	if (skipPrompts) {
 		if (!isSilentMode()) {
 			console.log('SKIPPING PROMPTS - Using defaults or provided values');
 		}
@@ -435,7 +454,6 @@ if (skipPrompts) {
 			};
 		}
 
-
 		// Determine storeTasksInGit: use CLI option if provided, otherwise prompt
 		let resolvedStoreTasksInGit = options.storeTasksInGit;
 		if (typeof resolvedStoreTasksInGit === 'undefined') {
@@ -443,16 +461,17 @@ if (skipPrompts) {
 				input: process.stdin,
 				output: process.stdout
 			});
-			const storeTasksAnswer = await new Promise(resolve => {
+			const storeTasksAnswer = await new Promise((resolve) => {
 				rl.question(
 					'Would you like your tasks.json and task files stored in Git? (y/N): ',
-					answer => {
+					(answer) => {
 						rl.close();
 						resolve(answer.trim().toLowerCase());
 					}
 				);
 			});
-			resolvedStoreTasksInGit = storeTasksAnswer === 'y' || storeTasksAnswer === 'yes';
+			resolvedStoreTasksInGit =
+				storeTasksAnswer === 'y' || storeTasksAnswer === 'yes';
 		}
 		createProjectStructure(addAliases, dryRun, resolvedStoreTasksInGit);
 	} else {
@@ -479,13 +498,17 @@ if (skipPrompts) {
 					rl,
 					'Would you like your tasks.json and task files stored in Git? (y/N): '
 				);
-				resolvedStoreTasksInGit = storeTasksAnswer.trim().toLowerCase() === 'y' || storeTasksAnswer.trim().toLowerCase() === 'yes';
+				resolvedStoreTasksInGit =
+					storeTasksAnswer.trim().toLowerCase() === 'y' ||
+					storeTasksAnswer.trim().toLowerCase() === 'yes';
 			}
 
 			// Confirm settings after all questions
 			console.log('\nTask Master Project settings:');
 			console.log(
-				chalk.blue('Add shell aliases (so you can use "tm" instead of "task-master"): '),
+				chalk.blue(
+					'Add shell aliases (so you can use "tm" instead of "task-master"): '
+				),
 				chalk.white(addAliasesPrompted ? 'Yes' : 'No')
 			);
 			console.log(
@@ -521,7 +544,11 @@ if (skipPrompts) {
 			}
 
 			// Create structure using only necessary values
-			createProjectStructure(addAliasesPrompted, dryRun, resolvedStoreTasksInGit);
+			createProjectStructure(
+				addAliasesPrompted,
+				dryRun,
+				resolvedStoreTasksInGit
+			);
 		} catch (error) {
 			rl.close();
 			log('error', `Error during initialization process: ${error.message}`);
@@ -589,7 +616,12 @@ function createProjectStructure(addAliases, dryRun, storeTasksInGit) {
 	);
 
 	// Copy .gitignore with dynamic tasks lines
-	copyTemplateFile('gitignore', path.join(targetDir, '.gitignore'), {}, storeTasksInGit);
+	copyTemplateFile(
+		'gitignore',
+		path.join(targetDir, '.gitignore'),
+		{},
+		storeTasksInGit
+	);
 
 	// Copy dev_workflow.mdc
 	copyTemplateFile(

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -2093,6 +2093,8 @@ function registerCommands(programInstance) {
 		.option('--skip-install', 'Skip installing dependencies')
 		.option('--dry-run', 'Show what would be done without making changes')
 		.option('--aliases', 'Add shell aliases (tm, taskmaster)')
+		.option('--git-tasks', 'Store tasks.json and task files in Git')
+		.option('--no-git-tasks', 'Do not store tasks.json and task files in Git')
 		.action(async (cmdOptions) => {
 			// cmdOptions contains parsed arguments
 			try {
@@ -2102,6 +2104,9 @@ function registerCommands(programInstance) {
 					JSON.stringify(cmdOptions)
 				);
 				// Directly call the initializeProject function, passing the parsed options
+				if (typeof cmdOptions.gitTasks === 'boolean') {
+					cmdOptions.storeTasksInGit = cmdOptions.gitTasks;
+				}
 				await initializeProject(cmdOptions);
 				// initializeProject handles its own flow, including potential process.exit()
 			} catch (error) {


### PR DESCRIPTION
## Feature: Flexible Git Storage for Task Files (`tasks.json` and `tasks/`)

### Overview

This PR introduces a robust, user-friendly mechanism for controlling whether `tasks.json` and the `tasks/` directory are stored in Git, supporting both interactive and automated workflows.

### Key Changes

- **New CLI Flags:**  
  - `--git-tasks` and `--no-git-tasks` for the `init` command allow users to explicitly choose whether to store `tasks.json` and `tasks/` in Git.
  - These flags override the interactive prompt, making the tool CI/CD and script friendly.

- **Improved Interactive Flow:**  
  - If no flag is provided, the CLI prompts the user once, at the end of the setup sequence, for their Git storage preference.
  - All settings (including Git storage) are summarized for confirmation before proceeding.

- **Non-Destructive `.gitignore` Merging:**  
  - Updates `.gitignore` without overwriting existing entries.
  - The section header `# Task files` is always included above the relevant lines, but never duplicated.
  - Only the `tasks.json` and `tasks/` lines are commented/uncommented as needed.

- **Code Quality:**  
  - Concise CLI argument handling.
  - Improved error handling and maintainability.

### Usage Examples

- Store in Git:  
  ```sh
  task-master init --git-tasks