### PR TITLE
Fix: disable streaming for parse prd

### DIFF
--- a/.changeset/rich-emus-say.md
+++ b/.changeset/rich-emus-say.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Temporarily disable streaming for improved model compatibility - will be re-enabled in upcoming release

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -9,17 +9,9 @@
 	"engines": {
 		"vscode": "^1.93.0"
 	},
-	"categories": [
-		"AI",
-		"Visualization",
-		"Education",
-		"Other"
-	],
+	"categories": ["AI", "Visualization", "Education", "Other"],
 	"main": "./dist/extension.js",
-	"activationEvents": [
-		"onStartupFinished",
-		"workspaceContains:.taskmaster/**"
-	],
+	"activationEvents": ["onStartupFinished", "workspaceContains:.taskmaster/**"],
 	"contributes": {
 		"viewsContainers": {
 			"activitybar": [
@@ -147,11 +139,7 @@
 				},
 				"taskmaster.ui.theme": {
 					"type": "string",
-					"enum": [
-						"auto",
-						"light",
-						"dark"
-					],
+					"enum": ["auto", "light", "dark"],
 					"default": "auto",
 					"description": "UI theme preference"
 				},
@@ -212,12 +200,7 @@
 				},
 				"taskmaster.debug.logLevel": {
 					"type": "string",
-					"enum": [
-						"error",
-						"warn",
-						"info",
-						"debug"
-					],
+					"enum": ["error", "warn", "info", "debug"],
 					"default": "info",
 					"description": "Logging level"
 				},

--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
 		"task-master-mcp": "mcp-server/server.js",
 		"task-master-ai": "mcp-server/server.js"
 	},
-	"workspaces": [
-		"apps/*",
-		"."
-	],
+	"workspaces": ["apps/*", "."],
 	"scripts": {
 		"test": "node --experimental-vm-modules node_modules/.bin/jest",
 		"test:fails": "node --experimental-vm-modules node_modules/.bin/jest --onlyFailures",

--- a/scripts/modules/task-manager/parse-prd/parse-prd-config.js
+++ b/scripts/modules/task-manager/parse-prd/parse-prd-config.js
@@ -63,8 +63,14 @@ export class PrdParseConfig {
 		this.targetTag = this.tag || getCurrentTag(this.projectRoot) || 'master';
 		this.isMCP = !!this.mcpLog;
 		this.outputFormat = this.isMCP && !this.reportProgress ? 'json' : 'text';
-		this.useStreaming =
-			typeof this.reportProgress === 'function' || this.outputFormat === 'text';
+		
+		// Feature flag: Temporarily disable streaming, use generateObject instead
+		// TODO: Re-enable streaming once issues are resolved
+		const ENABLE_STREAMING = false;
+		
+		this.useStreaming = ENABLE_STREAMING && (
+			typeof this.reportProgress === 'function' || this.outputFormat === 'text'
+		);
 	}
 
 	/**

--- a/scripts/modules/task-manager/parse-prd/parse-prd-config.js
+++ b/scripts/modules/task-manager/parse-prd/parse-prd-config.js
@@ -63,14 +63,15 @@ export class PrdParseConfig {
 		this.targetTag = this.tag || getCurrentTag(this.projectRoot) || 'master';
 		this.isMCP = !!this.mcpLog;
 		this.outputFormat = this.isMCP && !this.reportProgress ? 'json' : 'text';
-		
+
 		// Feature flag: Temporarily disable streaming, use generateObject instead
 		// TODO: Re-enable streaming once issues are resolved
 		const ENABLE_STREAMING = false;
-		
-		this.useStreaming = ENABLE_STREAMING && (
-			typeof this.reportProgress === 'function' || this.outputFormat === 'text'
-		);
+
+		this.useStreaming =
+			ENABLE_STREAMING &&
+			(typeof this.reportProgress === 'function' ||
+				this.outputFormat === 'text');
 	}
 
 	/**

--- a/tests/unit/scripts/modules/task-manager/parse-prd.test.js
+++ b/tests/unit/scripts/modules/task-manager/parse-prd.test.js
@@ -795,7 +795,7 @@ describe('parsePRD', () => {
 	});
 
 	describe('Streaming vs Non-Streaming Modes', () => {
-		test('should use streaming when reportProgress function is provided', async () => {
+		test('should use non-streaming when reportProgress function is provided (streaming disabled)', async () => {
 			// Setup mocks to simulate normal conditions (no existing output file)
 			fs.default.existsSync.mockImplementation((path) => {
 				if (path === 'tasks/tasks.json') return false; // Output file doesn't exist
@@ -815,22 +815,19 @@ describe('parsePRD', () => {
 			};
 			JSONParser.mockReturnValue(mockParser);
 
-			// Call the function with reportProgress to trigger streaming path
+			// Call the function with reportProgress - with streaming disabled, should use non-streaming
 			const result = await parsePRD('path/to/prd.txt', 'tasks/tasks.json', 3, {
 				reportProgress: mockReportProgress
 			});
 
-			// Verify streamObjectService was called (streaming path)
-			expect(streamObjectService).toHaveBeenCalled();
+			// With streaming disabled, should use generateObjectService instead
+			expect(generateObjectService).toHaveBeenCalled();
 
-			// Verify generateObjectService was NOT called (non-streaming path)
-			expect(generateObjectService).not.toHaveBeenCalled();
+			// Verify streamObjectService was NOT called (streaming is disabled)
+			expect(streamObjectService).not.toHaveBeenCalled();
 
-			// Verify progress reporting was called
+			// Verify progress reporting was still called
 			expect(mockReportProgress).toHaveBeenCalled();
-
-			// We no longer use parseStream with streamObject
-			// expect(parseStream).toHaveBeenCalled();
 
 			// Verify result structure
 			expect(result).toEqual({
@@ -840,7 +837,7 @@ describe('parsePRD', () => {
 			});
 		});
 
-		test('should fallback to non-streaming when streaming fails with specific errors', async () => {
+		test.skip('should fallback to non-streaming when streaming fails with specific errors (streaming disabled)', async () => {
 			// Setup mocks to simulate normal conditions (no existing output file)
 			fs.default.existsSync.mockImplementation((path) => {
 				if (path === 'tasks/tasks.json') return false; // Output file doesn't exist
@@ -954,7 +951,7 @@ describe('parsePRD', () => {
 			});
 		});
 
-		test('should handle research flag with streaming', async () => {
+		test('should handle research flag with non-streaming (streaming disabled)', async () => {
 			// Setup mocks to simulate normal conditions
 			fs.default.existsSync.mockImplementation((path) => {
 				if (path === 'tasks/tasks.json') return false; // Output file doesn't exist
@@ -965,19 +962,19 @@ describe('parsePRD', () => {
 			// Mock progress reporting function
 			const mockReportProgress = jest.fn(() => Promise.resolve());
 
-			// Call with streaming + research
+			// Call with reportProgress + research - with streaming disabled, should use non-streaming
 			await parsePRD('path/to/prd.txt', 'tasks/tasks.json', 3, {
 				reportProgress: mockReportProgress,
 				research: true
 			});
 
-			// Verify streaming path was used with research role
-			expect(streamObjectService).toHaveBeenCalledWith(
+			// With streaming disabled, should use generateObjectService with research role
+			expect(generateObjectService).toHaveBeenCalledWith(
 				expect.objectContaining({
 					role: 'research'
 				})
 			);
-			expect(generateObjectService).not.toHaveBeenCalled();
+			expect(streamObjectService).not.toHaveBeenCalled();
 		});
 
 		test('should handle research flag with non-streaming', async () => {
@@ -1009,7 +1006,7 @@ describe('parsePRD', () => {
 			expect(streamObjectService).not.toHaveBeenCalled();
 		});
 
-		test('should use streaming for CLI text mode even without reportProgress', async () => {
+		test('should use non-streaming for CLI text mode (streaming disabled)', async () => {
 			// Setup mocks to simulate normal conditions
 			fs.default.existsSync.mockImplementation((path) => {
 				if (path === 'tasks/tasks.json') return false; // Output file doesn't exist
@@ -1020,13 +1017,12 @@ describe('parsePRD', () => {
 			// Call without mcpLog and without reportProgress (CLI text mode)
 			const result = await parsePRD('path/to/prd.txt', 'tasks/tasks.json', 3);
 
-			// Verify streaming path was used (no mcpLog means CLI text mode, which should use streaming)
-			expect(streamObjectService).toHaveBeenCalled();
-			expect(generateObjectService).not.toHaveBeenCalled();
+			// With streaming disabled, should use generateObjectService even in CLI text mode
+			expect(generateObjectService).toHaveBeenCalled();
+			expect(streamObjectService).not.toHaveBeenCalled();
 
-			// Verify progress tracker components were called for CLI mode
-			expect(createParsePrdTracker).toHaveBeenCalled();
-			expect(displayParsePrdStart).toHaveBeenCalled();
+			// Progress tracker components may still be called for CLI mode display
+			// but the actual parsing uses non-streaming
 
 			expect(result).toEqual({
 				success: true,


### PR DESCRIPTION
# What type of PR is this?
<!-- Check one -->

 - [x] 🐛 Bug fix
 - [ ] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [x] Created changeset: `npm run changeset`
- [x] Tests pass: `npm test`
- [x] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [x] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [x] PR title follows conventional commits
- [x] Target branch correct
- [x] Labels added
- [x] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Streaming is temporarily disabled for task parsing; results are now delivered once processing completes for more predictable output timing.

- Tests
  - Unit tests updated to validate non-streaming behavior and adjusted/skipped streaming-path scenarios.

- Chores
  - Added a patch release changeset documenting the temporary streaming disablement.

- Style
  - Project JSON metadata arrays reformatted for consistent, compact representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->