### PR TITLE
fix: show command no longer requires complexity report to exist

### DIFF
--- a/.changeset/fix-show-command-complexity.md
+++ b/.changeset/fix-show-command-complexity.md
@@ -1,0 +1,7 @@
+---
+"task-master-ai": patch
+---
+
+Fix: show command no longer requires complexity report file to exist
+
+The `tm show` command was incorrectly requiring the complexity report file to exist even when not needed. Now it only validates the complexity report path when a custom report file is explicitly provided via the -r/--report option.

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -2353,10 +2353,14 @@ ${result.result}
 		.option('--tag <tag>', 'Specify tag context for task operations')
 		.action(async (taskId, options) => {
 			// Initialize TaskMaster
-			const taskMaster = initTaskMaster({
-				tasksPath: options.file || true,
-				complexityReportPath: options.report || false
-			});
+			const initOptions = {
+				tasksPath: options.file || true
+			};
+			// Only pass complexityReportPath if user provided a custom path
+			if (options.report && options.report !== COMPLEXITY_REPORT_FILE) {
+				initOptions.complexityReportPath = options.report;
+			}
+			const taskMaster = initTaskMaster(initOptions);
 
 			const idArg = taskId || options.id;
 			const statusFilter = options.status;


### PR DESCRIPTION
## Summary

Fixes an issue where the `tm show` command would fail with "complexity report override path does not exist" error when the complexity report file doesn't exist.

## The Problem

The `show` command was incorrectly requiring the complexity report file to exist even when it wasn't needed. This happened because:
- The command had a default value for the `-r, --report` option
- This default was always passed to `initTaskMaster()` 
- `initTaskMaster()` validates that any provided path exists

## The Fix

Modified the show command to only pass `complexityReportPath` to `initTaskMaster()` when the user explicitly provides a custom report path via the `-r/--report` option. This matches the behavior of other commands like `list`.

## Test Plan
✅ Linting passes (pre-existing import issues unchanged)
✅ Formatting passes
✅ All tests pass

## Impact
- Users can now use `tm show <id>` without needing a complexity report file
- The command still validates custom report paths when explicitly provided
- No breaking changes - existing functionality preserved