### PR TITLE
fix(bedrock): improve AWS credential handling and add model definitions

### DIFF
--- a/.changeset/modern-cats-pick.md
+++ b/.changeset/modern-cats-pick.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Improves Amazon Bedrock support

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -596,9 +596,9 @@ async function runInteractiveSetup(projectRoot) {
 				!process.env.AWS_ACCESS_KEY_ID ||
 				!process.env.AWS_SECRET_ACCESS_KEY
 			) {
-				console.error(
-					chalk.red(
-						'Error: AWS_ACCESS_KEY_ID and/or AWS_SECRET_ACCESS_KEY environment variables are missing. Please set them before using custom Bedrock models.'
+				console.warn(
+					chalk.yellow(
+						'Warning: AWS_ACCESS_KEY_ID and/or AWS_SECRET_ACCESS_KEY environment variables are missing. Will fallback to system configuration. (ex: aws config files or ec2 instance profiles)'
 					)
 				);
 				setupSuccess = false;

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -497,9 +497,13 @@ function getParametersForRole(role, explicitRoot = null) {
 function isApiKeySet(providerName, session = null, projectRoot = null) {
 	// Define the expected environment variable name for each provider
 
-	const okKeys = ['ollama', 'bedrock'];
+	// Providers that don't require API keys for authentication
+	const providersWithoutApiKeys = [
+		CUSTOM_PROVIDERS.OLLAMA,
+		CUSTOM_PROVIDERS.BEDROCK
+	];
 
-	if (okKeys.includes(providerName?.toLowerCase())) {
+	if (providersWithoutApiKeys.includes(providerName?.toLowerCase())) {
 		return true; // Indicate key status is effectively "OK"
 	}
 

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -496,7 +496,10 @@ function getParametersForRole(role, explicitRoot = null) {
  */
 function isApiKeySet(providerName, session = null, projectRoot = null) {
 	// Define the expected environment variable name for each provider
-	if (providerName?.toLowerCase() === 'ollama') {
+
+	const okKeys = ['ollama', 'bedrock'];
+
+	if (okKeys.includes(providerName?.toLowerCase())) {
 		return true; // Indicate key status is effectively "OK"
 	}
 

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -1,4 +1,20 @@
 {
+	"bedrock": [
+		{
+			"id": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+			"swe_score": 0.623,
+			"cost_per_1m_tokens": { "input": 3, "output": 15 },
+			"allowed_roles": [ "main", "fallback" ],
+			"max_tokens": 65536
+		},
+		{
+			"id": "us.deepseek.r1-v1:0",
+			"swe_score": 0,
+			"cost_per_1m_tokens": { "input": 1.35, "output": 5.4 },
+			"allowed_roles": [ "research" ],
+			"max_tokens": 65536
+		}
+	],
 	"anthropic": [
 		{
 			"id": "claude-sonnet-4-20250514",

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -4,14 +4,14 @@
 			"id": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
 			"swe_score": 0.623,
 			"cost_per_1m_tokens": { "input": 3, "output": 15 },
-			"allowed_roles": [ "main", "fallback" ],
+			"allowed_roles": ["main", "fallback"],
 			"max_tokens": 65536
 		},
 		{
 			"id": "us.deepseek.r1-v1:0",
 			"swe_score": 0,
 			"cost_per_1m_tokens": { "input": 1.35, "output": 5.4 },
-			"allowed_roles": [ "research" ],
+			"allowed_roles": ["research"],
 			"max_tokens": 65536
 		}
 	],

--- a/src/ai-providers/bedrock.js
+++ b/src/ai-providers/bedrock.js
@@ -24,7 +24,7 @@ export class BedrockAIProvider extends BaseAIProvider {
 			const credentialProvider = fromNodeProviderChain();
 
 			return createAmazonBedrock({
-				credentialProvider,
+				credentialProvider
 			});
 		} catch (error) {
 			this.handleError('client initialization', error);

--- a/src/ai-providers/bedrock.js
+++ b/src/ai-providers/bedrock.js
@@ -21,18 +21,10 @@ export class BedrockAIProvider extends BaseAIProvider {
 	 */
 	getClient(params) {
 		try {
-			const {
-				profile = process.env.AWS_PROFILE || 'default',
-				region = process.env.AWS_DEFAULT_REGION || 'us-east-1',
-				baseURL
-			} = params;
-
-			const credentialProvider = fromNodeProviderChain({ profile });
+			const credentialProvider = fromNodeProviderChain();
 
 			return createAmazonBedrock({
-				region,
 				credentialProvider,
-				...(baseURL && { baseURL })
 			});
 		} catch (error) {
 			this.handleError('client initialization', error);

--- a/tests/unit/config-manager.test.js
+++ b/tests/unit/config-manager.test.js
@@ -266,6 +266,7 @@ describe('Validation Functions', () => {
 		expect(configManager.validateProvider('perplexity')).toBe(true);
 		expect(configManager.validateProvider('ollama')).toBe(true);
 		expect(configManager.validateProvider('openrouter')).toBe(true);
+		expect(configManager.validateProvider('bedrock')).toBe(true);
 	});
 
 	test('validateProvider should return false for invalid providers', () => {


### PR DESCRIPTION
- Change error to warning when AWS credentials are missing in environment
- Allow fallback to system configuration (aws config files or instance profiles)
- Remove hardcoded region and profile parameters in Bedrock client
- Add Claude 3.7 Sonnet and DeepSeek R1 model definitions for Bedrock
- Update config manager to properly handle Bedrock provider