### PR TITLE
refactor: rename 'boomerang' to 'orchestrator' across codebase

### DIFF
--- a/docs/contributor-docs/testing-roo-integration.md
+++ b/docs/contributor-docs/testing-roo-integration.md
@@ -64,7 +64,7 @@ To manually verify that the Roo files are properly included in the package:
    ls -la .roo/rules
    ls -la .roo/rules-architect
    ls -la .roo/rules-ask
-   ls -la .roo/rules-boomerang
+   ls -la .roo/rules-orchestrator
    ls -la .roo/rules-code
    ls -la .roo/rules-debug
    ls -la .roo/rules-test

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,4 +1,4 @@
-# Available Models as of June 8, 2025
+# Available Models as of June 11, 2025
 
 ## Main Models
 

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -240,7 +240,7 @@ function copyTemplateFile(templateName, targetPath, replacements = {}) {
 			break;
 		case 'architect-rules':
 		case 'ask-rules':
-		case 'boomerang-rules':
+		case 'orchestrator-rules':
 		case 'code-rules':
 		case 'debug-rules':
 		case 'test-rules': {
@@ -475,7 +475,7 @@ function createProjectStructure(addAliases, dryRun, options) {
 	log('info', `Initializing project in ${targetDir}`);
 
 	// Define Roo modes locally (external integration, not part of core Task Master)
-	const ROO_MODES = ['architect', 'ask', 'boomerang', 'code', 'debug', 'test'];
+	const ROO_MODES = ['architect', 'ask', 'orchestrator', 'code', 'debug', 'test'];
 
 	// Create directories
 	ensureDirectoryExists(path.join(targetDir, '.cursor/rules'));

--- a/tests/integration/roo-files-inclusion.test.js
+++ b/tests/integration/roo-files-inclusion.test.js
@@ -39,21 +39,21 @@ describe('Roo Files Inclusion in Package', () => {
 
 		// Check for local ROO_MODES array definition
 		const hasLocalRooModes = initJsContent.includes(
-			"const ROO_MODES = ['architect', 'ask', 'boomerang', 'code', 'debug', 'test']"
+			"const ROO_MODES = ['architect', 'ask', 'orchestrator', 'code', 'debug', 'test']"
 		);
 		expect(hasLocalRooModes).toBe(true);
 
 		// Check for mode-specific patterns (these will still be present in the local array)
 		const hasArchitect = initJsContent.includes('architect');
 		const hasAsk = initJsContent.includes('ask');
-		const hasBoomerang = initJsContent.includes('boomerang');
+		const hasOrchestrator = initJsContent.includes('orchestrator');
 		const hasCode = initJsContent.includes('code');
 		const hasDebug = initJsContent.includes('debug');
 		const hasTest = initJsContent.includes('test');
 
 		expect(hasArchitect).toBe(true);
 		expect(hasAsk).toBe(true);
-		expect(hasBoomerang).toBe(true);
+		expect(hasOrchestrator).toBe(true);
 		expect(hasCode).toBe(true);
 		expect(hasDebug).toBe(true);
 		expect(hasTest).toBe(true);

--- a/tests/integration/roo-init-functionality.test.js
+++ b/tests/integration/roo-init-functionality.test.js
@@ -35,7 +35,7 @@ describe('Roo Initialization Functionality', () => {
 
 		// Check for local ROO_MODES definition
 		const hasLocalRooModes = initJsContent.includes(
-			"const ROO_MODES = ['architect', 'ask', 'boomerang', 'code', 'debug', 'test']"
+			"const ROO_MODES = ['architect', 'ask', 'orchestrator', 'code', 'debug', 'test']"
 		);
 		expect(hasLocalRooModes).toBe(true);
 	});

--- a/tests/unit/roo-integration.test.js
+++ b/tests/unit/roo-integration.test.js
@@ -59,7 +59,7 @@ describe('Roo Integration', () => {
 		fs.mkdirSync(path.join(tempDir, '.roo', 'rules'), { recursive: true });
 
 		// Create mode-specific rule directories
-		const rooModes = ['architect', 'ask', 'boomerang', 'code', 'debug', 'test'];
+		const rooModes = ['architect', 'ask', 'orchestrator', 'code', 'debug', 'test'];
 		for (const mode of rooModes) {
 			fs.mkdirSync(path.join(tempDir, '.roo', `rules-${mode}`), {
 				recursive: true
@@ -102,7 +102,7 @@ describe('Roo Integration', () => {
 			{ recursive: true }
 		);
 		expect(fs.mkdirSync).toHaveBeenCalledWith(
-			path.join(tempDir, '.roo', 'rules-boomerang'),
+			path.join(tempDir, '.roo', 'rules-orchestrator'),
 			{ recursive: true }
 		);
 		expect(fs.mkdirSync).toHaveBeenCalledWith(
@@ -133,7 +133,7 @@ describe('Roo Integration', () => {
 			expect.any(String)
 		);
 		expect(fs.writeFileSync).toHaveBeenCalledWith(
-			path.join(tempDir, '.roo', 'rules-boomerang', 'boomerang-rules'),
+			path.join(tempDir, '.roo', 'rules-orchestrator', 'orchestrator-rules'),
 			expect.any(String)
 		);
 		expect(fs.writeFileSync).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Renamed 'boomerang' mode to 'orchestrator' throughout the codebase for better clarity
- Updated all references in source files, tests, and documentation

## Changes
- Updated ROO_MODES array to use 'orchestrator' instead of 'boomerang'
- Renamed boomerang-rules case to orchestrator-rules in init.js
- Updated test files to reflect the new naming convention
- Updated documentation to use the new terminology

This change provides a more descriptive and meaningful name for this ROO mode.

## Test plan
- [ ] Run unit tests to ensure roo-integration tests pass
- [ ] Run integration tests for roo functionality
- [ ] Verify init command creates correct directory structure with new naming

🤖 Generated with [Claude Code](https://claude.ai/code)