### PR TITLE
Add Q Developer CLI at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ MCP (Model Control Protocol) lets you run Task Master directly from your editor.
 |              | Project | `<project_folder>/.cursor/mcp.json`   | `<project_folder>\.cursor\mcp.json`               | `mcpServers` |
 | **Windsurf** | Global  | `~/.codeium/windsurf/mcp_config.json` | `%USERPROFILE%\.codeium\windsurf\mcp_config.json` | `mcpServers` |
 | **VS Code**  | Project | `<project_folder>/.vscode/mcp.json`   | `<project_folder>\.vscode\mcp.json`               | `servers`    |
+| **Q CLI**    | Global  | `~/.aws/amazonq/mcp.json`             |                                                   | `mcpServers` |
 
 ##### Manual Configuration
 
-###### Cursor & Windsurf (`mcpServers`)
+###### Cursor & Windsurf & Q Developer CLI (`mcpServers`)
 
 ```json
 {


### PR DESCRIPTION
TaskMaster MCP is working well at Q Developer CLI and I add it for users

# What type of PR is this?
<!-- Check one -->

 - [ ] 🐛 Bug fix
 - [ ] ✨ Feature
 - [ ] 🔌 Integration
 - [X] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->

Add MCP Client, Amazon Q Developer CLI, at the document for setting Task Master MCP.

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [ ] Created changeset: `npm run changeset`
- [ ] Tests pass: `npm test`
- [ ] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Quick Reference to include a Q CLI entry for MCP path (Global scope), detailing the Linux/macOS location and leaving Windows unspecified.
  * Updated the manual configuration section title to include Q Developer CLI alongside Cursor and Windsurf, clarifying use of the mcpServers key.
  * Improves cross-platform configuration clarity for users integrating Q Developer CLI with supported editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->