### PR TITLE
feat: Add task id to task details UI

### DIFF
--- a/.changeset/light-crabs-warn.md
+++ b/.changeset/light-crabs-warn.md
@@ -1,0 +1,5 @@
+---
+"extension": minor
+---
+
+Display current task ID on task details page

--- a/apps/extension/src/components/TaskDetailsView.tsx
+++ b/apps/extension/src/components/TaskDetailsView.tsx
@@ -135,7 +135,7 @@ export const TaskDetailsView: React.FC<TaskDetailsViewProps> = ({
 								<BreadcrumbSeparator />
 								<BreadcrumbItem>
 									<span className="text-vscode-foreground">
-										{currentTask.title}
+										{`#${currentTask.id} `} {currentTask.title}
 									</span>
 								</BreadcrumbItem>
 							</BreadcrumbList>
@@ -152,9 +152,9 @@ export const TaskDetailsView: React.FC<TaskDetailsViewProps> = ({
 						</button>
 					</div>
 
-					{/* Task title */}
+					{/* Task ID and title */}
 					<h1 className="text-2xl font-bold tracking-tight text-vscode-foreground">
-						{currentTask.title}
+						{`#${currentTask.id} `} {currentTask.title}
 					</h1>
 
 					{/* Description */}

--- a/apps/extension/src/components/TaskDetailsView.tsx
+++ b/apps/extension/src/components/TaskDetailsView.tsx
@@ -55,8 +55,8 @@ export const TaskDetailsView: React.FC<TaskDetailsViewProps> = ({
 
 	const displayId =
 		isSubtask && parentTask
-			? `${parentTask.id}.${currentTask.id}`
-			: currentTask.id;
+			? `${parentTask.id}.${currentTask?.id}`
+			: currentTask?.id;
 
 	const handleStatusChange = async (newStatus: TaskMasterTask['status']) => {
 		if (!currentTask) return;

--- a/apps/extension/src/components/TaskDetailsView.tsx
+++ b/apps/extension/src/components/TaskDetailsView.tsx
@@ -53,6 +53,11 @@ export const TaskDetailsView: React.FC<TaskDetailsViewProps> = ({
 		refreshComplexityAfterAI
 	} = useTaskDetails({ taskId, sendMessage, tasks: allTasks });
 
+	const displayId =
+		isSubtask && parentTask
+			? `${parentTask.id}.${currentTask.id}`
+			: currentTask.id;
+
 	const handleStatusChange = async (newStatus: TaskMasterTask['status']) => {
 		if (!currentTask) return;
 
@@ -60,10 +65,7 @@ export const TaskDetailsView: React.FC<TaskDetailsViewProps> = ({
 			await sendMessage({
 				type: 'updateTaskStatus',
 				data: {
-					taskId:
-						isSubtask && parentTask
-							? `${parentTask.id}.${currentTask.id}`
-							: currentTask.id,
+					taskId: displayId,
 					newStatus: newStatus
 				}
 			});
@@ -135,7 +137,7 @@ export const TaskDetailsView: React.FC<TaskDetailsViewProps> = ({
 								<BreadcrumbSeparator />
 								<BreadcrumbItem>
 									<span className="text-vscode-foreground">
-										{`#${currentTask.id} `} {currentTask.title}
+										#{displayId} {currentTask.title}
 									</span>
 								</BreadcrumbItem>
 							</BreadcrumbList>
@@ -154,7 +156,7 @@ export const TaskDetailsView: React.FC<TaskDetailsViewProps> = ({
 
 					{/* Task ID and title */}
 					<h1 className="text-2xl font-bold tracking-tight text-vscode-foreground">
-						{`#${currentTask.id} `} {currentTask.title}
+						#{displayId} {currentTask.title}
 					</h1>
 
 					{/* Description */}


### PR DESCRIPTION
### Problem

When working with Task Master through the UI, it's not uncommon to switch to the command line interface, which requires the task ID for most operations. Currently, the task details page doesn't display the task ID, forcing users to navigate back to the task list to find this information before they can perform command line operations.

### Solution

Display the task ID prominently on the task details page to eliminate unnecessary navigation between views.

### User Impact

- Reduces friction when switching between UI and CLI workflows
- Eliminates the need to navigate back to task lists just to retrieve task IDs
- Improves overall user experience for power users who frequently use both interfaces

# What type of PR is this?
<!-- Check one -->

 - [ ] 🐛 Bug fix
 - [ ] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [x] Other: UI Enhancement
## Description
Display current task ID on task details page

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [x] Created changeset: `npm run changeset`
- [x] Tests pass: `npm test`
- [x] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [x] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The task details page now displays the current task ID alongside the task title in both the breadcrumb navigation and the main heading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->