### PR TITLE
fix: Subtask generation fails on gemini-2.5-pro

### DIFF
--- a/.changeset/tame-vans-throw.md
+++ b/.changeset/tame-vans-throw.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+fixes a critical issue where subtask generation fails on gemini-2.5-pro unless explicitly prompted to return 'details' field as a string not an object

--- a/scripts/modules/task-manager/expand-task.js
+++ b/scripts/modules/task-manager/expand-task.js
@@ -76,7 +76,7 @@ For each subtask, provide:
 - title: Clear, specific title
 - description: Detailed description
 - dependencies: Array of prerequisite subtask IDs (use the new sequential IDs)
-- details: Implementation details
+- details: Implementation details, the output should be in string
 - testStrategy: Optional testing approach
 
 
@@ -566,7 +566,7 @@ async function expandTask(
 			}
 
 			// --- Use Simplified System Prompt for Report Prompts ---
-			systemPrompt = `You are an AI assistant helping with task breakdown. Generate exactly ${finalSubtaskCount} subtasks based on the provided prompt and context. Respond ONLY with a valid JSON object containing a single key "subtasks" whose value is an array of the generated subtask objects. Each subtask object in the array must have keys: "id", "title", "description", "dependencies", "details", "status". Ensure the 'id' starts from ${nextSubtaskId} and is sequential. Ensure 'dependencies' only reference valid prior subtask IDs generated in this response (starting from ${nextSubtaskId}). Ensure 'status' is 'pending'. Do not include any other text or explanation.`;
+			systemPrompt = `You are an AI assistant helping with task breakdown. Generate exactly ${finalSubtaskCount} subtasks based on the provided prompt and context. Respond ONLY with a valid JSON object containing a single key "subtasks" whose value is an array of the generated subtask objects. Each subtask object in the array must have keys: "id", "title", "description", "dependencies", "details", "status". Ensure the 'id' starts from ${nextSubtaskId} and is sequential. Ensure 'dependencies' only reference valid prior subtask IDs generated in this response (starting from ${nextSubtaskId}). Ensure 'details' is a string. Ensure 'status' is 'pending'. Do not include any other text or explanation.`;
 			logger.info(
 				`Using expansion prompt from complexity report and simplified system prompt for task ${task.id}.`
 			);


### PR DESCRIPTION
## Description

This PR fixes a critical issue where subtask generation fails on gemini-2.5-pro unless explicitly prompted to `return 'details' field as a string not an object`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] I have tested this locally
- [x] All existing tests pass
- [ ] I have added tests for new functionality

## Changeset

- [x] I have created a changeset (or this change doesn't need one)
