### PR TITLE
fix(claude-code): recover from CLI JSON truncation bug (#913)

### DIFF
--- a/.changeset/claude-code-json-truncation.md
+++ b/.changeset/claude-code-json-truncation.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Recover from `@anthropic-ai/claude-code` JSON truncation bug that caused Task Master to crash when handling large (>8 kB) structured responses.  The CLI/SDK still truncates, but Task Master now detects the error, preserves buffered text, and returns a usable response instead of throwing. 


### PR DESCRIPTION
# Fix: Recover from Claude-Code JSON Truncation Bug (#913)

## Background / Original Issue
The Task Master CLI relies on the `@anthropic-ai/claude-code` SDK for local LLM execution.  A bug in the Claude-Code **CLI layer** truncates stdout when the response size crosses several hard cut-off lengths (≈4 k, 6 k, 8 k … 16 k characters).  When the SDK reads that output line-by-line it attempts `JSON.parse(line)` and throws a `SyntaxError` (e.g. *"Unterminated string in JSON at position 8000"*).  Any downstream consumer—including Task Master—crashes.

Issue originally documented and root-caused by **@LinLL** in [Issue #913](https://github.com/eyaltoledano/claude-task-master/issues/913).

## What This PR Does
1. **Detection & Recovery**  
   * In both `doGenerate()` and `doStream()` inside
     `src/ai-providers/custom-sdk/claude-code/language-model.js` we now:
     * Detect the characteristic JSON `SyntaxError` **plus** the presence of already-buffered text.
     * Convert the failure into a recoverable path:
       * Mark `finishReason: 'truncated'`.
       * Push a `provider-warning` so callers can surface telemetry.
       * Return or stream the buffered text (with `extractJson` applied where needed).
2. **User-Facing Behaviour**  
   * Task Master can once again parse long PRDs or `expand-task` outputs without crashing.
   * Output may still be truncated (until upstream CLI is fixed) but is delivered intact as far as the CLI provided it.
3. **Changeset Added**  
   * `.changeset/claude-code-json-truncation.md` records a *patch* bump for the next release.

## Credit
Huge thanks to **@LinLL** for the detailed reproduction, log traces, and root-cause analysis that made this quick work-around possible.

## Follow-ups / Future Work
* Remove the work-around once the Claude-Code CLI/SDK is patched upstream.
* Consider switching to direct HTTP API calls for large structured outputs to avoid CLI buffering entirely. 