### PR TITLE
fix: bump ai-sdk-provider-gemini-cli to v0.1.1

### DIFF
--- a/.changeset/fix-gemini-cli-dependency.md
+++ b/.changeset/fix-gemini-cli-dependency.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix compatibility with @google/gemini-cli-core v0.1.12+ by updating ai-sdk-provider-gemini-cli to v0.1.1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "task-master-ai",
-	"version": "0.20.0",
+	"version": "0.21.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "task-master-ai",
-			"version": "0.20.0",
+			"version": "0.21.0",
 			"license": "MIT WITH Commons-Clause",
 			"workspaces": [
 				"apps/*",
@@ -28,6 +28,7 @@
 				"@inquirer/search": "^3.0.15",
 				"@openrouter/ai-sdk-provider": "^0.4.5",
 				"ai": "^4.3.10",
+				"ai-sdk-provider-gemini-cli": "0.1.1",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"boxen": "^8.0.1",
@@ -81,7 +82,7 @@
 			"optionalDependencies": {
 				"@anthropic-ai/claude-code": "^1.0.25",
 				"@biomejs/cli-linux-x64": "^1.9.4",
-				"ai-sdk-provider-gemini-cli": "^0.0.4"
+				"ai-sdk-provider-gemini-cli": "^0.1.1"
 			}
 		},
 		"apps/extension": {
@@ -92,9 +93,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/amazon-bedrock": {
-			"version": "2.2.10",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-2.2.10.tgz",
-			"integrity": "sha512-icLGO7Q0NinnHIPgT+y1QjHVwH4HwV+brWbvM+FfCG2Afpa89PyKa3Ret91kGjZpBgM/xnj1B7K5eM+rRlsXQA==",
+			"version": "2.2.12",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-2.2.12.tgz",
+			"integrity": "sha512-m8gARnh45pr1s08Uu4J/Pm8913mwJPejPOm59b+kUqMsP9ilhUtH/bp8432Ra/v+vHuMoBrglG2ZvXtctAaH2g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -127,12 +128,12 @@
 			}
 		},
 		"node_modules/@ai-sdk/azure": {
-			"version": "1.3.23",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-1.3.23.tgz",
-			"integrity": "sha512-vpsaPtU24RBVk/IMM5UylR/N4RtAuL2NZLWc7LJ3tvMTHu6pI46a7w+1qIwR3F6yO9ehWR8qvfLaBefJNFxaVw==",
+			"version": "1.3.24",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-1.3.24.tgz",
+			"integrity": "sha512-6zOG8mwmd8esSL/L9oYFZSyZWORRTxuG6on9A3RdPe7MRJ607Q6BWsuvul79kecbLf5xQ4bfP7LzXaBizsd8OA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/openai": "1.3.22",
+				"@ai-sdk/openai": "1.3.23",
 				"@ai-sdk/provider": "1.1.3",
 				"@ai-sdk/provider-utils": "2.2.8"
 			},
@@ -144,9 +145,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/google": {
-			"version": "1.2.19",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.19.tgz",
-			"integrity": "sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA==",
+			"version": "1.2.22",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.22.tgz",
+			"integrity": "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -160,13 +161,13 @@
 			}
 		},
 		"node_modules/@ai-sdk/google-vertex": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-2.2.24.tgz",
-			"integrity": "sha512-zi1ZN6jQEBRke/WMbZv0YkeqQ3nOs8ihxjVh/8z1tUn+S1xgRaYXf4+r6+Izh2YqVHIMNwjhUYryQRBGq20cgQ==",
+			"version": "2.2.27",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-2.2.27.tgz",
+			"integrity": "sha512-iDGX/2yrU4OOL1p/ENpfl3MWxuqp9/bE22Z8Ip4DtLCUx6ismUNtrKO357igM1/3jrM6t9C6egCPniHqBsHOJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/anthropic": "1.2.12",
-				"@ai-sdk/google": "1.2.19",
+				"@ai-sdk/google": "1.2.22",
 				"@ai-sdk/provider": "1.1.3",
 				"@ai-sdk/provider-utils": "2.2.8",
 				"google-auth-library": "^9.15.0"
@@ -211,9 +212,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/openai": {
-			"version": "1.3.22",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.22.tgz",
-			"integrity": "sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw==",
+			"version": "1.3.23",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.23.tgz",
+			"integrity": "sha512-86U7rFp8yacUAOE/Jz8WbGcwMCqWvjK33wk5DXkfnAOEn3mx2r7tNSJdjukQFZbAK97VMXGPPHxF+aEARDXRXQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -227,9 +228,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/openai-compatible": {
-			"version": "0.2.14",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-0.2.14.tgz",
-			"integrity": "sha512-icjObfMCHKSIbywijaoLdZ1nSnuRnWgMEMLgwoxPJgxsUHMx0aVORnsLUid4SPtdhHI3X2masrt6iaEQLvOSFw==",
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-0.2.16.tgz",
+			"integrity": "sha512-LkvfcM8slJedRyJa/MiMiaOzcMjV1zNDwzTHEGz7aAsgsQV0maLfmJRi/nuSwf5jmp0EouC+JXXDUj2l94HgQw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -329,12 +330,12 @@
 			}
 		},
 		"node_modules/@ai-sdk/xai": {
-			"version": "1.2.16",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-1.2.16.tgz",
-			"integrity": "sha512-UOZT8td9PWwMi2dF9a0U44t/Oltmf6QmIJdSvrOcLG4mvpRc1UJn6YJaR0HtXs3YnW6SvY1zRdIDrW4GFpv4NA==",
+			"version": "1.2.18",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-1.2.18.tgz",
+			"integrity": "sha512-T70WEu+UKXD/Fdj9ck+ujIqUp5ru06mJ/7usePXeXL5EeTi8KXevXF9AMIDdhyD5MZPT2jI8t19lEr8Bhuh/Bg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/openai-compatible": "0.2.14",
+				"@ai-sdk/openai-compatible": "0.2.16",
 				"@ai-sdk/provider": "1.1.3",
 				"@ai-sdk/provider-utils": "2.2.8"
 			},
@@ -374,10 +375,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-code": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.34.tgz",
-			"integrity": "sha512-9mQd8hodE5/RxZnsWUCdLzqGUKuCzBczrfc2QfxrNSlvUFpOgTzjT1Zlww2vW9v0K1e5K9g1o08apqPl/QPmpw==",
-			"hasInstallScript": true,
+			"version": "1.0.57",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.57.tgz",
+			"integrity": "sha512-zMymGZzjG+JO9iKC5N5pAy8AxyHIMPCL6U3HYCR3vCj5M+Y0s3GAMma6GkvCXWFixRN6KSZItKw3HbQiaIBYlw==",
 			"license": "SEE LICENSE IN README.md",
 			"optional": true,
 			"bin": {
@@ -550,45 +550,45 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.835.0.tgz",
-			"integrity": "sha512-M28XmziapO/4dJxY5OW+KLAw5XTXOg9N+p7TiBvcE9kT0uDKLL5ypNG0ChW+7b8mXrMGA6wpVBb2MWDgf+6I6w==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.848.0.tgz",
+			"integrity": "sha512-Sin8aLnA81MgvUJrfQsBIQ1UJg4klWT3NuYYjExLiVQf3A0/F7Bfx1HTIyWXtSchY4QgGr7MMone0/0KZ4Dy9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/credential-provider-node": "3.835.0",
-				"@aws-sdk/middleware-host-header": "3.821.0",
-				"@aws-sdk/middleware-logger": "3.821.0",
-				"@aws-sdk/middleware-recursion-detection": "3.821.0",
-				"@aws-sdk/middleware-user-agent": "3.835.0",
-				"@aws-sdk/region-config-resolver": "3.821.0",
-				"@aws-sdk/types": "3.821.0",
-				"@aws-sdk/util-endpoints": "3.828.0",
-				"@aws-sdk/util-user-agent-browser": "3.821.0",
-				"@aws-sdk/util-user-agent-node": "3.835.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/credential-provider-node": "3.848.0",
+				"@aws-sdk/middleware-host-header": "3.840.0",
+				"@aws-sdk/middleware-logger": "3.840.0",
+				"@aws-sdk/middleware-recursion-detection": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.848.0",
+				"@aws-sdk/region-config-resolver": "3.840.0",
+				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.848.0",
+				"@aws-sdk/util-user-agent-browser": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.848.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.5.3",
-				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/core": "^3.7.0",
+				"@smithy/fetch-http-handler": "^5.1.0",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.12",
-				"@smithy/middleware-retry": "^4.1.13",
+				"@smithy/middleware-endpoint": "^4.1.15",
+				"@smithy/middleware-retry": "^4.1.16",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.7",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.20",
-				"@smithy/util-defaults-mode-node": "^4.0.20",
+				"@smithy/util-defaults-mode-browser": "^4.0.23",
+				"@smithy/util-defaults-mode-node": "^4.0.23",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -600,44 +600,44 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.835.0.tgz",
-			"integrity": "sha512-4J19IcBKU5vL8yw/YWEvbwEGcmCli0rpRyxG53v0K5/3weVPxVBbKfkWcjWVQ4qdxNz2uInfbTde4BRBFxWllQ==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
+			"integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/middleware-host-header": "3.821.0",
-				"@aws-sdk/middleware-logger": "3.821.0",
-				"@aws-sdk/middleware-recursion-detection": "3.821.0",
-				"@aws-sdk/middleware-user-agent": "3.835.0",
-				"@aws-sdk/region-config-resolver": "3.821.0",
-				"@aws-sdk/types": "3.821.0",
-				"@aws-sdk/util-endpoints": "3.828.0",
-				"@aws-sdk/util-user-agent-browser": "3.821.0",
-				"@aws-sdk/util-user-agent-node": "3.835.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/middleware-host-header": "3.840.0",
+				"@aws-sdk/middleware-logger": "3.840.0",
+				"@aws-sdk/middleware-recursion-detection": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.848.0",
+				"@aws-sdk/region-config-resolver": "3.840.0",
+				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.848.0",
+				"@aws-sdk/util-user-agent-browser": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.848.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.5.3",
-				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/core": "^3.7.0",
+				"@smithy/fetch-http-handler": "^5.1.0",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.12",
-				"@smithy/middleware-retry": "^4.1.13",
+				"@smithy/middleware-endpoint": "^4.1.15",
+				"@smithy/middleware-retry": "^4.1.16",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.7",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.20",
-				"@smithy/util-defaults-mode-node": "^4.0.20",
+				"@smithy/util-defaults-mode-browser": "^4.0.23",
+				"@smithy/util-defaults-mode-node": "^4.0.23",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -649,25 +649,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.835.0.tgz",
-			"integrity": "sha512-7mnf4xbaLI8rkDa+w6fUU48dG6yDuOgLXEPe4Ut3SbMp1ceJBPMozNHbCwkiyHk3HpxZYf8eVy0wXhJMrxZq5w==",
+			"version": "3.846.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+			"integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/types": "3.840.0",
 				"@aws-sdk/xml-builder": "3.821.0",
-				"@smithy/core": "^3.5.3",
+				"@smithy/core": "^3.7.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/signature-v4": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.7",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-utf8": "^4.0.0",
-				"fast-xml-parser": "4.4.1",
+				"fast-xml-parser": "5.2.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -675,13 +675,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.835.0.tgz",
-			"integrity": "sha512-1UOngj7DwRyeUB6FbeAF2ryVjGWRtmLfxltQKcJi41R5O8WN3bq8jgNY+zz0hdUVqVFoDot5yCJo87CqNJ/mSQ==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.848.0.tgz",
+			"integrity": "sha512-2cm/Ye6ktagW1h7FmF4sgo8STZyBr2+0+L9lr/veuPKZVWoi/FyhJR3l0TtKrd8z78no9P5xbsGUmxoDLtsxiw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/client-cognito-identity": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -691,13 +691,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.835.0.tgz",
-			"integrity": "sha512-U9LFWe7+ephNyekpUbzT7o6SmJTmn6xkrPkE0D7pbLojnPVi/8SZKyjtgQGIsAv+2kFkOCqMOIYUKd/0pE7uew==",
+			"version": "3.846.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+			"integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -707,20 +707,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.835.0.tgz",
-			"integrity": "sha512-jCdNEsQklil7frDm/BuVKl4ubVoQHRbV6fnkOjmxAJz0/v7cR8JP0jBGlqKKzh3ROh5/vo1/5VUZbCTLpc9dSg==",
+			"version": "3.846.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+			"integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/types": "3.840.0",
+				"@smithy/fetch-http-handler": "^5.1.0",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.7",
 				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -728,19 +728,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.835.0.tgz",
-			"integrity": "sha512-nqF6rYRAnJedmvDfrfKygzyeADcduDvtvn7GlbQQbXKeR2l7KnCdhuxHa0FALLvspkHiBx7NtInmvnd5IMuWsw==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
+			"integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/credential-provider-env": "3.835.0",
-				"@aws-sdk/credential-provider-http": "3.835.0",
-				"@aws-sdk/credential-provider-process": "3.835.0",
-				"@aws-sdk/credential-provider-sso": "3.835.0",
-				"@aws-sdk/credential-provider-web-identity": "3.835.0",
-				"@aws-sdk/nested-clients": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/credential-provider-env": "3.846.0",
+				"@aws-sdk/credential-provider-http": "3.846.0",
+				"@aws-sdk/credential-provider-process": "3.846.0",
+				"@aws-sdk/credential-provider-sso": "3.848.0",
+				"@aws-sdk/credential-provider-web-identity": "3.848.0",
+				"@aws-sdk/nested-clients": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -752,18 +752,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.835.0.tgz",
-			"integrity": "sha512-77B8elyZlaEd7vDYyCnYtVLuagIBwuJ0AQ98/36JMGrYX7TT8UVAhiDAfVe0NdUOMORvDNFfzL06VBm7wittYw==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
+			"integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.835.0",
-				"@aws-sdk/credential-provider-http": "3.835.0",
-				"@aws-sdk/credential-provider-ini": "3.835.0",
-				"@aws-sdk/credential-provider-process": "3.835.0",
-				"@aws-sdk/credential-provider-sso": "3.835.0",
-				"@aws-sdk/credential-provider-web-identity": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/credential-provider-env": "3.846.0",
+				"@aws-sdk/credential-provider-http": "3.846.0",
+				"@aws-sdk/credential-provider-ini": "3.848.0",
+				"@aws-sdk/credential-provider-process": "3.846.0",
+				"@aws-sdk/credential-provider-sso": "3.848.0",
+				"@aws-sdk/credential-provider-web-identity": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -775,13 +775,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.835.0.tgz",
-			"integrity": "sha512-qXkTt5pAhSi2Mp9GdgceZZFo/cFYrA735efqi/Re/nf0lpqBp8mRM8xv+iAaPHV4Q10q0DlkbEidT1DhxdT/+w==",
+			"version": "3.846.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+			"integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -792,15 +792,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.835.0.tgz",
-			"integrity": "sha512-jAiEMryaPFXayYGszrc7NcgZA/zrrE3QvvvUBh/Udasg+9Qp5ZELdJCm/p98twNyY9n5i6Ex6VgvdxZ7+iEheQ==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
+			"integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.835.0",
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/token-providers": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/client-sso": "3.848.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/token-providers": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -811,14 +811,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.835.0.tgz",
-			"integrity": "sha512-zfleEFXDLlcJ7cyfS4xSyCRpd8SVlYZfH3rp0pg2vPYKbnmXVE0r+gPIYXl4L+Yz4A2tizYl63nKCNdtbxadog==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
+			"integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/nested-clients": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/nested-clients": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -828,25 +828,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.835.0.tgz",
-			"integrity": "sha512-7FcMN2rWpLb4qlU4tzfWMcLbP0OKXy28llwBEX3gtoKhjQCxK8KPg2tg8BoezWNe1PJLuQcfzVj1k/CPLH4EaQ==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.848.0.tgz",
+			"integrity": "sha512-lRDuU05YC+r/1JmRULngJQli7scP5hmq0/7D+xw1s8eRM0H2auaH7LQFlq/SLxQZLMkVNPCrmsug3b3KcLj1NA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.835.0",
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.835.0",
-				"@aws-sdk/credential-provider-env": "3.835.0",
-				"@aws-sdk/credential-provider-http": "3.835.0",
-				"@aws-sdk/credential-provider-ini": "3.835.0",
-				"@aws-sdk/credential-provider-node": "3.835.0",
-				"@aws-sdk/credential-provider-process": "3.835.0",
-				"@aws-sdk/credential-provider-sso": "3.835.0",
-				"@aws-sdk/credential-provider-web-identity": "3.835.0",
-				"@aws-sdk/nested-clients": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/client-cognito-identity": "3.848.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.848.0",
+				"@aws-sdk/credential-provider-env": "3.846.0",
+				"@aws-sdk/credential-provider-http": "3.846.0",
+				"@aws-sdk/credential-provider-ini": "3.848.0",
+				"@aws-sdk/credential-provider-node": "3.848.0",
+				"@aws-sdk/credential-provider-process": "3.846.0",
+				"@aws-sdk/credential-provider-sso": "3.848.0",
+				"@aws-sdk/credential-provider-web-identity": "3.848.0",
+				"@aws-sdk/nested-clients": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.5.3",
+				"@smithy/core": "^3.7.0",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
@@ -858,12 +858,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.821.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
-			"integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
+			"integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -873,12 +873,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.821.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
-			"integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
+			"integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
 			},
@@ -887,12 +887,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.821.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
-			"integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
+			"integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -902,15 +902,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.835.0.tgz",
-			"integrity": "sha512-2gmAYygeE/gzhyF2XlkcbMLYFTbNfV61n+iCFa/ZofJHXYE+RxSyl5g4kujLEs7bVZHmjQZJXhprVSkGccq3/w==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+			"integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
-				"@aws-sdk/util-endpoints": "3.828.0",
-				"@smithy/core": "^3.5.3",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.848.0",
+				"@smithy/core": "^3.7.0",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -920,44 +920,44 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.835.0.tgz",
-			"integrity": "sha512-UtmOO0U5QkicjCEv+B32qqRAnS7o2ZkZhC+i3ccH1h3fsfaBshpuuNBwOYAzRCRBeKW5fw3ANFrV/+2FTp4jWg==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+			"integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/middleware-host-header": "3.821.0",
-				"@aws-sdk/middleware-logger": "3.821.0",
-				"@aws-sdk/middleware-recursion-detection": "3.821.0",
-				"@aws-sdk/middleware-user-agent": "3.835.0",
-				"@aws-sdk/region-config-resolver": "3.821.0",
-				"@aws-sdk/types": "3.821.0",
-				"@aws-sdk/util-endpoints": "3.828.0",
-				"@aws-sdk/util-user-agent-browser": "3.821.0",
-				"@aws-sdk/util-user-agent-node": "3.835.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/middleware-host-header": "3.840.0",
+				"@aws-sdk/middleware-logger": "3.840.0",
+				"@aws-sdk/middleware-recursion-detection": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.848.0",
+				"@aws-sdk/region-config-resolver": "3.840.0",
+				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.848.0",
+				"@aws-sdk/util-user-agent-browser": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.848.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.5.3",
-				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/core": "^3.7.0",
+				"@smithy/fetch-http-handler": "^5.1.0",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.12",
-				"@smithy/middleware-retry": "^4.1.13",
+				"@smithy/middleware-endpoint": "^4.1.15",
+				"@smithy/middleware-retry": "^4.1.16",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.7",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.20",
-				"@smithy/util-defaults-mode-node": "^4.0.20",
+				"@smithy/util-defaults-mode-browser": "^4.0.23",
+				"@smithy/util-defaults-mode-node": "^4.0.23",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -969,12 +969,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.821.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
-			"integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
+			"integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-config-provider": "^4.0.0",
@@ -986,14 +986,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.835.0.tgz",
-			"integrity": "sha512-zN1P3BE+Rv7w7q/CDA8VCQox6SE9QTn0vDtQ47AHA3eXZQQgYzBqgoLgJxR9rKKBIRGZqInJa/VRskLL95VliQ==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+			"integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.835.0",
-				"@aws-sdk/nested-clients": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/core": "3.846.0",
+				"@aws-sdk/nested-clients": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -1004,9 +1004,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.821.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
-			"integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
+			"integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.3.1",
@@ -1017,13 +1017,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.828.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
-			"integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+			"integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/types": "^4.3.1",
+				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-endpoints": "^3.0.6",
 				"tslib": "^2.6.2"
 			},
@@ -1044,25 +1045,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.821.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
-			"integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
+			"version": "3.840.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
+			"integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/types": "^4.3.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.835.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.835.0.tgz",
-			"integrity": "sha512-gY63QZ4W5w9JYHYuqvUxiVGpn7IbCt1ODPQB0ZZwGGr3WRmK+yyZxCtFjbYhEQDQLgTWpf8YgVxgQLv2ps0PJg==",
+			"version": "3.848.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+			"integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.835.0",
-				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/middleware-user-agent": "3.848.0",
+				"@aws-sdk/types": "3.840.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -1108,9 +1109,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
-			"integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1118,22 +1119,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+			"integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
+				"@babel/generator": "^7.28.0",
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.4",
-				"@babel/parser": "^7.27.4",
+				"@babel/helpers": "^7.27.6",
+				"@babel/parser": "^7.28.0",
 				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.27.4",
-				"@babel/types": "^7.27.3",
+				"@babel/traverse": "^7.28.0",
+				"@babel/types": "^7.28.0",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -1184,16 +1185,16 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-			"integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+			"integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.27.5",
-				"@babel/types": "^7.27.3",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.28.0",
+				"@babel/types": "^7.28.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
@@ -1235,6 +1236,16 @@
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
@@ -1324,13 +1335,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+			"integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.27.3"
+				"@babel/types": "^7.28.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1604,19 +1615,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+			"integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
-				"@babel/parser": "^7.27.4",
+				"@babel/generator": "^7.28.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.0",
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.3",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
+				"@babel/types": "^7.28.0",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1648,9 +1659,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-			"integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+			"version": "7.28.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+			"integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1713,6 +1724,57 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
 		"node_modules/@biomejs/cli-linux-x64": {
 			"version": "1.9.4",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
@@ -1724,6 +1786,57 @@
 			"optional": true,
 			"os": [
 				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=14.21.3"
@@ -2047,10 +2160,78 @@
 				"node": ">=0.1.90"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+			"integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+			"integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+			"integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+			"integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-			"integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
+			"integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2064,13 +2245,370 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+			"integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+			"integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+			"integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+			"integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+			"integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+			"integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+			"integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+			"integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+			"integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+			"integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+			"integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+			"integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+			"integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+			"integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+			"integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+			"integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+			"integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+			"integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+			"integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+			"integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+			"integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@google/gemini-cli-core": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/@google/gemini-cli-core/-/gemini-cli-core-0.1.9.tgz",
-			"integrity": "sha512-NFmu0qivppBZ3JT6to0A2+tEtcvWcWuhbfyTz42Wm2AoAtl941lTbcd/TiBryK0yWz3WCkqukuDxl+L7axLpvA==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/@google/gemini-cli-core/-/gemini-cli-core-0.1.13.tgz",
+			"integrity": "sha512-Vx3CbRpLJiGs/sj4SXlGH2ALKyON5skV/p+SCAoRuS6yRsANS1+diEeXbp6jlWT2TTiGoa8+GolqeNIU7wbN8w==",
 			"optional": true,
 			"dependencies": {
-				"@google/genai": "^1.4.0",
+				"@google/genai": "1.9.0",
 				"@modelcontextprotocol/sdk": "^1.11.0",
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",
@@ -2080,23 +2618,46 @@
 				"@opentelemetry/sdk-node": "^0.52.0",
 				"@types/glob": "^8.1.0",
 				"@types/html-to-text": "^9.0.4",
+				"ajv": "^8.17.1",
 				"diff": "^7.0.0",
-				"dotenv": "^16.6.1",
-				"gaxios": "^6.1.1",
+				"dotenv": "^17.1.0",
 				"glob": "^10.4.5",
 				"google-auth-library": "^9.11.0",
 				"html-to-text": "^9.0.5",
+				"https-proxy-agent": "^7.0.6",
 				"ignore": "^7.0.0",
 				"micromatch": "^4.0.8",
 				"open": "^10.1.2",
-				"shell-quote": "^1.8.2",
+				"shell-quote": "^1.8.3",
 				"simple-git": "^3.28.0",
 				"strip-ansi": "^7.1.0",
 				"undici": "^7.10.0",
 				"ws": "^8.18.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
+			}
+		},
+		"node_modules/@google/gemini-cli-core/node_modules/@google/genai": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
+			"integrity": "sha512-w9P93OXKPMs9H1mfAx9+p3zJqQGrWBGdvK/SVc7cLZEXNHr/3+vW2eif7ZShA6wU24rNLn9z9MK2vQFUvNRI2Q==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"google-auth-library": "^9.14.2",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.11.0"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@google/gemini-cli-core/node_modules/ansi-regex": {
@@ -2120,6 +2681,19 @@
 			"optional": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@google/gemini-cli-core/node_modules/dotenv": {
+			"version": "17.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+			"integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/@google/gemini-cli-core/node_modules/glob": {
@@ -2186,16 +2760,14 @@
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.8.0.tgz",
-			"integrity": "sha512-n3KiMFesQCy2R9iSdBIuJ0JWYQ1HZBJJkmt4PPZMGZKvlgHhBAGw1kUMyX+vsAIzprN3lK45DI755lm70wPOOg==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.10.0.tgz",
+			"integrity": "sha512-PR4tLuiIFMrpAiiCko2Z16ydikFsPF1c5TBfI64hlZcv3xBEApSCceLuDYu1pNMq2SkNh4r66J4AG+ZexBnMLw==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
 				"google-auth-library": "^9.14.2",
-				"ws": "^8.18.0",
-				"zod": "^3.22.4",
-				"zod-to-json-schema": "^3.22.4"
+				"ws": "^8.18.0"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -2374,6 +2946,28 @@
 				"@img/sharp-libvips-darwin-arm64": "1.0.4"
 			}
 		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+			"integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.0.4"
+			}
+		},
 		"node_modules/@img/sharp-libvips-darwin-arm64": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
@@ -2390,15 +2984,164 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+			"integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+			"integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+			"cpu": [
+				"arm"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+			"integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+			"integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+			"integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.0.5"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+			"integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+			"integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+			"integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
-			"integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
+			"integrity": "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/figures": "^1.0.13",
+				"@inquirer/type": "^3.0.8",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
@@ -2415,13 +3158,13 @@
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "5.1.12",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
-			"integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
+			"version": "5.1.14",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
+			"integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7"
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/type": "^3.0.8"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2436,13 +3179,13 @@
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "10.1.13",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
-			"integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+			"version": "10.1.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+			"integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/figures": "^1.0.13",
+				"@inquirer/type": "^3.0.8",
 				"ansi-escapes": "^4.3.2",
 				"cli-width": "^4.1.0",
 				"mute-stream": "^2.0.0",
@@ -2463,13 +3206,13 @@
 			}
 		},
 		"node_modules/@inquirer/editor": {
-			"version": "4.2.13",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
-			"integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+			"version": "4.2.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.15.tgz",
+			"integrity": "sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/type": "^3.0.8",
 				"external-editor": "^3.1.0"
 			},
 			"engines": {
@@ -2485,13 +3228,13 @@
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "4.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
-			"integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
+			"integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/type": "^3.0.8",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -2507,22 +3250,22 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-			"integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+			"integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "4.1.12",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
-			"integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
+			"integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7"
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/type": "^3.0.8"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2537,13 +3280,13 @@
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "3.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
-			"integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
+			"integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7"
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/type": "^3.0.8"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2558,13 +3301,13 @@
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "4.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
-			"integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
+			"integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/type": "^3.0.8",
 				"ansi-escapes": "^4.3.2"
 			},
 			"engines": {
@@ -2580,21 +3323,21 @@
 			}
 		},
 		"node_modules/@inquirer/prompts": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
-			"integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.7.1.tgz",
+			"integrity": "sha512-XDxPrEWeWUBy8scAXzXuFY45r/q49R0g72bUzgQXZ1DY/xEFX+ESDMkTQolcb5jRBzaNJX2W8XQl6krMNDTjaA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/checkbox": "^4.1.8",
-				"@inquirer/confirm": "^5.1.12",
-				"@inquirer/editor": "^4.2.13",
-				"@inquirer/expand": "^4.0.15",
-				"@inquirer/input": "^4.1.12",
-				"@inquirer/number": "^3.0.15",
-				"@inquirer/password": "^4.0.15",
-				"@inquirer/rawlist": "^4.1.3",
-				"@inquirer/search": "^3.0.15",
-				"@inquirer/select": "^4.2.3"
+				"@inquirer/checkbox": "^4.2.0",
+				"@inquirer/confirm": "^5.1.14",
+				"@inquirer/editor": "^4.2.15",
+				"@inquirer/expand": "^4.0.17",
+				"@inquirer/input": "^4.2.1",
+				"@inquirer/number": "^3.0.17",
+				"@inquirer/password": "^4.0.17",
+				"@inquirer/rawlist": "^4.1.5",
+				"@inquirer/search": "^3.0.17",
+				"@inquirer/select": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2609,13 +3352,13 @@
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
-			"integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
+			"integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/type": "^3.0.8",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -2631,14 +3374,14 @@
 			}
 		},
 		"node_modules/@inquirer/search": {
-			"version": "3.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
-			"integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.17.tgz",
+			"integrity": "sha512-CuBU4BAGFqRYors4TNCYzy9X3DpKtgIW4Boi0WNkm4Ei1hvY9acxKdBdyqzqBCEe4YxSdaQQsasJlFlUJNgojw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/figures": "^1.0.13",
+				"@inquirer/type": "^3.0.8",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -2654,14 +3397,14 @@
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
-			"integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
+			"integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/figures": "^1.0.13",
+				"@inquirer/type": "^3.0.8",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
@@ -2678,9 +3421,9 @@
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
-			"integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+			"integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -3279,18 +4022,14 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+			"integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -3303,27 +4042,17 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+			"integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.29",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+			"integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3457,9 +4186,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.0.tgz",
-			"integrity": "sha512-67hnl/ROKdb03Vuu0YOr+baKTvf1/5YBHBm9KnZdjdAh8hjt4FRCPD5ucwxGB237sBpzlqQsLy1PFu7z/ekZ9Q==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.16.0.tgz",
+			"integrity": "sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.6",
@@ -4529,9 +5258,9 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
-			"integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.1.tgz",
+			"integrity": "sha512-ExRCsHnXFtBPnM7MkfKBPcBBdHw1h/QS/cbNw4ho95qnyNHvnpmGbR39MIAv9KggTr5qSPxRSEL+hRXlyGyGQw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/middleware-serde": "^4.0.8",
@@ -4540,7 +5269,7 @@
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -4580,9 +5309,9 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
-			"integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
+			"integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/protocol-http": "^5.1.2",
@@ -4650,12 +5379,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.1.12",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.12.tgz",
-			"integrity": "sha512-Piy/9UOjh5FtEXhybjPwyOHcC/pGHFknl2Gc/q1YbEkngxY6eQwvBvZTNamXpyDAHCuP3h+lymcVcdyO3WdGqQ==",
+			"version": "4.1.16",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.16.tgz",
+			"integrity": "sha512-plpa50PIGLqzMR2ANKAw2yOW5YKS626KYKqae3atwucbz4Ve4uQ9K9BEZxDLIFmCu7hKLcrq2zmj4a+PfmUV5w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.5.3",
+				"@smithy/core": "^3.7.1",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -4669,15 +5398,15 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.13.tgz",
-			"integrity": "sha512-5ILvPCJevTcGpl7wAvSV9HKbIGS2Wxz505d0b5dP9kmjBhsFm1SAsSLIteMn925hlxPUkOsjcjMyaEiQDr9s4w==",
+			"version": "4.1.17",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.17.tgz",
+			"integrity": "sha512-gsCimeG6BApj0SBecwa1Be+Z+JOJe46iy3B3m3A8jKJHf7eIihP76Is4LwLrbJ1ygoS7Vg73lfqzejmLOrazUA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/service-error-classification": "^4.0.6",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.8",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -4744,9 +5473,9 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
-			"integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+			"integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/abort-controller": "^4.0.4",
@@ -4857,17 +5586,17 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.4.tgz",
-			"integrity": "sha512-38Ivn1VoArWi+wvJeW6rGl9lcuViYjmGfaZaBgOlFEyoQSIl2Rnr3uOWzwu3FE8NIvHflQVkwbveMQxBAEbd1A==",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.8.tgz",
+			"integrity": "sha512-pcW691/lx7V54gE+dDGC26nxz8nrvnvRSCJaIYD6XLPpOInEZeKdV/SpSux+wqeQ4Ine7LJQu8uxMvobTIBK0w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.5.3",
-				"@smithy/middleware-endpoint": "^4.1.12",
+				"@smithy/core": "^3.7.1",
+				"@smithy/middleware-endpoint": "^4.1.16",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4964,13 +5693,13 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.20",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.20.tgz",
-			"integrity": "sha512-496BbDMx/8kQrvlhT0EsX7JM7yVpK7CACmG3LsqMX9RaJnF7M/OVlfbxoRceUp5o5S0HqBnV8/xGOX7MYCv2Gw==",
+			"version": "4.0.24",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.24.tgz",
+			"integrity": "sha512-UkQNgaQ+bidw1MgdgPO1z1k95W/v8Ej/5o/T/Is8PiVUYPspl/ZxV6WO/8DrzZQu5ULnmpB9CDdMSRwgRc21AA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.8",
 				"@smithy/types": "^4.3.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
@@ -4980,16 +5709,16 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.20",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.20.tgz",
-			"integrity": "sha512-QsGHToYvRCoMyJQr/bXLG7L+nXNxICpG5LI1lRL0wkdkvLIxP89r4O+LHLWI9UeLzylxJ7VPnsTR/ADJ+F71/w==",
+			"version": "4.0.24",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.24.tgz",
+			"integrity": "sha512-phvGi/15Z4MpuQibTLOYIumvLdXb+XIJu8TA55voGgboln85jytA3wiD7CkUE8SNcWqkkb+uptZKPiuFouX/7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/config-resolver": "^4.1.4",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.4",
+				"@smithy/smithy-client": "^4.4.8",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
 			},
@@ -5051,13 +5780,13 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
-			"integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
+			"integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/fetch-http-handler": "^5.1.0",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-buffer-from": "^4.0.0",
@@ -5272,9 +6001,9 @@
 			"optional": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.112",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
-			"integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+			"version": "18.19.120",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
+			"integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -5376,9 +6105,9 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
@@ -5397,9 +6126,9 @@
 			}
 		},
 		"node_modules/ai": {
-			"version": "4.3.16",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-4.3.16.tgz",
-			"integrity": "sha512-KUDwlThJ5tr2Vw0A1ZkbDKNME3wzWhuVfAOwIvFUzl1TPVDFAXDFTXio3p+jaKneB+dKNCvFFlolYmmgHttG1g==",
+			"version": "4.3.19",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+			"integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -5423,15 +6152,15 @@
 			}
 		},
 		"node_modules/ai-sdk-provider-gemini-cli": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/ai-sdk-provider-gemini-cli/-/ai-sdk-provider-gemini-cli-0.0.4.tgz",
-			"integrity": "sha512-rXxNM/+wVHL8Syf/SjyoVmFJgTMwLnVSPPhqkLzbP6JKBvp81qZfkBFQiI9l6VMF1ctb6L+iSdVNd0/G1pTVZg==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ai-sdk-provider-gemini-cli/-/ai-sdk-provider-gemini-cli-0.1.1.tgz",
+			"integrity": "sha512-fvX3n9jTt8JaTyc+qDv5Og0H4NQMpS6B1VdaTT71AN2F+3u2Bz9/OSd7ATokrV2Rmv+ZlEnUCmJnke58zHXUSQ==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"@ai-sdk/provider": "^1.1.3",
 				"@ai-sdk/provider-utils": "^2.2.8",
-				"@google/gemini-cli-core": "^0.1.4",
+				"@google/gemini-cli-core": "^0.1.13",
 				"@google/genai": "^1.7.0",
 				"google-auth-library": "^9.0.0",
 				"zod": "^3.23.8",
@@ -5839,9 +6568,9 @@
 			}
 		},
 		"node_modules/bignumber.js": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
-			"integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -6112,9 +6841,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001726",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
-			"integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+			"version": "1.0.30001727",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+			"integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -6680,9 +7409,9 @@
 			}
 		},
 		"node_modules/decimal.js": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-			"integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"license": "MIT"
 		},
 		"node_modules/dedent": {
@@ -6968,9 +7697,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.174",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.174.tgz",
-			"integrity": "sha512-HE43yYdUUiJVjewV2A9EP8o89Kb4AqMKplMQP2IxEPUws1Etu/ZkdsgUDabUZ/WmbP4ZbvJDOcunvbBUPPIfmw==",
+			"version": "1.5.189",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
+			"integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -7098,9 +7827,9 @@
 			}
 		},
 		"node_modules/es-toolkit": {
-			"version": "1.39.5",
-			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
-			"integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
+			"version": "1.39.7",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
+			"integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -7109,9 +7838,9 @@
 			]
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-			"integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+			"version": "0.25.8",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
+			"integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -7122,31 +7851,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.5",
-				"@esbuild/android-arm": "0.25.5",
-				"@esbuild/android-arm64": "0.25.5",
-				"@esbuild/android-x64": "0.25.5",
-				"@esbuild/darwin-arm64": "0.25.5",
-				"@esbuild/darwin-x64": "0.25.5",
-				"@esbuild/freebsd-arm64": "0.25.5",
-				"@esbuild/freebsd-x64": "0.25.5",
-				"@esbuild/linux-arm": "0.25.5",
-				"@esbuild/linux-arm64": "0.25.5",
-				"@esbuild/linux-ia32": "0.25.5",
-				"@esbuild/linux-loong64": "0.25.5",
-				"@esbuild/linux-mips64el": "0.25.5",
-				"@esbuild/linux-ppc64": "0.25.5",
-				"@esbuild/linux-riscv64": "0.25.5",
-				"@esbuild/linux-s390x": "0.25.5",
-				"@esbuild/linux-x64": "0.25.5",
-				"@esbuild/netbsd-arm64": "0.25.5",
-				"@esbuild/netbsd-x64": "0.25.5",
-				"@esbuild/openbsd-arm64": "0.25.5",
-				"@esbuild/openbsd-x64": "0.25.5",
-				"@esbuild/sunos-x64": "0.25.5",
-				"@esbuild/win32-arm64": "0.25.5",
-				"@esbuild/win32-ia32": "0.25.5",
-				"@esbuild/win32-x64": "0.25.5"
+				"@esbuild/aix-ppc64": "0.25.8",
+				"@esbuild/android-arm": "0.25.8",
+				"@esbuild/android-arm64": "0.25.8",
+				"@esbuild/android-x64": "0.25.8",
+				"@esbuild/darwin-arm64": "0.25.8",
+				"@esbuild/darwin-x64": "0.25.8",
+				"@esbuild/freebsd-arm64": "0.25.8",
+				"@esbuild/freebsd-x64": "0.25.8",
+				"@esbuild/linux-arm": "0.25.8",
+				"@esbuild/linux-arm64": "0.25.8",
+				"@esbuild/linux-ia32": "0.25.8",
+				"@esbuild/linux-loong64": "0.25.8",
+				"@esbuild/linux-mips64el": "0.25.8",
+				"@esbuild/linux-ppc64": "0.25.8",
+				"@esbuild/linux-riscv64": "0.25.8",
+				"@esbuild/linux-s390x": "0.25.8",
+				"@esbuild/linux-x64": "0.25.8",
+				"@esbuild/netbsd-arm64": "0.25.8",
+				"@esbuild/netbsd-x64": "0.25.8",
+				"@esbuild/openbsd-arm64": "0.25.8",
+				"@esbuild/openbsd-x64": "0.25.8",
+				"@esbuild/openharmony-arm64": "0.25.8",
+				"@esbuild/sunos-x64": "0.25.8",
+				"@esbuild/win32-arm64": "0.25.8",
+				"@esbuild/win32-ia32": "0.25.8",
+				"@esbuild/win32-x64": "0.25.8"
 			}
 		},
 		"node_modules/escalade": {
@@ -7219,12 +7949,12 @@
 			}
 		},
 		"node_modules/eventsource-parser": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
-			"integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+			"integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/execa": {
@@ -7422,39 +8152,35 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+			"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/naturalintelligence"
 				}
 			],
 			"license": "MIT",
 			"dependencies": {
-				"strnum": "^1.0.5"
+				"strnum": "^2.1.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
 			}
 		},
 		"node_modules/fastmcp": {
-			"version": "3.8.4",
-			"resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.8.4.tgz",
-			"integrity": "sha512-gvZ2JOwFtbvU6By9KzZHs1dfh+VKHO187tdOK/lWKTBnKwdHIMFKPqsP4w35qpwynS4hyJRGJOuG3kFTQcP7EQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.10.0.tgz",
+			"integrity": "sha512-oFHQKrzrIzbZcIlDMmzaYH6w0qlQiZ7Ly5ogMII3y+ujhmkksmrcc3cObVMVEtBiupwLXOpF8oVE+wZYbYQ3sw==",
 			"license": "MIT",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.15.0",
+				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@standard-schema/spec": "^1.0.0",
 				"execa": "^9.6.0",
 				"file-type": "^21.0.0",
 				"fuse.js": "^7.1.0",
-				"mcp-proxy": "^5.3.0",
+				"mcp-proxy": "^5.4.0",
 				"strict-event-emitter-types": "^2.0.0",
 				"undici": "^7.11.0",
 				"uri-templates": "^0.2.0",
@@ -7681,9 +8407,9 @@
 			"license": "MIT"
 		},
 		"node_modules/figlet": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
-			"integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.2.tgz",
+			"integrity": "sha512-iPCpE9B/rOcjewIzDnagP9F2eySzGeHReX8WlrZQJkqFBk2wvq8gY0c6U6Hd2y9HnX1LQcYSeP7aEHoPt6sVKQ==",
 			"license": "MIT",
 			"bin": {
 				"figlet": "bin/index.js"
@@ -7788,9 +8514,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -8105,16 +8831,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/globby": {
@@ -8660,17 +9376,17 @@
 			}
 		},
 		"node_modules/inquirer": {
-			"version": "12.6.3",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.6.3.tgz",
-			"integrity": "sha512-eX9beYAjr1MqYsIjx1vAheXsRk1jbZRvHLcBu5nA9wX0rXR1IfCZLnVLp4Ym4mrhqmh7AuANwcdtgQ291fZDfQ==",
+			"version": "12.8.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.8.2.tgz",
+			"integrity": "sha512-oBDL9f4+cDambZVJdfJu2M5JQfvaug9lbo6fKDlFV40i8t3FGA1Db67ov5Hp5DInG4zmXhHWTSnlXBntnJ7GMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/prompts": "^7.5.3",
-				"@inquirer/type": "^3.0.7",
+				"@inquirer/core": "^10.1.15",
+				"@inquirer/prompts": "^7.7.1",
+				"@inquirer/type": "^3.0.8",
 				"ansi-escapes": "^4.3.2",
 				"mute-stream": "^2.0.0",
-				"run-async": "^3.0.0",
+				"run-async": "^4.0.5",
 				"rxjs": "^7.8.2"
 			},
 			"engines": {
@@ -10727,9 +11443,9 @@
 			}
 		},
 		"node_modules/mcp-proxy": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-5.3.0.tgz",
-			"integrity": "sha512-dknV3cAOdxJXampGqeG56G1UWFWf+2Msmh+r7WbTBqrZXaOFiZh6TSmd3Eig2+QQ5eCkLjrdpVKyjnisUSkizA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-5.4.0.tgz",
+			"integrity": "sha512-9B3BKPsm8uRWKRqBDB0w0pZ9O2/02Q6McdZDeThaNnkctT/HDulIER+qLThsp4kgVz5+iSYhnFN9eHEB6sYegQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.13.2",
@@ -11236,16 +11952,16 @@
 			}
 		},
 		"node_modules/open": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-			"integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"default-browser": "^5.2.1",
 				"define-lazy-prop": "^3.0.0",
 				"is-inside-container": "^1.0.0",
-				"is-wsl": "^3.1.0"
+				"wsl-utils": "^0.1.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -11717,9 +12433,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.1.tgz",
-			"integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -12237,9 +12953,9 @@
 			}
 		},
 		"node_modules/run-async": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.5.tgz",
+			"integrity": "sha512-oN9GTgxUNDBumHTTDmQ8dep6VIJbgj9S3dPP+9XylVLIK4xB9XTXtKWROd5pnhdXR9k0EgO1JRcNh0T+Ny2FsA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -12854,9 +13570,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-			"integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+			"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
 			"funding": [
 				{
 					"type": "github",
@@ -12866,9 +13582,9 @@
 			"license": "MIT"
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
-			"integrity": "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.2.tgz",
+			"integrity": "sha512-or9w505RhhY66+uoe5YOC5QO/bRuATaoim3XTh+pGKx5VMWi/HDhMKuCjDLsLJouU2zg9Hf1nLPcNW7IHv80kQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
@@ -12882,9 +13598,9 @@
 			}
 		},
 		"node_modules/superagent": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
-			"integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.2.tgz",
+			"integrity": "sha512-vWMq11OwWCC84pQaFPzF/VO3BrjkCeewuvJgt1jfV0499Z1QSAWN4EqfMM5WlFDDX9/oP8JjlDKpblrmEoyu4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12941,14 +13657,14 @@
 			"license": "MIT"
 		},
 		"node_modules/supertest": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.1.tgz",
-			"integrity": "sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.3.tgz",
+			"integrity": "sha512-ORY0gPa6ojmg/C74P/bDoS21WL6FMXq5I8mawkEz30/zkwdu0gOeqstFy316vHG6OKxqQ+IbGneRemHI8WraEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"methods": "^1.1.2",
-				"superagent": "^10.2.1"
+				"superagent": "^10.2.2"
 			},
 			"engines": {
 				"node": ">=14.18.0"
@@ -12980,9 +13696,9 @@
 			}
 		},
 		"node_modules/swr": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
-			"integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+			"integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
 			"license": "MIT",
 			"dependencies": {
 				"dequal": "^2.0.3",
@@ -13115,9 +13831,9 @@
 			}
 		},
 		"node_modules/token-types": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
-			"integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.3.tgz",
+			"integrity": "sha512-IKJ6EzuPPWtKtEIEPpIdXv9j5j2LGJEYk0CKY2efgKoYKLBiZdh6iQkLVBow/CB3phyWAWCyk+bZeaimJn6uRQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0",
@@ -13231,9 +13947,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
-			"integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
+			"integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -13601,9 +14317,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.18.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -13620,6 +14336,22 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xsschema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
 				"@inquirer/search": "^3.0.15",
 				"@openrouter/ai-sdk-provider": "^0.4.5",
 				"ai": "^4.3.10",
-				"ai-sdk-provider-gemini-cli": "0.1.1",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"boxen": "^8.0.1",
@@ -93,9 +92,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/amazon-bedrock": {
-			"version": "2.2.12",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-2.2.12.tgz",
-			"integrity": "sha512-m8gARnh45pr1s08Uu4J/Pm8913mwJPejPOm59b+kUqMsP9ilhUtH/bp8432Ra/v+vHuMoBrglG2ZvXtctAaH2g==",
+			"version": "2.2.10",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-2.2.10.tgz",
+			"integrity": "sha512-icLGO7Q0NinnHIPgT+y1QjHVwH4HwV+brWbvM+FfCG2Afpa89PyKa3Ret91kGjZpBgM/xnj1B7K5eM+rRlsXQA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -128,12 +127,12 @@
 			}
 		},
 		"node_modules/@ai-sdk/azure": {
-			"version": "1.3.24",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-1.3.24.tgz",
-			"integrity": "sha512-6zOG8mwmd8esSL/L9oYFZSyZWORRTxuG6on9A3RdPe7MRJ607Q6BWsuvul79kecbLf5xQ4bfP7LzXaBizsd8OA==",
+			"version": "1.3.23",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-1.3.23.tgz",
+			"integrity": "sha512-vpsaPtU24RBVk/IMM5UylR/N4RtAuL2NZLWc7LJ3tvMTHu6pI46a7w+1qIwR3F6yO9ehWR8qvfLaBefJNFxaVw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/openai": "1.3.23",
+				"@ai-sdk/openai": "1.3.22",
 				"@ai-sdk/provider": "1.1.3",
 				"@ai-sdk/provider-utils": "2.2.8"
 			},
@@ -145,9 +144,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/google": {
-			"version": "1.2.22",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.22.tgz",
-			"integrity": "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==",
+			"version": "1.2.19",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.19.tgz",
+			"integrity": "sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -161,13 +160,13 @@
 			}
 		},
 		"node_modules/@ai-sdk/google-vertex": {
-			"version": "2.2.27",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-2.2.27.tgz",
-			"integrity": "sha512-iDGX/2yrU4OOL1p/ENpfl3MWxuqp9/bE22Z8Ip4DtLCUx6ismUNtrKO357igM1/3jrM6t9C6egCPniHqBsHOJA==",
+			"version": "2.2.24",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-2.2.24.tgz",
+			"integrity": "sha512-zi1ZN6jQEBRke/WMbZv0YkeqQ3nOs8ihxjVh/8z1tUn+S1xgRaYXf4+r6+Izh2YqVHIMNwjhUYryQRBGq20cgQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/anthropic": "1.2.12",
-				"@ai-sdk/google": "1.2.22",
+				"@ai-sdk/google": "1.2.19",
 				"@ai-sdk/provider": "1.1.3",
 				"@ai-sdk/provider-utils": "2.2.8",
 				"google-auth-library": "^9.15.0"
@@ -212,9 +211,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/openai": {
-			"version": "1.3.23",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.23.tgz",
-			"integrity": "sha512-86U7rFp8yacUAOE/Jz8WbGcwMCqWvjK33wk5DXkfnAOEn3mx2r7tNSJdjukQFZbAK97VMXGPPHxF+aEARDXRXQ==",
+			"version": "1.3.22",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.22.tgz",
+			"integrity": "sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -228,9 +227,9 @@
 			}
 		},
 		"node_modules/@ai-sdk/openai-compatible": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-0.2.16.tgz",
-			"integrity": "sha512-LkvfcM8slJedRyJa/MiMiaOzcMjV1zNDwzTHEGz7aAsgsQV0maLfmJRi/nuSwf5jmp0EouC+JXXDUj2l94HgQw==",
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-0.2.14.tgz",
+			"integrity": "sha512-icjObfMCHKSIbywijaoLdZ1nSnuRnWgMEMLgwoxPJgxsUHMx0aVORnsLUid4SPtdhHI3X2masrt6iaEQLvOSFw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -330,12 +329,12 @@
 			}
 		},
 		"node_modules/@ai-sdk/xai": {
-			"version": "1.2.18",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-1.2.18.tgz",
-			"integrity": "sha512-T70WEu+UKXD/Fdj9ck+ujIqUp5ru06mJ/7usePXeXL5EeTi8KXevXF9AMIDdhyD5MZPT2jI8t19lEr8Bhuh/Bg==",
+			"version": "1.2.16",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-1.2.16.tgz",
+			"integrity": "sha512-UOZT8td9PWwMi2dF9a0U44t/Oltmf6QmIJdSvrOcLG4mvpRc1UJn6YJaR0HtXs3YnW6SvY1zRdIDrW4GFpv4NA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/openai-compatible": "0.2.16",
+				"@ai-sdk/openai-compatible": "0.2.14",
 				"@ai-sdk/provider": "1.1.3",
 				"@ai-sdk/provider-utils": "2.2.8"
 			},
@@ -375,9 +374,10 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-code": {
-			"version": "1.0.57",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.57.tgz",
-			"integrity": "sha512-zMymGZzjG+JO9iKC5N5pAy8AxyHIMPCL6U3HYCR3vCj5M+Y0s3GAMma6GkvCXWFixRN6KSZItKw3HbQiaIBYlw==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.34.tgz",
+			"integrity": "sha512-9mQd8hodE5/RxZnsWUCdLzqGUKuCzBczrfc2QfxrNSlvUFpOgTzjT1Zlww2vW9v0K1e5K9g1o08apqPl/QPmpw==",
+			"hasInstallScript": true,
 			"license": "SEE LICENSE IN README.md",
 			"optional": true,
 			"bin": {
@@ -550,45 +550,45 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.848.0.tgz",
-			"integrity": "sha512-Sin8aLnA81MgvUJrfQsBIQ1UJg4klWT3NuYYjExLiVQf3A0/F7Bfx1HTIyWXtSchY4QgGr7MMone0/0KZ4Dy9g==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.835.0.tgz",
+			"integrity": "sha512-M28XmziapO/4dJxY5OW+KLAw5XTXOg9N+p7TiBvcE9kT0uDKLL5ypNG0ChW+7b8mXrMGA6wpVBb2MWDgf+6I6w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/credential-provider-node": "3.848.0",
-				"@aws-sdk/middleware-host-header": "3.840.0",
-				"@aws-sdk/middleware-logger": "3.840.0",
-				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.848.0",
-				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.848.0",
-				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.848.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/credential-provider-node": "3.835.0",
+				"@aws-sdk/middleware-host-header": "3.821.0",
+				"@aws-sdk/middleware-logger": "3.821.0",
+				"@aws-sdk/middleware-recursion-detection": "3.821.0",
+				"@aws-sdk/middleware-user-agent": "3.835.0",
+				"@aws-sdk/region-config-resolver": "3.821.0",
+				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/util-endpoints": "3.828.0",
+				"@aws-sdk/util-user-agent-browser": "3.821.0",
+				"@aws-sdk/util-user-agent-node": "3.835.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.7.0",
-				"@smithy/fetch-http-handler": "^5.1.0",
+				"@smithy/core": "^3.5.3",
+				"@smithy/fetch-http-handler": "^5.0.4",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.15",
-				"@smithy/middleware-retry": "^4.1.16",
+				"@smithy/middleware-endpoint": "^4.1.12",
+				"@smithy/middleware-retry": "^4.1.13",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.1.0",
+				"@smithy/node-http-handler": "^4.0.6",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.7",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.23",
-				"@smithy/util-defaults-mode-node": "^4.0.23",
+				"@smithy/util-defaults-mode-browser": "^4.0.20",
+				"@smithy/util-defaults-mode-node": "^4.0.20",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -600,44 +600,44 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
-			"integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.835.0.tgz",
+			"integrity": "sha512-4J19IcBKU5vL8yw/YWEvbwEGcmCli0rpRyxG53v0K5/3weVPxVBbKfkWcjWVQ4qdxNz2uInfbTde4BRBFxWllQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/middleware-host-header": "3.840.0",
-				"@aws-sdk/middleware-logger": "3.840.0",
-				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.848.0",
-				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.848.0",
-				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.848.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/middleware-host-header": "3.821.0",
+				"@aws-sdk/middleware-logger": "3.821.0",
+				"@aws-sdk/middleware-recursion-detection": "3.821.0",
+				"@aws-sdk/middleware-user-agent": "3.835.0",
+				"@aws-sdk/region-config-resolver": "3.821.0",
+				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/util-endpoints": "3.828.0",
+				"@aws-sdk/util-user-agent-browser": "3.821.0",
+				"@aws-sdk/util-user-agent-node": "3.835.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.7.0",
-				"@smithy/fetch-http-handler": "^5.1.0",
+				"@smithy/core": "^3.5.3",
+				"@smithy/fetch-http-handler": "^5.0.4",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.15",
-				"@smithy/middleware-retry": "^4.1.16",
+				"@smithy/middleware-endpoint": "^4.1.12",
+				"@smithy/middleware-retry": "^4.1.13",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.1.0",
+				"@smithy/node-http-handler": "^4.0.6",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.7",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.23",
-				"@smithy/util-defaults-mode-node": "^4.0.23",
+				"@smithy/util-defaults-mode-browser": "^4.0.20",
+				"@smithy/util-defaults-mode-node": "^4.0.20",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -649,25 +649,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.846.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
-			"integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.835.0.tgz",
+			"integrity": "sha512-7mnf4xbaLI8rkDa+w6fUU48dG6yDuOgLXEPe4Ut3SbMp1ceJBPMozNHbCwkiyHk3HpxZYf8eVy0wXhJMrxZq5w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/types": "3.821.0",
 				"@aws-sdk/xml-builder": "3.821.0",
-				"@smithy/core": "^3.7.0",
+				"@smithy/core": "^3.5.3",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/signature-v4": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.7",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-utf8": "^4.0.0",
-				"fast-xml-parser": "5.2.5",
+				"fast-xml-parser": "4.4.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -675,13 +675,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.848.0.tgz",
-			"integrity": "sha512-2cm/Ye6ktagW1h7FmF4sgo8STZyBr2+0+L9lr/veuPKZVWoi/FyhJR3l0TtKrd8z78no9P5xbsGUmxoDLtsxiw==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.835.0.tgz",
+			"integrity": "sha512-1UOngj7DwRyeUB6FbeAF2ryVjGWRtmLfxltQKcJi41R5O8WN3bq8jgNY+zz0hdUVqVFoDot5yCJo87CqNJ/mSQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/client-cognito-identity": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -691,13 +691,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.846.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
-			"integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.835.0.tgz",
+			"integrity": "sha512-U9LFWe7+ephNyekpUbzT7o6SmJTmn6xkrPkE0D7pbLojnPVi/8SZKyjtgQGIsAv+2kFkOCqMOIYUKd/0pE7uew==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -707,20 +707,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.846.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
-			"integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.835.0.tgz",
+			"integrity": "sha512-jCdNEsQklil7frDm/BuVKl4ubVoQHRbV6fnkOjmxAJz0/v7cR8JP0jBGlqKKzh3ROh5/vo1/5VUZbCTLpc9dSg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/fetch-http-handler": "^5.1.0",
-				"@smithy/node-http-handler": "^4.1.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
+				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/node-http-handler": "^4.0.6",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.7",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.3",
+				"@smithy/util-stream": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -728,19 +728,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
-			"integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.835.0.tgz",
+			"integrity": "sha512-nqF6rYRAnJedmvDfrfKygzyeADcduDvtvn7GlbQQbXKeR2l7KnCdhuxHa0FALLvspkHiBx7NtInmvnd5IMuWsw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/credential-provider-env": "3.846.0",
-				"@aws-sdk/credential-provider-http": "3.846.0",
-				"@aws-sdk/credential-provider-process": "3.846.0",
-				"@aws-sdk/credential-provider-sso": "3.848.0",
-				"@aws-sdk/credential-provider-web-identity": "3.848.0",
-				"@aws-sdk/nested-clients": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/credential-provider-env": "3.835.0",
+				"@aws-sdk/credential-provider-http": "3.835.0",
+				"@aws-sdk/credential-provider-process": "3.835.0",
+				"@aws-sdk/credential-provider-sso": "3.835.0",
+				"@aws-sdk/credential-provider-web-identity": "3.835.0",
+				"@aws-sdk/nested-clients": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -752,18 +752,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
-			"integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.835.0.tgz",
+			"integrity": "sha512-77B8elyZlaEd7vDYyCnYtVLuagIBwuJ0AQ98/36JMGrYX7TT8UVAhiDAfVe0NdUOMORvDNFfzL06VBm7wittYw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.846.0",
-				"@aws-sdk/credential-provider-http": "3.846.0",
-				"@aws-sdk/credential-provider-ini": "3.848.0",
-				"@aws-sdk/credential-provider-process": "3.846.0",
-				"@aws-sdk/credential-provider-sso": "3.848.0",
-				"@aws-sdk/credential-provider-web-identity": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/credential-provider-env": "3.835.0",
+				"@aws-sdk/credential-provider-http": "3.835.0",
+				"@aws-sdk/credential-provider-ini": "3.835.0",
+				"@aws-sdk/credential-provider-process": "3.835.0",
+				"@aws-sdk/credential-provider-sso": "3.835.0",
+				"@aws-sdk/credential-provider-web-identity": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -775,13 +775,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.846.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
-			"integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.835.0.tgz",
+			"integrity": "sha512-qXkTt5pAhSi2Mp9GdgceZZFo/cFYrA735efqi/Re/nf0lpqBp8mRM8xv+iAaPHV4Q10q0DlkbEidT1DhxdT/+w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -792,15 +792,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
-			"integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.835.0.tgz",
+			"integrity": "sha512-jAiEMryaPFXayYGszrc7NcgZA/zrrE3QvvvUBh/Udasg+9Qp5ZELdJCm/p98twNyY9n5i6Ex6VgvdxZ7+iEheQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.848.0",
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/token-providers": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/client-sso": "3.835.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/token-providers": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -811,14 +811,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
-			"integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.835.0.tgz",
+			"integrity": "sha512-zfleEFXDLlcJ7cyfS4xSyCRpd8SVlYZfH3rp0pg2vPYKbnmXVE0r+gPIYXl4L+Yz4A2tizYl63nKCNdtbxadog==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/nested-clients": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/nested-clients": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -828,25 +828,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.848.0.tgz",
-			"integrity": "sha512-lRDuU05YC+r/1JmRULngJQli7scP5hmq0/7D+xw1s8eRM0H2auaH7LQFlq/SLxQZLMkVNPCrmsug3b3KcLj1NA==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.835.0.tgz",
+			"integrity": "sha512-7FcMN2rWpLb4qlU4tzfWMcLbP0OKXy28llwBEX3gtoKhjQCxK8KPg2tg8BoezWNe1PJLuQcfzVj1k/CPLH4EaQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.848.0",
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.848.0",
-				"@aws-sdk/credential-provider-env": "3.846.0",
-				"@aws-sdk/credential-provider-http": "3.846.0",
-				"@aws-sdk/credential-provider-ini": "3.848.0",
-				"@aws-sdk/credential-provider-node": "3.848.0",
-				"@aws-sdk/credential-provider-process": "3.846.0",
-				"@aws-sdk/credential-provider-sso": "3.848.0",
-				"@aws-sdk/credential-provider-web-identity": "3.848.0",
-				"@aws-sdk/nested-clients": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/client-cognito-identity": "3.835.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.835.0",
+				"@aws-sdk/credential-provider-env": "3.835.0",
+				"@aws-sdk/credential-provider-http": "3.835.0",
+				"@aws-sdk/credential-provider-ini": "3.835.0",
+				"@aws-sdk/credential-provider-node": "3.835.0",
+				"@aws-sdk/credential-provider-process": "3.835.0",
+				"@aws-sdk/credential-provider-sso": "3.835.0",
+				"@aws-sdk/credential-provider-web-identity": "3.835.0",
+				"@aws-sdk/nested-clients": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.7.0",
+				"@smithy/core": "^3.5.3",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
@@ -858,12 +858,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.840.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
-			"integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
+			"version": "3.821.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
+			"integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -873,12 +873,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.840.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
-			"integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
+			"version": "3.821.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
+			"integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
 			},
@@ -887,12 +887,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.840.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
-			"integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
+			"version": "3.821.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
+			"integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -902,15 +902,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
-			"integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.835.0.tgz",
+			"integrity": "sha512-2gmAYygeE/gzhyF2XlkcbMLYFTbNfV61n+iCFa/ZofJHXYE+RxSyl5g4kujLEs7bVZHmjQZJXhprVSkGccq3/w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.848.0",
-				"@smithy/core": "^3.7.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/util-endpoints": "3.828.0",
+				"@smithy/core": "^3.5.3",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -920,44 +920,44 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
-			"integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.835.0.tgz",
+			"integrity": "sha512-UtmOO0U5QkicjCEv+B32qqRAnS7o2ZkZhC+i3ccH1h3fsfaBshpuuNBwOYAzRCRBeKW5fw3ANFrV/+2FTp4jWg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/middleware-host-header": "3.840.0",
-				"@aws-sdk/middleware-logger": "3.840.0",
-				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.848.0",
-				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.848.0",
-				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.848.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/middleware-host-header": "3.821.0",
+				"@aws-sdk/middleware-logger": "3.821.0",
+				"@aws-sdk/middleware-recursion-detection": "3.821.0",
+				"@aws-sdk/middleware-user-agent": "3.835.0",
+				"@aws-sdk/region-config-resolver": "3.821.0",
+				"@aws-sdk/types": "3.821.0",
+				"@aws-sdk/util-endpoints": "3.828.0",
+				"@aws-sdk/util-user-agent-browser": "3.821.0",
+				"@aws-sdk/util-user-agent-node": "3.835.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.7.0",
-				"@smithy/fetch-http-handler": "^5.1.0",
+				"@smithy/core": "^3.5.3",
+				"@smithy/fetch-http-handler": "^5.0.4",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.15",
-				"@smithy/middleware-retry": "^4.1.16",
+				"@smithy/middleware-endpoint": "^4.1.12",
+				"@smithy/middleware-retry": "^4.1.13",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.1.0",
+				"@smithy/node-http-handler": "^4.0.6",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.7",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.23",
-				"@smithy/util-defaults-mode-node": "^4.0.23",
+				"@smithy/util-defaults-mode-browser": "^4.0.20",
+				"@smithy/util-defaults-mode-node": "^4.0.20",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -969,12 +969,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.840.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
-			"integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
+			"version": "3.821.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
+			"integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-config-provider": "^4.0.0",
@@ -986,14 +986,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
-			"integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.835.0.tgz",
+			"integrity": "sha512-zN1P3BE+Rv7w7q/CDA8VCQox6SE9QTn0vDtQ47AHA3eXZQQgYzBqgoLgJxR9rKKBIRGZqInJa/VRskLL95VliQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.846.0",
-				"@aws-sdk/nested-clients": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/core": "3.835.0",
+				"@aws-sdk/nested-clients": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -1004,9 +1004,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.840.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
-			"integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+			"version": "3.821.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
+			"integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.3.1",
@@ -1017,14 +1017,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
-			"integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
+			"version": "3.828.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
+			"integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/types": "^4.3.1",
-				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-endpoints": "^3.0.6",
 				"tslib": "^2.6.2"
 			},
@@ -1045,25 +1044,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.840.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
-			"integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
+			"version": "3.821.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
+			"integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/types": "^4.3.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.848.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
-			"integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
+			"version": "3.835.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.835.0.tgz",
+			"integrity": "sha512-gY63QZ4W5w9JYHYuqvUxiVGpn7IbCt1ODPQB0ZZwGGr3WRmK+yyZxCtFjbYhEQDQLgTWpf8YgVxgQLv2ps0PJg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.848.0",
-				"@aws-sdk/types": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.835.0",
+				"@aws-sdk/types": "3.821.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -1109,9 +1108,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
+			"integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1119,22 +1118,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-			"integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+			"version": "7.27.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
+			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
+				"@babel/generator": "^7.27.3",
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.6",
-				"@babel/parser": "^7.28.0",
+				"@babel/helpers": "^7.27.4",
+				"@babel/parser": "^7.27.4",
 				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.0",
-				"@babel/types": "^7.28.0",
+				"@babel/traverse": "^7.27.4",
+				"@babel/types": "^7.27.3",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -1185,16 +1184,16 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-			"integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+			"integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.0",
-				"@babel/types": "^7.28.0",
-				"@jridgewell/gen-mapping": "^0.3.12",
-				"@jridgewell/trace-mapping": "^0.3.28",
+				"@babel/parser": "^7.27.5",
+				"@babel/types": "^7.27.3",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
@@ -1236,16 +1235,6 @@
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
@@ -1335,13 +1324,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-			"integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.0"
+				"@babel/types": "^7.27.3"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1615,19 +1604,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-			"integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+			"version": "7.27.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.0",
+				"@babel/generator": "^7.27.3",
+				"@babel/parser": "^7.27.4",
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.0",
-				"debug": "^4.3.1"
+				"@babel/types": "^7.27.3",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1659,9 +1648,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-			"integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+			"version": "7.27.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+			"integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1724,57 +1713,6 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
 		"node_modules/@biomejs/cli-linux-x64": {
 			"version": "1.9.4",
 			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
@@ -1786,57 +1724,6 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=14.21.3"
@@ -2160,78 +2047,10 @@
 				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
-			"integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
-			"integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
-			"integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
-			"integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
-			"integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+			"integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2240,363 +2059,6 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
-			"integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
-			"integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
-			"integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
-			"integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
-			"integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
-			"integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
-			"integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
-			"integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
-			"integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
-			"integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
-			"integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
-			"integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
-			"integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
-			"integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
-			"integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
-			"integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
-			"integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
-			"integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
-			"integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
-			"integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
-			"integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=18"
@@ -2946,28 +2408,6 @@
 				"@img/sharp-libvips-darwin-arm64": "1.0.4"
 			}
 		},
-		"node_modules/@img/sharp-darwin-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-			"integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.0.4"
-			}
-		},
 		"node_modules/@img/sharp-libvips-darwin-arm64": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
@@ -2984,164 +2424,15 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-			"integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-			"integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-			"cpu": [
-				"arm"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-			"integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-			"integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-			"integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.0.5"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-			"integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-linux-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-			"integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-win32-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-			"integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0 AND LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
-			"integrity": "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
+			"integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/figures": "^1.0.13",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
@@ -3158,13 +2449,13 @@
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "5.1.14",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
-			"integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+			"version": "5.1.12",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
+			"integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/type": "^3.0.8"
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3179,13 +2470,13 @@
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "10.1.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-			"integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+			"version": "10.1.13",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
+			"integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/figures": "^1.0.13",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
 				"ansi-escapes": "^4.3.2",
 				"cli-width": "^4.1.0",
 				"mute-stream": "^2.0.0",
@@ -3206,13 +2497,13 @@
 			}
 		},
 		"node_modules/@inquirer/editor": {
-			"version": "4.2.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.15.tgz",
-			"integrity": "sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
+			"integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
 				"external-editor": "^3.1.0"
 			},
 			"engines": {
@@ -3228,13 +2519,13 @@
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "4.0.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
-			"integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
+			"version": "4.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
+			"integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -3250,22 +2541,22 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-			"integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
+			"integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
-			"integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
+			"integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/type": "^3.0.8"
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3280,13 +2571,13 @@
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
-			"integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
+			"integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/type": "^3.0.8"
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3301,13 +2592,13 @@
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "4.0.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
-			"integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
+			"version": "4.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
+			"integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
 				"ansi-escapes": "^4.3.2"
 			},
 			"engines": {
@@ -3323,21 +2614,21 @@
 			}
 		},
 		"node_modules/@inquirer/prompts": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.7.1.tgz",
-			"integrity": "sha512-XDxPrEWeWUBy8scAXzXuFY45r/q49R0g72bUzgQXZ1DY/xEFX+ESDMkTQolcb5jRBzaNJX2W8XQl6krMNDTjaA==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
+			"integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/checkbox": "^4.2.0",
-				"@inquirer/confirm": "^5.1.14",
-				"@inquirer/editor": "^4.2.15",
-				"@inquirer/expand": "^4.0.17",
-				"@inquirer/input": "^4.2.1",
-				"@inquirer/number": "^3.0.17",
-				"@inquirer/password": "^4.0.17",
-				"@inquirer/rawlist": "^4.1.5",
-				"@inquirer/search": "^3.0.17",
-				"@inquirer/select": "^4.3.1"
+				"@inquirer/checkbox": "^4.1.8",
+				"@inquirer/confirm": "^5.1.12",
+				"@inquirer/editor": "^4.2.13",
+				"@inquirer/expand": "^4.0.15",
+				"@inquirer/input": "^4.1.12",
+				"@inquirer/number": "^3.0.15",
+				"@inquirer/password": "^4.0.15",
+				"@inquirer/rawlist": "^4.1.3",
+				"@inquirer/search": "^3.0.15",
+				"@inquirer/select": "^4.2.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3352,13 +2643,13 @@
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
-			"integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
+			"integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -3374,14 +2665,14 @@
 			}
 		},
 		"node_modules/@inquirer/search": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.17.tgz",
-			"integrity": "sha512-CuBU4BAGFqRYors4TNCYzy9X3DpKtgIW4Boi0WNkm4Ei1hvY9acxKdBdyqzqBCEe4YxSdaQQsasJlFlUJNgojw==",
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
+			"integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/figures": "^1.0.13",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
@@ -3397,14 +2688,14 @@
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
-			"integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
+			"integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/figures": "^1.0.13",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
@@ -3421,9 +2712,9 @@
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-			"integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
+			"integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -4022,14 +3313,18 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.12",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-			"integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
 				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -4042,17 +3337,27 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-			"integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.29",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-			"integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4186,9 +3491,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.16.0.tgz",
-			"integrity": "sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.0.tgz",
+			"integrity": "sha512-67hnl/ROKdb03Vuu0YOr+baKTvf1/5YBHBm9KnZdjdAh8hjt4FRCPD5ucwxGB237sBpzlqQsLy1PFu7z/ekZ9Q==",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.6",
@@ -5258,9 +4563,9 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.1.tgz",
-			"integrity": "sha512-ExRCsHnXFtBPnM7MkfKBPcBBdHw1h/QS/cbNw4ho95qnyNHvnpmGbR39MIAv9KggTr5qSPxRSEL+hRXlyGyGQw==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
+			"integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/middleware-serde": "^4.0.8",
@@ -5269,7 +4574,7 @@
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-stream": "^4.2.3",
+				"@smithy/util-stream": "^4.2.2",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -5309,9 +4614,9 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
-			"integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
+			"integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/protocol-http": "^5.1.2",
@@ -5379,12 +4684,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.1.16",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.16.tgz",
-			"integrity": "sha512-plpa50PIGLqzMR2ANKAw2yOW5YKS626KYKqae3atwucbz4Ve4uQ9K9BEZxDLIFmCu7hKLcrq2zmj4a+PfmUV5w==",
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.12.tgz",
+			"integrity": "sha512-Piy/9UOjh5FtEXhybjPwyOHcC/pGHFknl2Gc/q1YbEkngxY6eQwvBvZTNamXpyDAHCuP3h+lymcVcdyO3WdGqQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.7.1",
+				"@smithy/core": "^3.5.3",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -5398,15 +4703,15 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.1.17",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.17.tgz",
-			"integrity": "sha512-gsCimeG6BApj0SBecwa1Be+Z+JOJe46iy3B3m3A8jKJHf7eIihP76Is4LwLrbJ1ygoS7Vg73lfqzejmLOrazUA==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.13.tgz",
+			"integrity": "sha512-5ILvPCJevTcGpl7wAvSV9HKbIGS2Wxz505d0b5dP9kmjBhsFm1SAsSLIteMn925hlxPUkOsjcjMyaEiQDr9s4w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/service-error-classification": "^4.0.6",
-				"@smithy/smithy-client": "^4.4.8",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -5473,9 +4778,9 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
-			"integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
+			"integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/abort-controller": "^4.0.4",
@@ -5586,17 +4891,17 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.8.tgz",
-			"integrity": "sha512-pcW691/lx7V54gE+dDGC26nxz8nrvnvRSCJaIYD6XLPpOInEZeKdV/SpSux+wqeQ4Ine7LJQu8uxMvobTIBK0w==",
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.4.tgz",
+			"integrity": "sha512-38Ivn1VoArWi+wvJeW6rGl9lcuViYjmGfaZaBgOlFEyoQSIl2Rnr3uOWzwu3FE8NIvHflQVkwbveMQxBAEbd1A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.7.1",
-				"@smithy/middleware-endpoint": "^4.1.16",
+				"@smithy/core": "^3.5.3",
+				"@smithy/middleware-endpoint": "^4.1.12",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.3",
+				"@smithy/util-stream": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5693,13 +4998,13 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.24",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.24.tgz",
-			"integrity": "sha512-UkQNgaQ+bidw1MgdgPO1z1k95W/v8Ej/5o/T/Is8PiVUYPspl/ZxV6WO/8DrzZQu5ULnmpB9CDdMSRwgRc21AA==",
+			"version": "4.0.20",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.20.tgz",
+			"integrity": "sha512-496BbDMx/8kQrvlhT0EsX7JM7yVpK7CACmG3LsqMX9RaJnF7M/OVlfbxoRceUp5o5S0HqBnV8/xGOX7MYCv2Gw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.8",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
@@ -5709,16 +5014,16 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.24",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.24.tgz",
-			"integrity": "sha512-phvGi/15Z4MpuQibTLOYIumvLdXb+XIJu8TA55voGgboln85jytA3wiD7CkUE8SNcWqkkb+uptZKPiuFouX/7g==",
+			"version": "4.0.20",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.20.tgz",
+			"integrity": "sha512-QsGHToYvRCoMyJQr/bXLG7L+nXNxICpG5LI1lRL0wkdkvLIxP89r4O+LHLWI9UeLzylxJ7VPnsTR/ADJ+F71/w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/config-resolver": "^4.1.4",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.8",
+				"@smithy/smithy-client": "^4.4.4",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
 			},
@@ -5780,13 +5085,13 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
-			"integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
+			"integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.1.0",
-				"@smithy/node-http-handler": "^4.1.0",
+				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/node-http-handler": "^4.0.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-buffer-from": "^4.0.0",
@@ -6001,9 +5306,9 @@
 			"optional": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.120",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.120.tgz",
-			"integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+			"version": "18.19.112",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+			"integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -6105,9 +5410,9 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
@@ -6126,9 +5431,9 @@
 			}
 		},
 		"node_modules/ai": {
-			"version": "4.3.19",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-			"integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+			"version": "4.3.16",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-4.3.16.tgz",
+			"integrity": "sha512-KUDwlThJ5tr2Vw0A1ZkbDKNME3wzWhuVfAOwIvFUzl1TPVDFAXDFTXio3p+jaKneB+dKNCvFFlolYmmgHttG1g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -6568,9 +5873,9 @@
 			}
 		},
 		"node_modules/bignumber.js": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+			"integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -6841,9 +6146,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001727",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-			"integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+			"version": "1.0.30001726",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+			"integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
 			"dev": true,
 			"funding": [
 				{
@@ -7409,9 +6714,9 @@
 			}
 		},
 		"node_modules/decimal.js": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+			"integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
 			"license": "MIT"
 		},
 		"node_modules/dedent": {
@@ -7697,9 +7002,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.189",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
-			"integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
+			"version": "1.5.174",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.174.tgz",
+			"integrity": "sha512-HE43yYdUUiJVjewV2A9EP8o89Kb4AqMKplMQP2IxEPUws1Etu/ZkdsgUDabUZ/WmbP4ZbvJDOcunvbBUPPIfmw==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -7827,9 +7132,9 @@
 			}
 		},
 		"node_modules/es-toolkit": {
-			"version": "1.39.7",
-			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
-			"integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==",
+			"version": "1.39.5",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+			"integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -7838,9 +7143,9 @@
 			]
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
-			"integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+			"integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -7851,32 +7156,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.8",
-				"@esbuild/android-arm": "0.25.8",
-				"@esbuild/android-arm64": "0.25.8",
-				"@esbuild/android-x64": "0.25.8",
-				"@esbuild/darwin-arm64": "0.25.8",
-				"@esbuild/darwin-x64": "0.25.8",
-				"@esbuild/freebsd-arm64": "0.25.8",
-				"@esbuild/freebsd-x64": "0.25.8",
-				"@esbuild/linux-arm": "0.25.8",
-				"@esbuild/linux-arm64": "0.25.8",
-				"@esbuild/linux-ia32": "0.25.8",
-				"@esbuild/linux-loong64": "0.25.8",
-				"@esbuild/linux-mips64el": "0.25.8",
-				"@esbuild/linux-ppc64": "0.25.8",
-				"@esbuild/linux-riscv64": "0.25.8",
-				"@esbuild/linux-s390x": "0.25.8",
-				"@esbuild/linux-x64": "0.25.8",
-				"@esbuild/netbsd-arm64": "0.25.8",
-				"@esbuild/netbsd-x64": "0.25.8",
-				"@esbuild/openbsd-arm64": "0.25.8",
-				"@esbuild/openbsd-x64": "0.25.8",
-				"@esbuild/openharmony-arm64": "0.25.8",
-				"@esbuild/sunos-x64": "0.25.8",
-				"@esbuild/win32-arm64": "0.25.8",
-				"@esbuild/win32-ia32": "0.25.8",
-				"@esbuild/win32-x64": "0.25.8"
+				"@esbuild/aix-ppc64": "0.25.5",
+				"@esbuild/android-arm": "0.25.5",
+				"@esbuild/android-arm64": "0.25.5",
+				"@esbuild/android-x64": "0.25.5",
+				"@esbuild/darwin-arm64": "0.25.5",
+				"@esbuild/darwin-x64": "0.25.5",
+				"@esbuild/freebsd-arm64": "0.25.5",
+				"@esbuild/freebsd-x64": "0.25.5",
+				"@esbuild/linux-arm": "0.25.5",
+				"@esbuild/linux-arm64": "0.25.5",
+				"@esbuild/linux-ia32": "0.25.5",
+				"@esbuild/linux-loong64": "0.25.5",
+				"@esbuild/linux-mips64el": "0.25.5",
+				"@esbuild/linux-ppc64": "0.25.5",
+				"@esbuild/linux-riscv64": "0.25.5",
+				"@esbuild/linux-s390x": "0.25.5",
+				"@esbuild/linux-x64": "0.25.5",
+				"@esbuild/netbsd-arm64": "0.25.5",
+				"@esbuild/netbsd-x64": "0.25.5",
+				"@esbuild/openbsd-arm64": "0.25.5",
+				"@esbuild/openbsd-x64": "0.25.5",
+				"@esbuild/sunos-x64": "0.25.5",
+				"@esbuild/win32-arm64": "0.25.5",
+				"@esbuild/win32-ia32": "0.25.5",
+				"@esbuild/win32-x64": "0.25.5"
 			}
 		},
 		"node_modules/escalade": {
@@ -7949,12 +7253,12 @@
 			}
 		},
 		"node_modules/eventsource-parser": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
-			"integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+			"integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/execa": {
@@ -8152,35 +7456,39 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-			"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+			"integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
 				}
 			],
 			"license": "MIT",
 			"dependencies": {
-				"strnum": "^2.1.0"
+				"strnum": "^1.0.5"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
 			}
 		},
 		"node_modules/fastmcp": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.10.0.tgz",
-			"integrity": "sha512-oFHQKrzrIzbZcIlDMmzaYH6w0qlQiZ7Ly5ogMII3y+ujhmkksmrcc3cObVMVEtBiupwLXOpF8oVE+wZYbYQ3sw==",
+			"version": "3.8.4",
+			"resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.8.4.tgz",
+			"integrity": "sha512-gvZ2JOwFtbvU6By9KzZHs1dfh+VKHO187tdOK/lWKTBnKwdHIMFKPqsP4w35qpwynS4hyJRGJOuG3kFTQcP7EQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.15.1",
+				"@modelcontextprotocol/sdk": "^1.15.0",
 				"@standard-schema/spec": "^1.0.0",
 				"execa": "^9.6.0",
 				"file-type": "^21.0.0",
 				"fuse.js": "^7.1.0",
-				"mcp-proxy": "^5.4.0",
+				"mcp-proxy": "^5.3.0",
 				"strict-event-emitter-types": "^2.0.0",
 				"undici": "^7.11.0",
 				"uri-templates": "^0.2.0",
@@ -8407,9 +7715,9 @@
 			"license": "MIT"
 		},
 		"node_modules/figlet": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.2.tgz",
-			"integrity": "sha512-iPCpE9B/rOcjewIzDnagP9F2eySzGeHReX8WlrZQJkqFBk2wvq8gY0c6U6Hd2y9HnX1LQcYSeP7aEHoPt6sVKQ==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
+			"integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==",
 			"license": "MIT",
 			"bin": {
 				"figlet": "bin/index.js"
@@ -8514,9 +7822,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -8831,6 +8139,16 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/globby": {
@@ -9376,17 +8694,17 @@
 			}
 		},
 		"node_modules/inquirer": {
-			"version": "12.8.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.8.2.tgz",
-			"integrity": "sha512-oBDL9f4+cDambZVJdfJu2M5JQfvaug9lbo6fKDlFV40i8t3FGA1Db67ov5Hp5DInG4zmXhHWTSnlXBntnJ7GMA==",
+			"version": "12.6.3",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.6.3.tgz",
+			"integrity": "sha512-eX9beYAjr1MqYsIjx1vAheXsRk1jbZRvHLcBu5nA9wX0rXR1IfCZLnVLp4Ym4mrhqmh7AuANwcdtgQ291fZDfQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.15",
-				"@inquirer/prompts": "^7.7.1",
-				"@inquirer/type": "^3.0.8",
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/prompts": "^7.5.3",
+				"@inquirer/type": "^3.0.7",
 				"ansi-escapes": "^4.3.2",
 				"mute-stream": "^2.0.0",
-				"run-async": "^4.0.5",
+				"run-async": "^3.0.0",
 				"rxjs": "^7.8.2"
 			},
 			"engines": {
@@ -11443,9 +10761,9 @@
 			}
 		},
 		"node_modules/mcp-proxy": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-5.4.0.tgz",
-			"integrity": "sha512-9B3BKPsm8uRWKRqBDB0w0pZ9O2/02Q6McdZDeThaNnkctT/HDulIER+qLThsp4kgVz5+iSYhnFN9eHEB6sYegQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-5.3.0.tgz",
+			"integrity": "sha512-dknV3cAOdxJXampGqeG56G1UWFWf+2Msmh+r7WbTBqrZXaOFiZh6TSmd3Eig2+QQ5eCkLjrdpVKyjnisUSkizA==",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.13.2",
@@ -12433,9 +11751,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.1.tgz",
+			"integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -12953,9 +12271,9 @@
 			}
 		},
 		"node_modules/run-async": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.5.tgz",
-			"integrity": "sha512-oN9GTgxUNDBumHTTDmQ8dep6VIJbgj9S3dPP+9XylVLIK4xB9XTXtKWROd5pnhdXR9k0EgO1JRcNh0T+Ny2FsA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -13570,9 +12888,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-			"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+			"integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
 			"funding": [
 				{
 					"type": "github",
@@ -13582,9 +12900,9 @@
 			"license": "MIT"
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.2",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.2.tgz",
-			"integrity": "sha512-or9w505RhhY66+uoe5YOC5QO/bRuATaoim3XTh+pGKx5VMWi/HDhMKuCjDLsLJouU2zg9Hf1nLPcNW7IHv80kQ==",
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
+			"integrity": "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==",
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
@@ -13598,9 +12916,9 @@
 			}
 		},
 		"node_modules/superagent": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.2.tgz",
-			"integrity": "sha512-vWMq11OwWCC84pQaFPzF/VO3BrjkCeewuvJgt1jfV0499Z1QSAWN4EqfMM5WlFDDX9/oP8JjlDKpblrmEoyu4Q==",
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
+			"integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13657,14 +12975,14 @@
 			"license": "MIT"
 		},
 		"node_modules/supertest": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.3.tgz",
-			"integrity": "sha512-ORY0gPa6ojmg/C74P/bDoS21WL6FMXq5I8mawkEz30/zkwdu0gOeqstFy316vHG6OKxqQ+IbGneRemHI8WraEw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.1.tgz",
+			"integrity": "sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"methods": "^1.1.2",
-				"superagent": "^10.2.2"
+				"superagent": "^10.2.1"
 			},
 			"engines": {
 				"node": ">=14.18.0"
@@ -13696,9 +13014,9 @@
 			}
 		},
 		"node_modules/swr": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
-			"integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+			"integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
 			"license": "MIT",
 			"dependencies": {
 				"dequal": "^2.0.3",
@@ -13831,9 +13149,9 @@
 			}
 		},
 		"node_modules/token-types": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.3.tgz",
-			"integrity": "sha512-IKJ6EzuPPWtKtEIEPpIdXv9j5j2LGJEYk0CKY2efgKoYKLBiZdh6iQkLVBow/CB3phyWAWCyk+bZeaimJn6uRQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
+			"integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0",
@@ -13947,9 +13265,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
-			"integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
+			"integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -14317,9 +13635,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.18.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "task-master-ai",
-	"version": "0.21.0-rc.0",
+	"version": "0.21.0",
 	"description": "A task management system for ambitious AI-driven development that doesn't overwhelm and confuse Cursor.",
 	"main": "index.js",
 	"type": "module",
@@ -84,8 +84,8 @@
 	},
 	"optionalDependencies": {
 		"@anthropic-ai/claude-code": "^1.0.25",
-		"ai-sdk-provider-gemini-cli": "^0.0.4",
-		"@biomejs/cli-linux-x64": "^1.9.4"
+		"@biomejs/cli-linux-x64": "^1.9.4",
+		"ai-sdk-provider-gemini-cli": "^0.1.1"
 	},
 	"engines": {
 		"node": ">=18.0.0"


### PR DESCRIPTION
## Summary

This PR updates the `ai-sdk-provider-gemini-cli` dependency from v0.0.4 to v0.1.1 to address a breaking change introduced in `@google/gemini-cli-core` v0.1.12+.

## Problem

The `@google/gemini-cli-core` package introduced a breaking change in v0.1.12+ where the `createContentGeneratorConfig` function signature was modified, causing the following error:
```
TypeError: config.getModel is not a function
```

This breaks compatibility for users who have updated their gemini-cli-core dependency.

## Solution

Updated to `ai-sdk-provider-gemini-cli` v0.1.1 which includes:
- Fixed compatibility with `@google/gemini-cli-core` ^0.1.13
- Added proxy support via configuration
- Resolved the breaking API change

## Changes

- Updated `ai-sdk-provider-gemini-cli` from `^0.0.4` to `^0.1.1` in package.json
- Updated package-lock.json accordingly
- Added changeset for patch release

## Testing

- ✅ All tests pass (290 passing)
- ✅ Code formatting verified
- ✅ Package installs correctly from npm registry

## References

- Fixes #1029
- Related upstream fix: https://github.com/ben-vargas/ai-sdk-provider-gemini-cli/releases/tag/v0.1.1

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Gemini CLI provider dependency to enhance compatibility.
  * Released version 0.21.0 as a stable update.
  * Added a changeset documenting the patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->