### PR TITLE
fix: remove default value from complexity report option to enable tag-specific detection

### DIFF
--- a/.changeset/fix-tag-complexity-detection.md
+++ b/.changeset/fix-tag-complexity-detection.md
@@ -1,0 +1,7 @@
+---
+"task-master-ai": patch
+---
+
+Fix tag-specific complexity report detection in expand command
+
+The expand command now correctly finds and uses tag-specific complexity reports (e.g., `task-complexity-report_feature-xyz.json`) when operating in a tag context. Previously, it would always look for the generic `task-complexity-report.json` file due to a default value in the CLI option definition.

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -1564,8 +1564,8 @@ function registerCommands(programInstance) {
 		) // Allow file override
 		.option(
 			'-cr, --complexity-report <file>',
-			'Path to the report file',
-			COMPLEXITY_REPORT_FILE
+			'Path to the complexity report file (use this to specify the complexity report, not --file)'
+			// Removed default value to allow tag-specific auto-detection
 		)
 		.option('--tag <tag>', 'Specify tag context for task operations')
 		.action(async (options) => {


### PR DESCRIPTION
## Summary

Fixes #1042 - `tm expand --all` now correctly finds tag-specific complexity reports.

## Problem

When operating from a tag other than 'master', the `tm expand --all` command would fail to locate the tag-specific complexity report (e.g., `task-complexity-report_error_handling.json`) even though it was correctly generated by `tm analyze-complexity`.

## Root Cause

The `-cr/--complexity-report` option had a default value (`COMPLEXITY_REPORT_FILE`) that was always applied, even when the user didn't specify the option. This prevented the automatic tag-specific path detection in `TaskMaster.getComplexityReportPath()`.

## Solution

Removed the default value from the `-cr` option definition. Now when the option isn't specified, the system properly generates tag-aware paths based on the current tag context.

## Changes

- Removed default value from `-cr/--complexity-report` option in the expand command
- Improved the option description to clarify it's for complexity reports (not tasks files)

## Testing

The fix ensures that:
1. When in tag `error_handling`, `tm expand --all` looks for `task-complexity-report_error_handling.json`
2. When in tag `master`, `tm expand --all` looks for `task-complexity-report.json`
3. Users can still override with `-cr <path>` if needed

## Workaround (for users on older versions)

Until this fix is released, users can work around the issue by explicitly specifying the complexity report:
```bash
tm expand --all -cr .taskmaster/reports/task-complexity-report_<tag-name>.json
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the CLI experience by updating the complexity report file option, allowing for more flexible and explicit file selection.
  * Enhanced the "expand" command to automatically detect and use tag-specific complexity report files for accurate reporting.
* **Documentation**
  * Clarified the description for the complexity report file option to better distinguish it from similar options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->