### PR TITLE
Fix: Correct version resolution for banner and update check

### DIFF
--- a/.changeset/many-wasps-sell.md
+++ b/.changeset/many-wasps-sell.md
@@ -1,0 +1,5 @@
+---
+'task-master-ai': patch
+---
+
+Task Master no longer tells you to update when you're already up to date

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,8 +1,8 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
-    "task-master-ai": "0.13.1"
+    "task-master-ai": "0.13.2"
   },
   "changesets": [
     "beige-doodles-type",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "task-master-ai",
-	"version": "0.13.2-rc.1",
+	"version": "0.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "task-master-ai",
-			"version": "0.13.2-rc.1",
+			"version": "0.12",
 			"license": "MIT WITH Commons-Clause",
 			"dependencies": {
 				"@ai-sdk/anthropic": "^1.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "task-master-ai",
-	"version": "0.13.2-rc.1",
+	"version": "0.13.2",
 	"description": "A task management system for ambitious AI-driven development that doesn't overwhelm and confuse Cursor.",
 	"main": "index.js",
 	"type": "module",

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -4,7 +4,7 @@
  */
 
 import { program } from 'commander';
-import path, { dirname, join as pathJoin } from 'path';
+import path from 'path';
 import chalk from 'chalk';
 import boxen from 'boxen';
 import fs from 'fs';

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -11,7 +11,6 @@ import fs from 'fs';
 import https from 'https';
 import inquirer from 'inquirer';
 import ora from 'ora'; // Import ora
-import { fileURLToPath } from 'url'; // Added import
 
 import { log, readJSON } from './utils.js';
 import {
@@ -1270,7 +1269,10 @@ function registerCommands(programInstance) {
 			'-d, --description <description>',
 			'Task description (for manual task creation)'
 		)
-		.option('--details <details>', 'Implementation details (for manual task creation)')
+		.option(
+			'--details <details>',
+			'Implementation details (for manual task creation)'
+		)
 		.option(
 			'--dependencies <dependencies>',
 			'Comma-separated list of task IDs this task depends on'
@@ -1642,7 +1644,7 @@ function registerCommands(programInstance) {
 								chalk.white('Create new subtask:') +
 								'\n' +
 								chalk.yellow(
-									`  task-master add-subtask -p 5 -t "Implement login UI" -d "Create the login form"`
+									`  task-master add-subtask --parent=5 --title="Implement login UI" --description="Create the login form"`
 								) +
 								'\n\n',
 							{ padding: 1, borderColor: 'blue', borderStyle: 'round' }
@@ -2376,25 +2378,7 @@ function setupCLI() {
  */
 async function checkForUpdate() {
 	// Get current version from package.json ONLY
-	let currentVersion = 'unknown'; // Initialize with a default
-	try {
-		// Get the directory of the current module (commands.js)
-		const currentModuleFilename = fileURLToPath(import.meta.url);
-		const currentModuleDirname = dirname(currentModuleFilename);
-		// Construct the path to package.json relative to commands.js (../../package.json)
-		const packageJsonPath = pathJoin(currentModuleDirname, '..', '..', 'package.json');
-
-		if (fs.existsSync(packageJsonPath)) {
-			const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
-			const packageJson = JSON.parse(packageJsonContent);
-			currentVersion = packageJson.version;
-		} else {
-			log('debug', `Own package.json not found at expected path for update check: ${packageJsonPath}`);
-		}
-	} catch (error) {
-		// Silently fail and use default
-		log('debug', `Error reading current package version: ${error.message}`);
-	}
+	const currentVersion = getTaskMasterVersion();
 
 	return new Promise((resolve) => {
 		// Get the latest version from npm registry

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -73,7 +73,7 @@ import {
 	getApiKeyStatusReport
 } from './task-manager/models.js';
 import { findProjectRoot } from './utils.js';
-
+import { getTaskMasterVersion } from '../../src/utils/getVersion.js';
 /**
  * Runs the interactive setup process for model configuration.
  * @param {string|null} projectRoot - The resolved project root directory.

--- a/scripts/modules/ui.js
+++ b/scripts/modules/ui.js
@@ -9,7 +9,6 @@ import boxen from 'boxen';
 import ora from 'ora';
 import Table from 'cli-table3';
 import gradient from 'gradient-string';
-import fs from 'fs';
 import {
 	log,
 	findTaskById,
@@ -17,6 +16,7 @@ import {
 	truncate,
 	isSilentMode
 } from './utils.js';
+import fs from 'fs';
 import { findNextTask, analyzeTaskComplexity } from './task-manager.js';
 import { getProjectName, getDefaultSubtasks } from './config-manager.js';
 import { getTaskMasterVersion } from '../../src/utils/getVersion.js';

--- a/scripts/modules/ui.js
+++ b/scripts/modules/ui.js
@@ -9,8 +9,6 @@ import boxen from 'boxen';
 import ora from 'ora';
 import Table from 'cli-table3';
 import gradient from 'gradient-string';
-import { fileURLToPath } from 'url'; 
-import path, { dirname, join as pathJoin } from 'path'; 
 import fs from 'fs';
 import {
 	log,
@@ -21,6 +19,7 @@ import {
 } from './utils.js';
 import { findNextTask, analyzeTaskComplexity } from './task-manager.js';
 import { getProjectName, getDefaultSubtasks } from './config-manager.js';
+import { getTaskMasterVersion } from '../../src/utils/getVersion.js';
 
 // Create a color gradient for the banner
 const coolGradient = gradient(['#00b4d8', '#0077b6', '#03045e']);
@@ -47,25 +46,7 @@ function displayBanner() {
 	);
 
 	// Read version directly from package.json
-	let version = 'unknown'; // Initialize with a default
-	try {
-		// Get the directory of the current module (ui.js)
-		const currentModuleFilename = fileURLToPath(import.meta.url);
-		const currentModuleDirname = dirname(currentModuleFilename);
-		// Construct the path to package.json relative to ui.js (../../package.json)
-		const packageJsonPath = pathJoin(currentModuleDirname, '..', '..', 'package.json');
-
-		if (fs.existsSync(packageJsonPath)) {
-			const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
-			const packageJson = JSON.parse(packageJsonContent);
-			version = packageJson.version;
-		} else {
-			log('warn', `Own package.json not found at expected path: ${packageJsonPath}`);
-		}
-	} catch (error) {
-		// Silently fall back to default version
-		log('warn', 'Could not read own package.json for version info.', error);
-	}
+	const version = getTaskMasterVersion();
 
 	console.log(
 		boxen(
@@ -946,7 +927,7 @@ async function displayNextTask(tasksPath) {
 						}
 						return chalk.red(`${nextTask.id}.${depId} (Not found)`);
 					}
-					return depId; // Assume it's a top-level task ID if not a number < 100
+					return depId;
 				});
 
 				// Join the formatted dependencies directly instead of passing to formatDependenciesWithStatus again
@@ -1238,7 +1219,6 @@ async function displayTaskById(tasksPath, taskId, statusFilter = null) {
 			const statusColor = statusColorMap[st.status || 'pending'] || chalk.white;
 			let subtaskDeps = 'None';
 			if (st.dependencies && st.dependencies.length > 0) {
-				// Format dependencies with correct notation
 				const formattedDeps = st.dependencies.map((depId) => {
 					// Use the original, unfiltered list for dependency status lookup
 					const sourceListForDeps = originalSubtasks || task.subtasks;

--- a/src/utils/getVersion.js
+++ b/src/utils/getVersion.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { log } from '../../scripts/modules/utils.js';
+
+/**
+ * Reads the version from the nearest package.json relative to this file.
+ * Returns 'unknown' if not found or on error.
+ * @returns {string} The version string or 'unknown'.
+ */
+export function getTaskMasterVersion() {
+	let version = 'unknown';
+	try {
+		// Get the directory of the current module (getPackageVersion.js)
+		const currentModuleFilename = fileURLToPath(import.meta.url);
+		const currentModuleDirname = path.dirname(currentModuleFilename);
+		// Construct the path to package.json relative to this file (../../package.json)
+		const packageJsonPath = path.join(
+			currentModuleDirname,
+			'..',
+			'..',
+			'package.json'
+		);
+
+		if (fs.existsSync(packageJsonPath)) {
+			const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+			const packageJson = JSON.parse(packageJsonContent);
+			version = packageJson.version;
+		}
+	} catch (error) {
+		// Silently fall back to default version
+		log('warn', 'Could not read own package.json for version info.', error);
+	}
+	return version;
+}


### PR DESCRIPTION
This pull request resolves issues where the tool's version was displayed as 'unknown' in the main banner and in the update availability notification.

**Changes Made:**

- Modified `displayBanner` in `scripts/modules/ui.js` to correctly read `package.json` relative to its own script location using `import.meta.url`. This ensures the main banner displays the accurate installed version.
- Modified `checkForUpdate` in `scripts/modules/commands.js` to also use `import.meta.url` for resolving its `package.json` path. This fixes the 'unknown' version in the "Update Available!" message.
- Restored a missing closing curly brace in `scripts/modules/ui.js` which was causing a `SyntaxError`.

These changes ensure consistent and correct version reporting throughout the tool.

- Closes #432