### PR TITLE
Fix/task-path-fix-in-commandjs

### DIFF
--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -970,6 +970,8 @@ function registerCommands(programInstance) {
 			const prompt = options.prompt;
 			const useResearch = options.research || false;
 
+			const tasksPath = taskMaster.getTasksPath();
+
 			// Resolve tag using standard pattern
 			const tag =
 				options.tag || getCurrentTag(taskMaster.getProjectRoot()) || 'master';
@@ -1063,6 +1065,7 @@ function registerCommands(programInstance) {
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Resolve tag using standard pattern
 				const tag =
@@ -1160,7 +1163,7 @@ function registerCommands(programInstance) {
 				}
 
 				const result = await updateTaskById(
-					tasksPath,
+					taskMaster.getTasksPath(),
 					taskId,
 					prompt,
 					useResearch,
@@ -1234,6 +1237,7 @@ function registerCommands(programInstance) {
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Resolve tag using standard pattern
 				const tag =
@@ -1333,7 +1337,7 @@ function registerCommands(programInstance) {
 				}
 
 				const result = await updateSubtaskById(
-					tasksPath,
+					taskMaster.getTasksPath(),
 					subtaskId,
 					prompt,
 					useResearch,
@@ -1571,7 +1575,7 @@ function registerCommands(programInstance) {
 				// Updated call to the refactored expandAllTasks
 				try {
 					const result = await expandAllTasks(
-						tasksPath,
+						taskMaster.getTasksPath(),
 						options.num, // Pass num
 						options.research, // Pass research flag
 						options.prompt, // Pass additional context
@@ -1598,7 +1602,7 @@ function registerCommands(programInstance) {
 				try {
 					// Call the refactored expandTask function
 					await expandTask(
-						tasksPath,
+						taskMaster.getTasksPath(),
 						options.id,
 						options.num,
 						options.research,
@@ -2091,7 +2095,6 @@ ${result.result}
 		.option('--all', 'Clear subtasks from all tasks')
 		.option('--tag <tag>', 'Specify tag context for task operations')
 		.action(async (options) => {
-			const tasksPath = options.file || TASKMASTER_TASKS_FILE;
 			const taskIds = options.id;
 			const all = options.all;
 			const tag = options.tag;
@@ -2249,7 +2252,7 @@ ${result.result}
 
 			try {
 				const { newTaskId, telemetryData } = await addTask(
-					tasksPath,
+					taskMaster.getTasksPath(),
 					options.prompt,
 					dependenciesArray,
 					options.priority,
@@ -2288,8 +2291,6 @@ ${result.result}
 		)
 		.option('--tag <tag>', 'Specify tag context for task operations')
 		.action(async (options) => {
-			const tasksPath = options.file || TASKMASTER_TASKS_FILE;
-			const reportPath = options.report;
 			const tag = options.tag;
 
 			// Initialize TaskMaster
@@ -4250,6 +4251,7 @@ Examples:
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Validate tasks file exists
 				if (!fs.existsSync(tasksPath)) {
@@ -4319,7 +4321,7 @@ Examples:
 					};
 
 					await createTagFromBranch(
-						tasksPath,
+						taskMaster.getTasksPath(),
 						currentBranch,
 						branchOptions,
 						context,
@@ -4389,6 +4391,7 @@ Examples:
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Validate tasks file exists
 				if (!fs.existsSync(tasksPath)) {
@@ -4443,6 +4446,7 @@ Examples:
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Validate tasks file exists
 				if (!fs.existsSync(tasksPath)) {
@@ -4492,6 +4496,7 @@ Examples:
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Validate tasks file exists
 				if (!fs.existsSync(tasksPath)) {
@@ -4537,6 +4542,7 @@ Examples:
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Validate tasks file exists
 				if (!fs.existsSync(tasksPath)) {
@@ -4588,6 +4594,7 @@ Examples:
 				const taskMaster = initTaskMaster({
 					tasksPath: options.file || true
 				});
+				const tasksPath = taskMaster.getTasksPath();
 
 				// Validate tasks file exists
 				if (!fs.existsSync(tasksPath)) {
@@ -4608,7 +4615,7 @@ Examples:
 				};
 
 				await copyTag(
-					taskMaster.getTasksPath(),
+					tasksPath,
 					sourceName,
 					targetName,
 					copyOptions,


### PR DESCRIPTION
- Replaced local `tasksPath` variable assignments with direct calls to `taskMaster.getTasksPath()` for consistency and clarity across multiple command functions.
- This change enhances maintainability by ensuring a single source of truth for task paths, reducing redundancy in path handling logic.