### PR TITLE
feat: add prompt for claude code to include context when generating tasks

### DIFF
--- a/scripts/modules/task-manager/analyze-task-complexity.js
+++ b/scripts/modules/task-manager/analyze-task-complexity.js
@@ -410,8 +410,12 @@ async function analyzeTaskComplexity(options, context = {}) {
 		const promptManager = getPromptManager();
 
 		// Check if Claude Code is being used as the provider
-		const { getMainProvider, getResearchProvider } = await import('../config-manager.js');
-		const currentProvider = useResearch ? getResearchProvider(projectRoot) : getMainProvider(projectRoot);
+		const { getMainProvider, getResearchProvider } = await import(
+			'../config-manager.js'
+		);
+		const currentProvider = useResearch
+			? getResearchProvider(projectRoot)
+			: getMainProvider(projectRoot);
 		const isClaudeCode = currentProvider === CUSTOM_PROVIDERS.CLAUDE_CODE;
 
 		const promptParams = {

--- a/scripts/modules/task-manager/analyze-task-complexity.js
+++ b/scripts/modules/task-manager/analyze-task-complexity.js
@@ -13,7 +13,7 @@ import {
 
 import { generateTextService } from '../ai-services-unified.js';
 
-import { getDebugFlag, getProjectName } from '../config-manager.js';
+import { getDebugFlag, getProjectName, getMainProvider, getResearchProvider } from '../config-manager.js';
 import { getPromptManager } from '../prompt-manager.js';
 import {
 	COMPLEXITY_REPORT_FILE,
@@ -410,9 +410,6 @@ async function analyzeTaskComplexity(options, context = {}) {
 		const promptManager = getPromptManager();
 
 		// Check if Claude Code is being used as the provider
-		const { getMainProvider, getResearchProvider } = await import(
-			'../config-manager.js'
-		);
 		const currentProvider = useResearch
 			? getResearchProvider(projectRoot)
 			: getMainProvider(projectRoot);

--- a/scripts/modules/task-manager/analyze-task-complexity.js
+++ b/scripts/modules/task-manager/analyze-task-complexity.js
@@ -13,7 +13,12 @@ import {
 
 import { generateTextService } from '../ai-services-unified.js';
 
-import { getDebugFlag, getProjectName, getMainProvider, getResearchProvider } from '../config-manager.js';
+import {
+	getDebugFlag,
+	getProjectName,
+	getMainProvider,
+	getResearchProvider
+} from '../config-manager.js';
 import { getPromptManager } from '../prompt-manager.js';
 import {
 	COMPLEXITY_REPORT_FILE,

--- a/scripts/modules/task-manager/expand-task.js
+++ b/scripts/modules/task-manager/expand-task.js
@@ -18,7 +18,12 @@ import {
 
 import { generateTextService } from '../ai-services-unified.js';
 
-import { getDefaultSubtasks, getDebugFlag } from '../config-manager.js';
+import { 
+	getDefaultSubtasks, 
+	getDebugFlag,
+	getMainProvider,
+	getResearchProvider
+} from '../config-manager.js';
 import { getPromptManager } from '../prompt-manager.js';
 import generateTaskFiles from './generate-task-files.js';
 import { COMPLEXITY_REPORT_FILE } from '../../../src/constants/paths.js';
@@ -453,9 +458,6 @@ async function expandTask(
 		const promptManager = getPromptManager();
 
 		// Check if Claude Code is being used as the provider
-		const { getMainProvider, getResearchProvider } = await import(
-			'../config-manager.js'
-		);
 		const currentProvider = useResearch
 			? getResearchProvider(projectRoot)
 			: getMainProvider(projectRoot);

--- a/scripts/modules/task-manager/expand-task.js
+++ b/scripts/modules/task-manager/expand-task.js
@@ -18,8 +18,8 @@ import {
 
 import { generateTextService } from '../ai-services-unified.js';
 
-import { 
-	getDefaultSubtasks, 
+import {
+	getDefaultSubtasks,
 	getDebugFlag,
 	getMainProvider,
 	getResearchProvider

--- a/scripts/modules/task-manager/parse-prd.js
+++ b/scripts/modules/task-manager/parse-prd.js
@@ -17,7 +17,7 @@ import {
 } from '../utils.js';
 
 import { generateObjectService } from '../ai-services-unified.js';
-import { getDebugFlag } from '../config-manager.js';
+import { getDebugFlag, getMainProvider, getResearchProvider, getDefaultPriority } from '../config-manager.js';
 import { getPromptManager } from '../prompt-manager.js';
 import { displayAiUsageSummary } from '../ui.js';
 import { CUSTOM_PROVIDERS } from '../../../src/constants/providers.js';
@@ -175,8 +175,6 @@ async function parsePRD(prdPath, tasksPath, numTasks, options = {}) {
 		const promptManager = getPromptManager();
 
 		// Get defaultTaskPriority from config
-		const { getDefaultPriority, getMainProvider, getResearchProvider } =
-			await import('../config-manager.js');
 		const defaultTaskPriority = getDefaultPriority(projectRoot) || 'medium';
 
 		// Check if Claude Code is being used as the provider

--- a/scripts/modules/task-manager/parse-prd.js
+++ b/scripts/modules/task-manager/parse-prd.js
@@ -17,7 +17,12 @@ import {
 } from '../utils.js';
 
 import { generateObjectService } from '../ai-services-unified.js';
-import { getDebugFlag, getMainProvider, getResearchProvider, getDefaultPriority } from '../config-manager.js';
+import {
+	getDebugFlag,
+	getMainProvider,
+	getResearchProvider,
+	getDefaultPriority
+} from '../config-manager.js';
 import { getPromptManager } from '../prompt-manager.js';
 import { displayAiUsageSummary } from '../ui.js';
 import { CUSTOM_PROVIDERS } from '../../../src/constants/providers.js';

--- a/tests/unit/scripts/modules/task-manager/expand-task.test.js
+++ b/tests/unit/scripts/modules/task-manager/expand-task.test.js
@@ -123,7 +123,9 @@ jest.unstable_mockModule(
 	() => ({
 		getDefaultSubtasks: jest.fn(() => 3),
 		getDebugFlag: jest.fn(() => false),
-		getDefaultNumTasks: jest.fn(() => 10)
+		getDefaultNumTasks: jest.fn(() => 10),
+		getMainProvider: jest.fn(() => 'openai'),
+		getResearchProvider: jest.fn(() => 'perplexity')
 	})
 );
 

--- a/tests/unit/scripts/modules/task-manager/parse-prd.test.js
+++ b/tests/unit/scripts/modules/task-manager/parse-prd.test.js
@@ -49,7 +49,9 @@ jest.unstable_mockModule(
 	() => ({
 		getDebugFlag: jest.fn(() => false),
 		getDefaultNumTasks: jest.fn(() => 10),
-		getDefaultPriority: jest.fn(() => 'medium')
+		getDefaultPriority: jest.fn(() => 'medium'),
+		getMainProvider: jest.fn(() => 'openai'),
+		getResearchProvider: jest.fn(() => 'perplexity')
 	})
 );
 


### PR DESCRIPTION
# What type of PR is this?
<!-- Check one -->

 - [ ] 🐛 Bug fix
 - [x] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
tm parse-prd
```
- Check if the parse prd using the claude code ai provider is trying to re-create already existing boilerplate code like intializing nextjs or something like that

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [ ] Created changeset: `npm run changeset`
- [ ] Tests pass: `npm test`
- [ ] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Refactored imports to use static rather than dynamic loading for configuration functions across task management modules.
  * Updated unit tests to mock additional configuration provider functions without changing test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->