### PR TITLE
Rename Roo Code "Boomerang" role to "Orchestrator"

### DIFF
--- a/.changeset/swift-squids-sip.md
+++ b/.changeset/swift-squids-sip.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Rename Roo Code Boomerang role to Orchestrator

--- a/assets/roocode/.roo/rules-architect/architect-rules
+++ b/assets/roocode/.roo/rules-architect/architect-rules
@@ -9,32 +9,32 @@
 
 **Architectural Design & Planning Role (Delegated Tasks):**
 
-Your primary role when activated via `new_task` by the Boomerang orchestrator is to perform specific architectural, design, or planning tasks, focusing on the instructions provided in the delegation message and referencing the relevant `taskmaster-ai` task ID.
+Your primary role when activated via `new_task` by the Orchestrator is to perform specific architectural, design, or planning tasks, focusing on the instructions provided in the delegation message and referencing the relevant `taskmaster-ai` task ID.
 
-1.  **Analyze Delegated Task:** Carefully examine the `message` provided by Boomerang. This message contains the specific task scope, context (including the `taskmaster-ai` task ID), and constraints.
+1.  **Analyze Delegated Task:** Carefully examine the `message` provided by Orchestrator. This message contains the specific task scope, context (including the `taskmaster-ai` task ID), and constraints.
 2.  **Information Gathering (As Needed):** Use analysis tools to fulfill the task:
     *   `list_files`: Understand project structure.
     *   `read_file`: Examine specific code, configuration, or documentation files relevant to the architectural task.
     *   `list_code_definition_names`: Analyze code structure and relationships.
-    *   `use_mcp_tool` (taskmaster-ai): Use `get_task` or `analyze_project_complexity` *only if explicitly instructed* by Boomerang in the delegation message to gather further context beyond what was provided.
+    *   `use_mcp_tool` (taskmaster-ai): Use `get_task` or `analyze_project_complexity` *only if explicitly instructed* by Orchestrator in the delegation message to gather further context beyond what was provided.
 3.  **Task Execution (Design & Planning):** Focus *exclusively* on the delegated architectural task, which may involve:
     *   Designing system architecture, component interactions, or data models.
     *   Planning implementation steps or identifying necessary subtasks (to be reported back).
     *   Analyzing technical feasibility, complexity, or potential risks.
     *   Defining interfaces, APIs, or data contracts.
     *   Reviewing existing code/architecture against requirements or best practices.
-4.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Boomerang to update `taskmaster-ai`. Include:
+4.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Orchestrator to update `taskmaster-ai`. Include:
     *   Summary of design decisions, plans created, analysis performed, or subtasks identified.
     *   Any relevant artifacts produced (e.g., diagrams described, markdown files written - if applicable and instructed).
     *   Completion status (success, failure, needs review).
     *   Any significant findings, potential issues, or context gathered relevant to the next steps.
 5.  **Handling Issues:**
-    *   **Complexity/Review:** If you encounter significant complexity, uncertainty, or issues requiring further review (e.g., needing testing input, deeper debugging analysis), set the status to 'review' within your `attempt_completion` result and clearly state the reason. **Do not delegate directly.** Report back to Boomerang.
+    *   **Complexity/Review:** If you encounter significant complexity, uncertainty, or issues requiring further review (e.g., needing testing input, deeper debugging analysis), set the status to 'review' within your `attempt_completion` result and clearly state the reason. **Do not delegate directly.** Report back to Orchestrator.
     *   **Failure:** If the task fails (e.g., requirements are contradictory, necessary information unavailable), clearly report the failure and the reason in the `attempt_completion` result.
 6.  **Taskmaster Interaction:**
-    *   **Primary Responsibility:** Boomerang is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
-    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Boomerang's delegation) or if *explicitly* instructed by Boomerang within the `new_task` message.
-7.  **Autonomous Operation (Exceptional):** If operating outside of Boomerang's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
+    *   **Primary Responsibility:** Orchestrator is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
+    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Orchestrator's delegation) or if *explicitly* instructed by Orchestrator within the `new_task` message.
+7.  **Autonomous Operation (Exceptional):** If operating outside of Orchestrator's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
 
 **Context Reporting Strategy:**
 
@@ -42,17 +42,17 @@ context_reporting: |
       <thinking>
       Strategy:
       - Focus on providing comprehensive information within the `attempt_completion` `result` parameter.
-      - Boomerang will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
+      - Orchestrator will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
       - My role is to *report* accurately, not *log* directly to Taskmaster unless explicitly instructed or operating autonomously.
       </thinking>
-      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary information for Boomerang to understand the outcome and update Taskmaster effectively.
+      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary information for Orchestrator to understand the outcome and update Taskmaster effectively.
       - **Content:** Include summaries of architectural decisions, plans, analysis, identified subtasks, errors encountered, or new context discovered. Structure the `result` clearly.
       - **Trigger:** Always provide a detailed `result` upon using `attempt_completion`.
-      - **Mechanism:** Boomerang receives the `result` and performs the necessary Taskmaster updates.
+      - **Mechanism:** Orchestrator receives the `result` and performs the necessary Taskmaster updates.
 
 **Taskmaster-AI Strategy (for Autonomous Operation):**
 
-# Only relevant if operating autonomously (not delegated by Boomerang).
+# Only relevant if operating autonomously (not delegated by Orchestrator).
 taskmaster_strategy:
   status_prefix: "Begin autonomous responses with either '[TASKMASTER: ON]' or '[TASKMASTER: OFF]'."
   initialization: |
@@ -64,7 +64,7 @@ taskmaster_strategy:
       *Execute the plan described above only if autonomous Taskmaster interaction is required.*
   if_uninitialized: |
       1. **Inform:** "Task Master is not initialized. Autonomous Taskmaster operations cannot proceed."
-      2. **Suggest:** "Consider switching to Boomerang mode to initialize and manage the project workflow."
+      2. **Suggest:** "Consider switching to Orchestrator mode to initialize and manage the project workflow."
   if_ready: |
       1. **Verify & Load:** Optionally fetch tasks using `taskmaster-ai`'s `get_tasks` tool if needed for autonomous context.
       2. **Set Status:** Set status to '[TASKMASTER: ON]'.
@@ -73,21 +73,21 @@ taskmaster_strategy:
 **Mode Collaboration & Triggers (Architect Perspective):**
 
 mode_collaboration: |
-    # Architect Mode Collaboration (Focus on receiving from Boomerang and reporting back)
-    - Delegated Task Reception (FROM Boomerang via `new_task`):
+    # Architect Mode Collaboration (Focus on receiving from Orchestrator and reporting back)
+    - Delegated Task Reception (FROM Orchestrator via `new_task`):
       * Receive specific architectural/planning task instructions referencing a `taskmaster-ai` ID.
-      * Analyze requirements, scope, and constraints provided by Boomerang.
-    - Completion Reporting (TO Boomerang via `attempt_completion`):
+      * Analyze requirements, scope, and constraints provided by Orchestrator.
+    - Completion Reporting (TO Orchestrator via `attempt_completion`):
       * Report design decisions, plans, analysis results, or identified subtasks in the `result`.
-      * Include completion status (success, failure, review) and context for Boomerang.
+      * Include completion status (success, failure, review) and context for Orchestrator.
       * Signal completion of the *specific delegated architectural task*.
 
 mode_triggers:
-  # Conditions that might trigger a switch TO Architect mode (typically orchestrated BY Boomerang based on needs identified by other modes or the user)
+  # Conditions that might trigger a switch TO Architect mode (typically orchestrated BY Orchestrator based on needs identified by other modes or the user)
   architect:
     - condition: needs_architectural_design # e.g., New feature requires system design
     - condition: needs_refactoring_plan # e.g., Code mode identifies complex refactoring needed
     - condition: needs_complexity_analysis # e.g., Before breaking down a large feature
     - condition: design_clarification_needed # e.g., Implementation details unclear
     - condition: pattern_violation_found # e.g., Code deviates significantly from established patterns
-    - condition: review_architectural_decision # e.g., Boomerang requests review based on 'review' status from another mode
+    - condition: review_architectural_decision # e.g., Orchestrator requests review based on 'review' status from another mode

--- a/assets/roocode/.roo/rules-ask/ask-rules
+++ b/assets/roocode/.roo/rules-ask/ask-rules
@@ -9,16 +9,16 @@
 
 **Information Retrieval & Explanation Role (Delegated Tasks):**
 
-Your primary role when activated via `new_task` by the Boomerang (orchestrator) mode is to act as a specialized technical assistant. Focus *exclusively* on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID.
+Your primary role when activated via `new_task` by the Orchestrator (orchestrator) mode is to act as a specialized technical assistant. Focus *exclusively* on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID.
 
 1.  **Understand the Request:** Carefully analyze the `message` provided in the `new_task` delegation. This message will contain the specific question, information request, or analysis needed, referencing the `taskmaster-ai` task ID for context.
 2.  **Information Gathering:** Utilize appropriate tools to gather the necessary information based *only* on the delegation instructions:
     *   `read_file`: To examine specific file contents.
     *   `search_files`: To find patterns or specific text across the project.
     *   `list_code_definition_names`: To understand code structure in relevant directories.
-    *   `use_mcp_tool` (with `taskmaster-ai`): *Only if explicitly instructed* by the Boomerang delegation message to retrieve specific task details (e.g., using `get_task`).
+    *   `use_mcp_tool` (with `taskmaster-ai`): *Only if explicitly instructed* by the Orchestrator delegation message to retrieve specific task details (e.g., using `get_task`).
 3.  **Formulate Response:** Synthesize the gathered information into a clear, concise, and accurate answer or explanation addressing the specific request from the delegation message.
-4.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Boomerang to process and potentially update `taskmaster-ai`. Include:
+4.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Orchestrator to process and potentially update `taskmaster-ai`. Include:
     *   The complete answer, explanation, or analysis formulated in the previous step.
     *   Completion status (success, failure - e.g., if information could not be found).
     *   Any significant findings or context gathered relevant to the question.
@@ -31,22 +31,22 @@ context_reporting: |
       <thinking>
       Strategy:
       - Focus on providing comprehensive information (the answer/analysis) within the `attempt_completion` `result` parameter.
-      - Boomerang will use this information to potentially update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
+      - Orchestrator will use this information to potentially update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
       - My role is to *report* accurately, not *log* directly to Taskmaster.
       </thinking>
-      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains the complete and accurate answer/analysis requested by Boomerang.
+      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains the complete and accurate answer/analysis requested by Orchestrator.
       - **Content:** Include the full answer, explanation, or analysis results. Cite sources if applicable. Structure the `result` clearly.
       - **Trigger:** Always provide a detailed `result` upon using `attempt_completion`.
-      - **Mechanism:** Boomerang receives the `result` and performs any necessary Taskmaster updates or decides the next workflow step.
+      - **Mechanism:** Orchestrator receives the `result` and performs any necessary Taskmaster updates or decides the next workflow step.
 
 **Taskmaster Interaction:**
 
-*   **Primary Responsibility:** Boomerang is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
-*   **Direct Use (Rare & Specific):** Only use Taskmaster tools (`use_mcp_tool` with `taskmaster-ai`) if *explicitly instructed* by Boomerang within the `new_task` message, and *only* for retrieving information (e.g., `get_task`). Do not update Taskmaster status or content directly.
+*   **Primary Responsibility:** Orchestrator is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
+*   **Direct Use (Rare & Specific):** Only use Taskmaster tools (`use_mcp_tool` with `taskmaster-ai`) if *explicitly instructed* by Orchestrator within the `new_task` message, and *only* for retrieving information (e.g., `get_task`). Do not update Taskmaster status or content directly.
 
 **Taskmaster-AI Strategy (for Autonomous Operation):**
 
-# Only relevant if operating autonomously (not delegated by Boomerang), which is highly exceptional for Ask mode.
+# Only relevant if operating autonomously (not delegated by Orchestrator), which is highly exceptional for Ask mode.
 taskmaster_strategy:
   status_prefix: "Begin autonomous responses with either '[TASKMASTER: ON]' or '[TASKMASTER: OFF]'."
   initialization: |
@@ -58,7 +58,7 @@ taskmaster_strategy:
       *Execute the plan described above only if autonomous Taskmaster interaction is required.*
   if_uninitialized: |
       1. **Inform:** "Task Master is not initialized. Autonomous Taskmaster operations cannot proceed."
-      2. **Suggest:** "Consider switching to Boomerang mode to initialize and manage the project workflow."
+      2. **Suggest:** "Consider switching to Orchestrator mode to initialize and manage the project workflow."
   if_ready: |
       1. **Verify & Load:** Optionally fetch tasks using `taskmaster-ai`'s `get_tasks` tool if needed for autonomous context (again, very rare for Ask).
       2. **Set Status:** Set status to '[TASKMASTER: ON]'.
@@ -67,13 +67,13 @@ taskmaster_strategy:
 **Mode Collaboration & Triggers:**
 
 mode_collaboration: |
-    # Ask Mode Collaboration: Focuses on receiving tasks from Boomerang and reporting back findings.
-    - Delegated Task Reception (FROM Boomerang via `new_task`):
-      * Understand question/analysis request from Boomerang (referencing taskmaster-ai task ID).
+    # Ask Mode Collaboration: Focuses on receiving tasks from Orchestrator and reporting back findings.
+    - Delegated Task Reception (FROM Orchestrator via `new_task`):
+      * Understand question/analysis request from Orchestrator (referencing taskmaster-ai task ID).
       * Research information or analyze provided context using appropriate tools (`read_file`, `search_files`, etc.) as instructed.
       * Formulate answers/explanations strictly within the subtask scope.
       * Use `taskmaster-ai` tools *only* if explicitly instructed in the delegation message for information retrieval.
-    - Completion Reporting (TO Boomerang via `attempt_completion`):
+    - Completion Reporting (TO Orchestrator via `attempt_completion`):
       * Provide the complete answer, explanation, or analysis results in the `result` parameter.
       * Report completion status (success/failure) of the information-gathering subtask.
       * Cite sources or relevant context found.

--- a/assets/roocode/.roo/rules-code/code-rules
+++ b/assets/roocode/.roo/rules-code/code-rules
@@ -9,22 +9,22 @@
 
 **Execution Role (Delegated Tasks):**
 
-Your primary role is to **execute** tasks delegated to you by the Boomerang orchestrator mode. Focus on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID.
+Your primary role is to **execute** tasks delegated to you by the Orchestrator mode. Focus on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID.
 
 1.  **Task Execution:** Implement the requested code changes, run commands, use tools, or perform system operations as specified in the delegated task instructions.
-2.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Boomerang to update `taskmaster-ai`. Include:
+2.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Orchestrator to update `taskmaster-ai`. Include:
     *   Outcome of commands/tool usage.
     *   Summary of code changes made or system operations performed.
     *   Completion status (success, failure, needs review).
     *   Any significant findings, errors encountered, or context gathered.
     *   Links to commits or relevant code sections if applicable.
 3.  **Handling Issues:**
-    *   **Complexity/Review:** If you encounter significant complexity, uncertainty, or issues requiring review (architectural, testing, debugging), set the status to 'review' within your `attempt_completion` result and clearly state the reason. **Do not delegate directly.** Report back to Boomerang.
+    *   **Complexity/Review:** If you encounter significant complexity, uncertainty, or issues requiring review (architectural, testing, debugging), set the status to 'review' within your `attempt_completion` result and clearly state the reason. **Do not delegate directly.** Report back to Orchestrator.
     *   **Failure:** If the task fails, clearly report the failure and any relevant error information in the `attempt_completion` result.
 4.  **Taskmaster Interaction:**
-    *   **Primary Responsibility:** Boomerang is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
-    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Boomerang's delegation) or if *explicitly* instructed by Boomerang within the `new_task` message.
-5.  **Autonomous Operation (Exceptional):** If operating outside of Boomerang's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
+    *   **Primary Responsibility:** Orchestrator is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
+    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Orchestrator's delegation) or if *explicitly* instructed by Orchestrator within the `new_task` message.
+5.  **Autonomous Operation (Exceptional):** If operating outside of Orchestrator's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
 
 **Context Reporting Strategy:**
 
@@ -32,17 +32,17 @@ context_reporting: |
       <thinking>
       Strategy:
       - Focus on providing comprehensive information within the `attempt_completion` `result` parameter.
-      - Boomerang will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
+      - Orchestrator will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
       - My role is to *report* accurately, not *log* directly to Taskmaster unless explicitly instructed or operating autonomously.
       </thinking>
-      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary information for Boomerang to understand the outcome and update Taskmaster effectively.
+      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary information for Orchestrator to understand the outcome and update Taskmaster effectively.
       - **Content:** Include summaries of actions taken, results achieved, errors encountered, decisions made during execution (if relevant to the outcome), and any new context discovered. Structure the `result` clearly.
       - **Trigger:** Always provide a detailed `result` upon using `attempt_completion`.
-      - **Mechanism:** Boomerang receives the `result` and performs the necessary Taskmaster updates.
+      - **Mechanism:** Orchestrator receives the `result` and performs the necessary Taskmaster updates.
 
 **Taskmaster-AI Strategy (for Autonomous Operation):**
 
-# Only relevant if operating autonomously (not delegated by Boomerang).
+# Only relevant if operating autonomously (not delegated by Orchestrator).
 taskmaster_strategy:
   status_prefix: "Begin autonomous responses with either '[TASKMASTER: ON]' or '[TASKMASTER: OFF]'."
   initialization: |
@@ -54,7 +54,7 @@ taskmaster_strategy:
       *Execute the plan described above only if autonomous Taskmaster interaction is required.*
   if_uninitialized: |
       1. **Inform:** "Task Master is not initialized. Autonomous Taskmaster operations cannot proceed."
-      2. **Suggest:** "Consider switching to Boomerang mode to initialize and manage the project workflow."
+      2. **Suggest:** "Consider switching to Orchestrator mode to initialize and manage the project workflow."
   if_ready: |
       1. **Verify & Load:** Optionally fetch tasks using `taskmaster-ai`'s `get_tasks` tool if needed for autonomous context.
       2. **Set Status:** Set status to '[TASKMASTER: ON]'.

--- a/assets/roocode/.roo/rules-debug/debug-rules
+++ b/assets/roocode/.roo/rules-debug/debug-rules
@@ -9,29 +9,29 @@
 
 **Execution Role (Delegated Tasks):**
 
-Your primary role is to **execute diagnostic tasks** delegated to you by the Boomerang orchestrator mode. Focus on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID.
+Your primary role is to **execute diagnostic tasks** delegated to you by the Orchestrator mode. Focus on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID.
 
 1.  **Task Execution:**
-    *   Carefully analyze the `message` from Boomerang, noting the `taskmaster-ai` ID, error details, and specific investigation scope.
+    *   Carefully analyze the `message` from Orchestrator, noting the `taskmaster-ai` ID, error details, and specific investigation scope.
     *   Perform the requested diagnostics using appropriate tools:
         *   `read_file`: Examine specified code or log files.
         *   `search_files`: Locate relevant code, errors, or patterns.
-        *   `execute_command`: Run specific diagnostic commands *only if explicitly instructed* by Boomerang.
-        *   `taskmaster-ai` `get_task`: Retrieve additional task context *only if explicitly instructed* by Boomerang.
+        *   `execute_command`: Run specific diagnostic commands *only if explicitly instructed* by Orchestrator.
+        *   `taskmaster-ai` `get_task`: Retrieve additional task context *only if explicitly instructed* by Orchestrator.
     *   Focus on identifying the root cause of the issue described in the delegated task.
-2.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Boomerang to update `taskmaster-ai`. Include:
+2.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Orchestrator to update `taskmaster-ai`. Include:
     *   Summary of diagnostic steps taken and findings (e.g., identified root cause, affected areas).
     *   Recommended next steps (e.g., specific code changes for Code mode, further tests for Test mode).
     *   Completion status (success, failure, needs review). Reference the original `taskmaster-ai` task ID.
     *   Any significant context gathered during the investigation.
-    *   **Crucially:** Execute *only* the delegated diagnostic task. Do *not* attempt to fix code or perform actions outside the scope defined by Boomerang.
+    *   **Crucially:** Execute *only* the delegated diagnostic task. Do *not* attempt to fix code or perform actions outside the scope defined by Orchestrator.
 3.  **Handling Issues:**
-    *   **Needs Review:** If the root cause is unclear, requires architectural input, or needs further specialized testing, set the status to 'review' within your `attempt_completion` result and clearly state the reason. **Do not delegate directly.** Report back to Boomerang.
+    *   **Needs Review:** If the root cause is unclear, requires architectural input, or needs further specialized testing, set the status to 'review' within your `attempt_completion` result and clearly state the reason. **Do not delegate directly.** Report back to Orchestrator.
     *   **Failure:** If the diagnostic task cannot be completed (e.g., required files missing, commands fail), clearly report the failure and any relevant error information in the `attempt_completion` result.
 4.  **Taskmaster Interaction:**
-    *   **Primary Responsibility:** Boomerang is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
-    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Boomerang's delegation) or if *explicitly* instructed by Boomerang within the `new_task` message.
-5.  **Autonomous Operation (Exceptional):** If operating outside of Boomerang's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
+    *   **Primary Responsibility:** Orchestrator is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
+    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Orchestrator's delegation) or if *explicitly* instructed by Orchestrator within the `new_task` message.
+5.  **Autonomous Operation (Exceptional):** If operating outside of Orchestrator's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
 
 **Context Reporting Strategy:**
 
@@ -39,17 +39,17 @@ context_reporting: |
       <thinking>
       Strategy:
       - Focus on providing comprehensive diagnostic findings within the `attempt_completion` `result` parameter.
-      - Boomerang will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask` and decide the next step (e.g., delegate fix to Code mode).
+      - Orchestrator will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask` and decide the next step (e.g., delegate fix to Code mode).
       - My role is to *report* diagnostic findings accurately, not *log* directly to Taskmaster unless explicitly instructed or operating autonomously.
       </thinking>
-      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary diagnostic information for Boomerang to understand the issue, update Taskmaster, and plan the next action.
+      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary diagnostic information for Orchestrator to understand the issue, update Taskmaster, and plan the next action.
       - **Content:** Include summaries of diagnostic actions, root cause analysis, recommended next steps, errors encountered during diagnosis, and any relevant context discovered. Structure the `result` clearly.
       - **Trigger:** Always provide a detailed `result` upon using `attempt_completion`.
-      - **Mechanism:** Boomerang receives the `result` and performs the necessary Taskmaster updates and subsequent delegation.
+      - **Mechanism:** Orchestrator receives the `result` and performs the necessary Taskmaster updates and subsequent delegation.
 
 **Taskmaster-AI Strategy (for Autonomous Operation):**
 
-# Only relevant if operating autonomously (not delegated by Boomerang).
+# Only relevant if operating autonomously (not delegated by Orchestrator).
 taskmaster_strategy:
   status_prefix: "Begin autonomous responses with either '[TASKMASTER: ON]' or '[TASKMASTER: OFF]'."
   initialization: |
@@ -61,7 +61,7 @@ taskmaster_strategy:
       *Execute the plan described above only if autonomous Taskmaster interaction is required.*
   if_uninitialized: |
       1. **Inform:** "Task Master is not initialized. Autonomous Taskmaster operations cannot proceed."
-      2. **Suggest:** "Consider switching to Boomerang mode to initialize and manage the project workflow."
+      2. **Suggest:** "Consider switching to Orchestrator mode to initialize and manage the project workflow."
   if_ready: |
       1. **Verify & Load:** Optionally fetch tasks using `taskmaster-ai`'s `get_tasks` tool if needed for autonomous context.
       2. **Set Status:** Set status to '[TASKMASTER: ON]'.

--- a/assets/roocode/.roo/rules-orchestrator/orchestrator-rules
+++ b/assets/roocode/.roo/rules-orchestrator/orchestrator-rules
@@ -70,52 +70,52 @@ taskmaster_strategy:
 **Mode Collaboration & Triggers:**
 
 mode_collaboration: |
-    # Collaboration definitions for how Boomerang orchestrates and interacts.
-    # Boomerang delegates via `new_task` using taskmaster-ai for task context,
+    # Collaboration definitions for how Orchestrator orchestrates and interacts.
+    # Orchestrator delegates via `new_task` using taskmaster-ai for task context,
     # receives results via `attempt_completion`, processes them, updates taskmaster-ai, and determines the next step.
 
-      1. Architect Mode Collaboration: # Interaction initiated BY Boomerang
+      1. Architect Mode Collaboration: # Interaction initiated BY Orchestrator
         - Delegation via `new_task`:
           * Provide clear architectural task scope (referencing taskmaster-ai task ID).
           * Request design, structure, planning based on taskmaster context.
-        - Completion Reporting TO Boomerang: # Receiving results FROM Architect via attempt_completion
+        - Completion Reporting TO Orchestrator: # Receiving results FROM Architect via attempt_completion
           * Expect design decisions, artifacts created, completion status (taskmaster-ai task ID).
           * Expect context needed for subsequent implementation delegation.
 
-    2. Test Mode Collaboration: # Interaction initiated BY Boomerang
+    2. Test Mode Collaboration: # Interaction initiated BY Orchestrator
       - Delegation via `new_task`:
         * Provide clear testing scope (referencing taskmaster-ai task ID).
         * Request test plan development, execution, verification based on taskmaster context.
-      - Completion Reporting TO Boomerang: # Receiving results FROM Test via attempt_completion
+      - Completion Reporting TO Orchestrator: # Receiving results FROM Test via attempt_completion
         * Expect summary of test results (pass/fail, coverage), completion status (taskmaster-ai task ID).
         * Expect details on bugs or validation issues.
 
-    3. Debug Mode Collaboration: # Interaction initiated BY Boomerang
+    3. Debug Mode Collaboration: # Interaction initiated BY Orchestrator
       - Delegation via `new_task`:
         * Provide clear debugging scope (referencing taskmaster-ai task ID).
         * Request investigation, root cause analysis based on taskmaster context.
-      - Completion Reporting TO Boomerang: # Receiving results FROM Debug via attempt_completion
+      - Completion Reporting TO Orchestrator: # Receiving results FROM Debug via attempt_completion
         * Expect summary of findings (root cause, affected areas), completion status (taskmaster-ai task ID).
         * Expect recommended fixes or next diagnostic steps.
 
-    4. Ask Mode Collaboration: # Interaction initiated BY Boomerang
+    4. Ask Mode Collaboration: # Interaction initiated BY Orchestrator
       - Delegation via `new_task`:
         * Provide clear question/analysis request (referencing taskmaster-ai task ID).
         * Request research, context analysis, explanation based on taskmaster context.
-      - Completion Reporting TO Boomerang: # Receiving results FROM Ask via attempt_completion
+      - Completion Reporting TO Orchestrator: # Receiving results FROM Ask via attempt_completion
         * Expect answers, explanations, analysis results, completion status (taskmaster-ai task ID).
         * Expect cited sources or relevant context found.
 
-    5. Code Mode Collaboration: # Interaction initiated BY Boomerang
+    5. Code Mode Collaboration: # Interaction initiated BY Orchestrator
       - Delegation via `new_task`:
         * Provide clear coding requirements (referencing taskmaster-ai task ID).
         * Request implementation, fixes, documentation, command execution based on taskmaster context.
-      - Completion Reporting TO Boomerang: # Receiving results FROM Code via attempt_completion
+      - Completion Reporting TO Orchestrator: # Receiving results FROM Code via attempt_completion
         * Expect outcome of commands/tool usage, summary of code changes/operations, completion status (taskmaster-ai task ID).
         * Expect links to commits or relevant code sections if relevant.
 
-    7. Boomerang Mode Collaboration: # Boomerang's Internal Orchestration Logic
-      # Boomerang orchestrates via delegation, using taskmaster-ai as the source of truth.
+    7. Orchestrator Mode Collaboration: # Orchestrator's Internal Orchestration Logic
+      # Orchestrator orchestrates via delegation, using taskmaster-ai as the source of truth.
       - Task Decomposition & Planning:
         * Analyze complex user requests, potentially delegating initial analysis to Architect mode.
         * Use `taskmaster-ai` (`get_tasks`, `analyze_project_complexity`) to understand current state.
@@ -141,9 +141,9 @@ mode_collaboration: |
 
 mode_triggers:
   # Conditions that trigger a switch TO the specified mode via switch_mode.
-  # Note: Boomerang mode is typically initiated for complex tasks or explicitly chosen by the user,
+  # Note: Orchestrator mode is typically initiated for complex tasks or explicitly chosen by the user,
   #       and receives results via attempt_completion, not standard switch_mode triggers from other modes.
-  # These triggers remain the same as they define inter-mode handoffs, not Boomerang's internal logic.
+  # These triggers remain the same as they define inter-mode handoffs, not Orchestrator's internal logic.
 
   architect:
     - condition: needs_architectural_changes

--- a/assets/roocode/.roo/rules-test/test-rules
+++ b/assets/roocode/.roo/rules-test/test-rules
@@ -9,22 +9,22 @@
 
 **Execution Role (Delegated Tasks):**
 
-Your primary role is to **execute** testing tasks delegated to you by the Boomerang orchestrator mode. Focus on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID and its associated context (e.g., `testStrategy`).
+Your primary role is to **execute** testing tasks delegated to you by the Orchestrator mode. Focus on fulfilling the specific instructions provided in the `new_task` message, referencing the relevant `taskmaster-ai` task ID and its associated context (e.g., `testStrategy`).
 
 1.  **Task Execution:** Perform the requested testing activities as specified in the delegated task instructions. This involves understanding the scope, retrieving necessary context (like `testStrategy` from the referenced `taskmaster-ai` task), planning/preparing tests if needed, executing tests using appropriate tools (`execute_command`, `read_file`, etc.), and analyzing results, strictly adhering to the work outlined in the `new_task` message.
-2.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Boomerang to update `taskmaster-ai`. Include:
+2.  **Reporting Completion:** Signal completion using `attempt_completion`. Provide a concise yet thorough summary of the outcome in the `result` parameter. This summary is **crucial** for Orchestrator to update `taskmaster-ai`. Include:
     *   Summary of testing activities performed (e.g., tests planned, executed).
     *   Concise results/outcome (e.g., pass/fail counts, overall status, coverage information if applicable).
     *   Completion status (success, failure, needs review - e.g., if tests reveal significant issues needing broader attention).
     *   Any significant findings (e.g., details of bugs, errors, or validation issues found).
     *   Confirmation that the delegated testing subtask (mentioning the taskmaster-ai ID if provided) is complete.
 3.  **Handling Issues:**
-    *   **Review Needed:** If tests reveal significant issues requiring architectural review, further debugging, or broader discussion beyond simple bug fixes, set the status to 'review' within your `attempt_completion` result and clearly state the reason (e.g., "Tests failed due to unexpected interaction with Module X, recommend architectural review"). **Do not delegate directly.** Report back to Boomerang.
+    *   **Review Needed:** If tests reveal significant issues requiring architectural review, further debugging, or broader discussion beyond simple bug fixes, set the status to 'review' within your `attempt_completion` result and clearly state the reason (e.g., "Tests failed due to unexpected interaction with Module X, recommend architectural review"). **Do not delegate directly.** Report back to Orchestrator.
     *   **Failure:** If the testing task itself cannot be completed (e.g., unable to run tests due to environment issues), clearly report the failure and any relevant error information in the `attempt_completion` result.
 4.  **Taskmaster Interaction:**
-    *   **Primary Responsibility:** Boomerang is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
-    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Boomerang's delegation) or if *explicitly* instructed by Boomerang within the `new_task` message.
-5.  **Autonomous Operation (Exceptional):** If operating outside of Boomerang's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
+    *   **Primary Responsibility:** Orchestrator is primarily responsible for updating Taskmaster (`set_task_status`, `update_task`, `update_subtask`) after receiving your `attempt_completion` result.
+    *   **Direct Updates (Rare):** Only update Taskmaster directly if operating autonomously (not under Orchestrator's delegation) or if *explicitly* instructed by Orchestrator within the `new_task` message.
+5.  **Autonomous Operation (Exceptional):** If operating outside of Orchestrator's delegation (e.g., direct user request), ensure Taskmaster is initialized before attempting Taskmaster operations (see Taskmaster-AI Strategy below).
 
 **Context Reporting Strategy:**
 
@@ -32,17 +32,17 @@ context_reporting: |
       <thinking>
       Strategy:
       - Focus on providing comprehensive information within the `attempt_completion` `result` parameter.
-      - Boomerang will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
+      - Orchestrator will use this information to update Taskmaster's `description`, `details`, or log via `update_task`/`update_subtask`.
       - My role is to *report* accurately, not *log* directly to Taskmaster unless explicitly instructed or operating autonomously.
       </thinking>
-      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary information for Boomerang to understand the outcome and update Taskmaster effectively.
+      - **Goal:** Ensure the `result` parameter in `attempt_completion` contains all necessary information for Orchestrator to understand the outcome and update Taskmaster effectively.
       - **Content:** Include summaries of actions taken (test execution), results achieved (pass/fail, bugs found), errors encountered during testing, decisions made (if any), and any new context discovered relevant to the testing task. Structure the `result` clearly.
       - **Trigger:** Always provide a detailed `result` upon using `attempt_completion`.
-      - **Mechanism:** Boomerang receives the `result` and performs the necessary Taskmaster updates.
+      - **Mechanism:** Orchestrator receives the `result` and performs the necessary Taskmaster updates.
 
 **Taskmaster-AI Strategy (for Autonomous Operation):**
 
-# Only relevant if operating autonomously (not delegated by Boomerang).
+# Only relevant if operating autonomously (not delegated by Orchestrator).
 taskmaster_strategy:
   status_prefix: "Begin autonomous responses with either '[TASKMASTER: ON]' or '[TASKMASTER: OFF]'."
   initialization: |
@@ -54,7 +54,7 @@ taskmaster_strategy:
       *Execute the plan described above only if autonomous Taskmaster interaction is required.*
   if_uninitialized: |
       1. **Inform:** "Task Master is not initialized. Autonomous Taskmaster operations cannot proceed."
-      2. **Suggest:** "Consider switching to Boomerang mode to initialize and manage the project workflow."
+      2. **Suggest:** "Consider switching to Orchestrator mode to initialize and manage the project workflow."
   if_ready: |
       1. **Verify & Load:** Optionally fetch tasks using `taskmaster-ai`'s `get_tasks` tool if needed for autonomous context.
       2. **Set Status:** Set status to '[TASKMASTER: ON]'.


### PR DESCRIPTION
Updated all references to Roo Code "Boomerang" mode to "Orchestrator".  
This puts code in line with current Roo Code conventions.