### PR TITLE
Add validation of task status

### DIFF
--- a/mcp-server/src/tools/set-task-status.js
+++ b/mcp-server/src/tools/set-task-status.js
@@ -11,6 +11,7 @@ import {
 } from './utils.js';
 import { setTaskStatusDirect } from '../core/task-master-core.js';
 import { findTasksJsonPath } from '../core/utils/path-utils.js';
+import { VALID_TASK_STATUS_VALUES } from '../../../../scripts/modules/task-manager/set-task-status.js';
 
 /**
  * Register the setTaskStatus tool with the MCP server
@@ -28,8 +29,10 @@ export function registerSetTaskStatusTool(server) {
 				),
 			status: z
 				.string()
+				.transform((val) => val.trim().toLowerCase())
+				.pipe(z.enum(VALID_TASK_STATUS_VALUES))
 				.describe(
-					"New status to set (e.g., 'pending', 'done', 'in-progress', 'review', 'deferred', 'cancelled'."
+					`New status to set. Must be one of: ${VALID_TASK_STATUS_VALUES.join(', ')}. Input will be trimmed and lowercased.`
 				),
 			file: z.string().optional().describe('Absolute path to the tasks file'),
 			projectRoot: z


### PR DESCRIPTION
I wasn't able to figure out how to write an automated test for this (the current tests which set status don't actually call the internal setTaskStatus method but use a test helper). But this does seem to work based on my CLI testing, it rejects invalid statuses and normalizes all statuses to lowercase.

Fixes #506