### PR TITLE
fix: changed the GEMINI api key name to GOOGLE api key name

### DIFF
--- a/docs/providers/gemini-cli.md
+++ b/docs/providers/gemini-cli.md
@@ -37,7 +37,7 @@ For OAuth use, select `Login with Google` - This will open a browser window for 
 While the primary use case is OAuth authentication, you can also use an API key if needed:
 
 ```bash
-export GEMINI_API_KEY="your-gemini-api-key"
+export GOOGLE_API_KEY="your-google-api-key"
 ```
 
 **Note:** If you want to use API keys, consider using the standard `google` provider instead, as `gemini-cli` is specifically designed for OAuth/subscription users.
@@ -130,7 +130,7 @@ If you get an authentication error:
 
 1. **Primary solution**: Run `gemini` to authenticate with your Google account - use `/auth` slash command in **gemini-cli** to change authentication method if desired.
 2. **Check authentication status**: Run `gemini` and use `/about` to verify your Auth Method and GCP Project if applicable.
-3. **If using API key** (not recommended): Ensure `GEMINI_API_KEY` env variable is set correctly, see the gemini-cli README.md for more info.
+3. **If using API key** (not recommended): Ensure `GOOGLE_API_KEY` env variable is set correctly, see the gemini-cli README.md for more info.
 
 ### "Model not found" Error
 

--- a/src/ai-providers/gemini-cli.js
+++ b/src/ai-providers/gemini-cli.js
@@ -654,9 +654,8 @@ Generate ${subtaskCount} subtasks based on the original task context. Return ONL
 	}
 
 	getRequiredApiKeyName() {
-		return 'GEMINI_API_KEY';
+		return 'GOOGLE_API_KEY';
 	}
-
 	isRequiredApiKey() {
 		return false;
 	}

--- a/tests/unit/ai-services-unified.test.js
+++ b/tests/unit/ai-services-unified.test.js
@@ -224,7 +224,7 @@ jest.unstable_mockModule('../../src/ai-providers/index.js', () => ({
 		generateText: jest.fn(),
 		streamText: jest.fn(),
 		generateObject: jest.fn(),
-		getRequiredApiKeyName: jest.fn(() => 'GEMINI_API_KEY'),
+		getRequiredApiKeyName: jest.fn(() => 'GOOGLE_API_KEY'),
 		isRequiredApiKey: jest.fn(() => false)
 	}))
 }));


### PR DESCRIPTION
# What type of PR is this?
<!-- Check one -->

 - [x] 🐛 Bug fix
 - [ ] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
This PR fixes an issue with the Gemini CLI provider where it was looking for the environment variable `GEMINI_API_KEY` instead of the standard `GOOGLE_API_KEY` used by all other Google-related providers in the codebase.

**Expected result:**
Env variable inside user confige can now start with GOOGLE, and not GEMINI, as the .env.example says.

## Contributor Checklist

- [x] Created changeset: `npm run changeset`
- [x] Tests pass: `npm test`
- [x] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [x] Addressed CodeRabbit comments (if any)
- [x] Linked related issues (if any)
- [x] Manually tested the changes

## Changelog Entry
"Changed GEMINI_API_KEY to GOOGLE_API_KEY"

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)
