### PR TITLE
Default to Cursor profile for MCP init when no rules specified

### DIFF
--- a/.changeset/mean-papayas-share.md
+++ b/.changeset/mean-papayas-share.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Default to Cursor profile for MCP init when no rules specified

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,9 @@ dev-debug.log
 *.njsproj
 *.sln
 *.sw?
+
+# OS specific
+
+# Task files
+# tasks.json
+# tasks/ 

--- a/.gitignore
+++ b/.gitignore
@@ -87,9 +87,3 @@ dev-debug.log
 *.njsproj
 *.sln
 *.sw?
-
-# OS specific
-
-# Task files
-# tasks.json
-# tasks/ 

--- a/mcp-server/src/core/direct-functions/initialize-project.js
+++ b/mcp-server/src/core/direct-functions/initialize-project.js
@@ -75,10 +75,12 @@ export async function initializeProjectDirect(args, log, context = {}) {
 		// Handle rules option with MCP-specific defaults
 		if (Array.isArray(args.rules) && args.rules.length > 0) {
 			options.rules = args.rules;
+			options.rulesExplicitlyProvided = true;
 			log.info(`Including rules: ${args.rules.join(', ')}`);
 		} else {
 			// For MCP initialization, default to Cursor profile only
 			options.rules = ['cursor'];
+			options.rulesExplicitlyProvided = true;
 			log.info(
 				`No rule profiles specified, defaulting to: Cursor`
 			);

--- a/mcp-server/src/core/direct-functions/initialize-project.js
+++ b/mcp-server/src/core/direct-functions/initialize-project.js
@@ -81,9 +81,7 @@ export async function initializeProjectDirect(args, log, context = {}) {
 			// For MCP initialization, default to Cursor profile only
 			options.rules = ['cursor'];
 			options.rulesExplicitlyProvided = true;
-			log.info(
-				`No rule profiles specified, defaulting to: Cursor`
-			);
+			log.info(`No rule profiles specified, defaulting to: Cursor`);
 		}
 
 		log.info(`Initializing project with options: ${JSON.stringify(options)}`);

--- a/mcp-server/src/core/direct-functions/initialize-project.js
+++ b/mcp-server/src/core/direct-functions/initialize-project.js
@@ -72,14 +72,15 @@ export async function initializeProjectDirect(args, log, context = {}) {
 			yes: true // Force yes mode
 		};
 
-		// Handle rules option just like CLI
+		// Handle rules option with MCP-specific defaults
 		if (Array.isArray(args.rules) && args.rules.length > 0) {
 			options.rules = args.rules;
 			log.info(`Including rules: ${args.rules.join(', ')}`);
 		} else {
-			options.rules = RULE_PROFILES;
+			// For MCP initialization, default to Cursor profile only
+			options.rules = ['cursor'];
 			log.info(
-				`No rule profiles specified, defaulting to: ${RULE_PROFILES.join(', ')}`
+				`No rule profiles specified, defaulting to: Cursor`
 			);
 		}
 

--- a/mcp-server/src/tools/initialize-project.js
+++ b/mcp-server/src/tools/initialize-project.js
@@ -51,7 +51,7 @@ export function registerInitializeProjectTool(server) {
 				.array(z.enum(RULE_PROFILES))
 				.optional()
 				.describe(
-					`List of rule profiles to include at initialization. If omitted, defaults to all available profiles. Available options: ${RULE_PROFILES.join(', ')}`
+					`List of rule profiles to include at initialization. If omitted, defaults to Cursor profile only. Available options: ${RULE_PROFILES.join(', ')}`
 				)
 		}),
 		execute: withNormalizedProjectRoot(async (args, context) => {


### PR DESCRIPTION
### Summary
Updates MCP `initialize_project` to default to Cursor profile instead of installing all rule profiles when no profiles specified.

### Changes
- **MCP initialization**: Defaults to `["cursor"]` rules when none specified
- **CLI behavior**: Unchanged - runs interactive rules setup when no profiles specified
- **Impact**: Cleaner project directory without extra rule profiles installed by default