### PR TITLE
readme: add troubleshooting note for MCP tools not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ MCP (Model Control Protocol) lets you run Task Master directly from your editor.
 
 > 🔑 Replace `YOUR_…_KEY_HERE` with your real API keys. You can remove keys you don't use.
 
+> **Note**: If you see `0 tools enabled` in the MCP settings, try removing the `--package=task-master-ai` flag from `args`.
+
 ###### VS Code (`servers` + `type`)
 
 ```json


### PR DESCRIPTION
## Description:

Adds a troubleshooting note about removing --package flag when "0 tools enabled" appears in MCP settings.

![image](https://github.com/user-attachments/assets/65feda7b-a1b7-4ca5-9a5b-2d5f59cd6106)

## Type of Change:

- [x] Documentation update

## Changeset:

- [x] This change doesn't need one

## References:
- Fixes #761
- Discussed in #767