### PR TITLE
fix: prevent tag corruption in bulk updates

### DIFF
--- a/.changeset/chubby-needles-beam.md
+++ b/.changeset/chubby-needles-beam.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix bulk update tag corruption in tagged task lists

--- a/mcp-server/src/core/direct-functions/update-tasks.js
+++ b/mcp-server/src/core/direct-functions/update-tasks.js
@@ -21,7 +21,7 @@ import {
  */
 export async function updateTasksDirect(args, log, context = {}) {
 	const { session } = context;
-	const { from, prompt, research, tasksJsonPath, projectRoot } = args;
+	const { from, prompt, research, tasksJsonPath, projectRoot, tag } = args;
 
 	// Create the standard logger wrapper
 	const logWrapper = createLogWrapper(log);
@@ -75,7 +75,8 @@ export async function updateTasksDirect(args, log, context = {}) {
 			{
 				session,
 				mcpLog: logWrapper,
-				projectRoot
+				projectRoot,
+				tag
 			},
 			'json'
 		);

--- a/mcp-server/src/tools/update.js
+++ b/mcp-server/src/tools/update.js
@@ -43,11 +43,12 @@ export function registerUpdateTool(server) {
 				.optional()
 				.describe(
 					'The directory of the project. (Optional, usually from session)'
-				)
+				),
+			tag: z.string().optional().describe('Tag context to operate on')
 		}),
 		execute: withNormalizedProjectRoot(async (args, { log, session }) => {
 			const toolName = 'update';
-			const { from, prompt, research, file, projectRoot } = args;
+			const { from, prompt, research, file, projectRoot, tag } = args;
 
 			try {
 				log.info(
@@ -71,7 +72,8 @@ export function registerUpdateTool(server) {
 						from: from,
 						prompt: prompt,
 						research: research,
-						projectRoot: projectRoot
+						projectRoot: projectRoot,
+						tag: tag
 					},
 					log,
 					{ session }

--- a/tests/unit/scripts/modules/task-manager/update-tasks.test.js
+++ b/tests/unit/scripts/modules/task-manager/update-tasks.test.js
@@ -255,12 +255,22 @@ describe('updateTasks', () => {
 		const mockTasksPath = '/mock/path/tasks.json';
 		const mockFromId = 1;
 		const mockPrompt = 'Update master tag tasks';
-		
+
 		const mockTaggedData = {
 			master: {
 				tasks: [
-					{ id: 1, title: 'Master Task', status: 'pending', details: 'Old details' },
-					{ id: 2, title: 'Master Task 2', status: 'done', details: 'Done task' }
+					{
+						id: 1,
+						title: 'Master Task',
+						status: 'pending',
+						details: 'Old details'
+					},
+					{
+						id: 2,
+						title: 'Master Task 2',
+						status: 'done',
+						details: 'Done task'
+					}
 				],
 				metadata: {
 					created: '2024-01-01T00:00:00.000Z',
@@ -269,7 +279,12 @@ describe('updateTasks', () => {
 			},
 			'feature-branch': {
 				tasks: [
-					{ id: 1, title: 'Feature Task', status: 'pending', details: 'Feature work' }
+					{
+						id: 1,
+						title: 'Feature Task',
+						status: 'pending',
+						details: 'Feature work'
+					}
 				],
 				metadata: {
 					created: '2024-01-02T00:00:00.000Z',

--- a/tests/unit/scripts/modules/task-manager/update-tasks.test.js
+++ b/tests/unit/scripts/modules/task-manager/update-tasks.test.js
@@ -165,7 +165,11 @@ describe('updateTasks', () => {
 
 		// Assert
 		// 1. Read JSON called
-		expect(readJSON).toHaveBeenCalledWith(mockTasksPath, '/mock/path');
+		expect(readJSON).toHaveBeenCalledWith(
+			mockTasksPath,
+			'/mock/path',
+			'master'
+		);
 
 		// 2. AI Service called with correct args
 		expect(generateTextService).toHaveBeenCalledWith(expect.any(Object));
@@ -183,7 +187,9 @@ describe('updateTasks', () => {
 						])
 					})
 				})
-			})
+			}),
+			'/mock/path',
+			'master'
 		);
 
 		// 4. Check return value
@@ -228,7 +234,11 @@ describe('updateTasks', () => {
 		);
 
 		// Assert
-		expect(readJSON).toHaveBeenCalledWith(mockTasksPath, '/mock/path');
+		expect(readJSON).toHaveBeenCalledWith(
+			mockTasksPath,
+			'/mock/path',
+			'master'
+		);
 		expect(generateTextService).not.toHaveBeenCalled();
 		expect(writeJSON).not.toHaveBeenCalled();
 		expect(log).toHaveBeenCalledWith(
@@ -238,5 +248,99 @@ describe('updateTasks', () => {
 
 		// Should return early with no updates
 		expect(result).toBeUndefined();
+	});
+
+	test('should preserve all tags when updating tasks in tagged context', async () => {
+		// Arrange - Simple 2-tag structure to test tag corruption fix
+		const mockTasksPath = '/mock/path/tasks.json';
+		const mockFromId = 1;
+		const mockPrompt = 'Update master tag tasks';
+		
+		const mockTaggedData = {
+			master: {
+				tasks: [
+					{ id: 1, title: 'Master Task', status: 'pending', details: 'Old details' },
+					{ id: 2, title: 'Master Task 2', status: 'done', details: 'Done task' }
+				],
+				metadata: {
+					created: '2024-01-01T00:00:00.000Z',
+					description: 'Master tag tasks'
+				}
+			},
+			'feature-branch': {
+				tasks: [
+					{ id: 1, title: 'Feature Task', status: 'pending', details: 'Feature work' }
+				],
+				metadata: {
+					created: '2024-01-02T00:00:00.000Z',
+					description: 'Feature branch tasks'
+				}
+			}
+		};
+
+		const mockUpdatedTasks = [
+			{
+				id: 1,
+				title: 'Updated Master Task',
+				status: 'pending',
+				details: 'Updated details',
+				description: 'Updated description',
+				dependencies: [],
+				priority: 'medium',
+				testStrategy: 'Test the updated functionality',
+				subtasks: []
+			}
+		];
+
+		// Configure mocks - readJSON returns resolved view for master tag
+		readJSON.mockReturnValue({
+			...mockTaggedData.master,
+			tag: 'master',
+			_rawTaggedData: mockTaggedData
+		});
+
+		generateTextService.mockResolvedValue({
+			mainResult: JSON.stringify(mockUpdatedTasks),
+			telemetryData: { commandName: 'update-tasks', totalCost: 0.05 }
+		});
+
+		// Act
+		const result = await updateTasks(
+			mockTasksPath,
+			mockFromId,
+			mockPrompt,
+			false, // research
+			{ projectRoot: '/mock/project/root', tag: 'master' },
+			'json'
+		);
+
+		// Assert - CRITICAL: Both tags must be preserved (this would fail before the fix)
+		expect(writeJSON).toHaveBeenCalledWith(
+			mockTasksPath,
+			expect.objectContaining({
+				_rawTaggedData: expect.objectContaining({
+					master: expect.objectContaining({
+						tasks: expect.arrayContaining([
+							expect.objectContaining({ id: 1, title: 'Updated Master Task' }),
+							expect.objectContaining({ id: 2, title: 'Master Task 2' }) // Unchanged done task
+						])
+					}),
+					// CRITICAL: This tag would be missing/corrupted if the bug existed
+					'feature-branch': expect.objectContaining({
+						tasks: expect.arrayContaining([
+							expect.objectContaining({ id: 1, title: 'Feature Task' })
+						]),
+						metadata: expect.objectContaining({
+							description: 'Feature branch tasks'
+						})
+					})
+				})
+			}),
+			'/mock/project/root',
+			'master'
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.updatedTasks).toEqual(mockUpdatedTasks);
 	});
 });


### PR DESCRIPTION
## Description

Fix critical bug in bulk update functionality that was corrupting tasks.json when working with tagged task lists. The issue was in the `update-tasks.js` file where the `writeJSON` call was missing the required `projectRoot` and `tag` parameters, causing data corruption and task disappearance in tagged contexts.

Closes #854

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

The `updateTasks` function in `scripts/modules/task-manager/update-tasks.js` was calling `writeJSON(filepath, data)` without the required `projectRoot` and `tag` parameters. When `writeJSON` tries to handle tagged data without proper context, it corrupts the file structure causing tasks to disappear from tasks.json.

## Changes Made

1. **Core Function Fix** (`scripts/modules/task-manager/update-tasks.js`):
   - Added `getCurrentTag` import for proper tag handling
   - Updated function signature to accept `tag` parameter
   - Added tag resolution logic with proper fallback chain
   - Fixed `readJSON` and `writeJSON` calls to include `projectRoot` and `tag` parameters

2. **MCP Integration Updates**:
   - Updated MCP direct function to extract and pass tag parameter
   - Updated MCP tool to accept tag parameter in schema
   - Ensured proper tag propagation through the call chain

3. **Comprehensive Testing**:
   - Added test case to verify tag preservation during bulk updates
   - Covers both master and feature-branch tag scenarios
   - Ensures data integrity is maintained across all tag contexts

## Testing

- [x] I have tested this locally
- [x] All existing tests pass
- [x] I have added tests for new functionality
- [x] Verified fix prevents the specific corruption scenario described in #854
- [x] Tested with multiple tag contexts (master, feature-branch)

## Changeset

- [x] I have created a changeset (patch level for bug fix)

## Files Modified

- `scripts/modules/task-manager/update-tasks.js` - Core function fix
- `mcp-server/src/core/direct-functions/update-tasks.js` - MCP direct function update
- `mcp-server/src/tools/update.js` - MCP tool parameter addition
- `tests/unit/scripts/modules/task-manager/update-tasks.test.js` - Added regression test
- `.changeset/chubby-needles-beam.md` - Changeset for the fix
