### PR TITLE
Fix parse-prd --append when using the command line and an input PRD

### DIFF
--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -608,8 +608,8 @@ function registerCommands(programInstance) {
 
 				spinner = ora('Parsing PRD and generating tasks...\n').start();
 				await parsePRD(inputFile, outputPath, numTasks, {
-					useAppend: useAppend,
-					useForce: useForce
+					append: useAppend,
+					force: useForce
 				});
 				spinner.succeed('Tasks generated successfully!');
 			} catch (error) {


### PR DESCRIPTION
`parsePRD` is expecting options to be called `append` and `force` and not `useAppend` and `useForce`.
Seems bug has been introduced with commit 0288311
.
In practice it means that without this a command like `task-master parsePRD --input script/my-feeature-PRD.md --append` is failing with a message like:

`[ERROR] Output file tasks/tasks.json already exists. Use --force to overwrite or --append.`.