### PR TITLE
fix: .gitignore missing trailing newline during project initialization

### DIFF
--- a/.changeset/major-dogs-admire.md
+++ b/.changeset/major-dogs-admire.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix .gitignore missing trailing newline during project initialization

--- a/src/utils/manage-gitignore.js
+++ b/src/utils/manage-gitignore.js
@@ -170,7 +170,7 @@ function validateInputs(targetPath, content, storeTasksInGit) {
  */
 function createNewGitignoreFile(targetPath, templateLines, log) {
 	try {
-		fs.writeFileSync(targetPath, templateLines.join('\n'));
+		fs.writeFileSync(targetPath, templateLines.join('\n') + '\n');
 		if (typeof log === 'function') {
 			log('success', `Created ${targetPath} with full template`);
 		}
@@ -223,7 +223,7 @@ function mergeWithExistingFile(
 		finalLines.push(...buildTaskFilesSection(storeTasksInGit));
 
 		// Write result
-		fs.writeFileSync(targetPath, finalLines.join('\n'));
+		fs.writeFileSync(targetPath, finalLines.join('\n') + '\n');
 
 		if (typeof log === 'function') {
 			const hasNewContent =

--- a/tests/unit/manage-gitignore.test.js
+++ b/tests/unit/manage-gitignore.test.js
@@ -179,7 +179,8 @@ logs
 
 # Task files
 # tasks.json
-# tasks/ `
+# tasks/ 
+`
 				);
 				expect(mockLog).toHaveBeenCalledWith(
 					'success',
@@ -200,7 +201,8 @@ logs
 
 # Task files
 tasks.json
-tasks/ `
+tasks/ 
+`
 				);
 				expect(mockLog).toHaveBeenCalledWith(
 					'success',
@@ -432,7 +434,8 @@ tasks/ `;
 				const writtenContent = writeFileSyncSpy.mock.calls[0][1];
 				expect(writtenContent).toBe(`# Task files
 # tasks.json
-# tasks/ `);
+# tasks/ 
+`);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary
Fixes an issue where .gitignore files created during project initialization were missing the standard trailing newline.

## Changes
- Updated `src/utils/manage-gitignore.js` to append `\n` when writing .gitignore files
- Affects both new file creation and existing file merging paths

## Impact
- Ensures .gitignore files follow POSIX text file standards
- Prevents potential issues with tools that expect files to end with newlines
- No breaking changes or behavioral differences beyond the newline addition