### PR TITLE
Fix Cursor & Windsurf `mcpServers` json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ MCP (Model Control Protocol) lets you run Task Master directly from your editor.
         "OPENROUTER_API_KEY": "YOUR_OPENROUTER_KEY_HERE",
         "XAI_API_KEY": "YOUR_XAI_KEY_HERE",
         "AZURE_OPENAI_API_KEY": "YOUR_AZURE_KEY_HERE",
-        "OLLAMA_API_KEY": "YOUR_OLLAMA_API_KEY_HERE",
-      },
-    },
-  },
+        "OLLAMA_API_KEY": "YOUR_OLLAMA_API_KEY_HERE"
+      }
+    }
+  }
 }
 ```
 

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -135,7 +135,7 @@
 		},
 		{
 			"id": "gemini-2.0-flash",
-			"swe_score": 0,
+			"swe_score": 0.518,
 			"cost_per_1m_tokens": { "input": 0.15, "output": 0.6 },
 			"allowed_roles": ["main", "fallback"],
 			"max_tokens": 1048000

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -128,14 +128,14 @@
 		},
 		{
 			"id": "gemini-2.5-flash-preview-04-17",
-			"swe_score": 0,
+			"swe_score": 0.604,
 			"cost_per_1m_tokens": null,
 			"allowed_roles": ["main", "fallback"],
 			"max_tokens": 1048000
 		},
 		{
 			"id": "gemini-2.0-flash",
-			"swe_score": 0.754,
+			"swe_score": 0,
 			"cost_per_1m_tokens": { "input": 0.15, "output": 0.6 },
 			"allowed_roles": ["main", "fallback"],
 			"max_tokens": 1048000


### PR DESCRIPTION
The current .json config shown on the README has a bunch of extra commas, which are not valid:
<img width="806" alt="image" src="https://github.com/user-attachments/assets/e290104f-ab62-413b-aa2f-d2f7a3e587d8" />

<img width="555" alt="image" src="https://github.com/user-attachments/assets/caf609ed-b266-461a-b7b4-f6a73322a6fb" />

The correct version would remove the last comma after the last entry of `env`, as well as the unnecessary ones between curly brackets:
<img width="527" alt="image" src="https://github.com/user-attachments/assets/dc58548c-d115-4dbc-ae85-ee22b0e501c7" />
<img width="817" alt="image" src="https://github.com/user-attachments/assets/2a770dde-a328-4f8e-b888-59bbbef35eae" />


I didn't test the VS Code option, but it also seems incorrect with the commas: 
<img width="524" alt="image" src="https://github.com/user-attachments/assets/2dd49f58-bae8-4967-93de-9a24de17d6e1" />
