### PR TITLE
fix: handle subtasks in getTask method

### DIFF
--- a/.changeset/fix-subtask-getTask.md
+++ b/.changeset/fix-subtask-getTask.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fixed issue where `tm show` command could not find subtasks using dotted notation IDs (e.g., '8.1'). The command now properly searches within parent task subtasks and returns the correct subtask information.

--- a/.changeset/fix-subtask-getTask.md
+++ b/.changeset/fix-subtask-getTask.md
@@ -2,4 +2,6 @@
 "task-master-ai": patch
 ---
 
-Fixed issue where `tm show` command could not find subtasks using dotted notation IDs (e.g., '8.1'). The command now properly searches within parent task subtasks and returns the correct subtask information.
+Fixed issue where `tm show` command could not find subtasks using dotted notation IDs (e.g., '8.1'). 
+
+- The command now properly searches within parent task subtasks and returns the correct subtask information.

--- a/packages/tm-core/src/services/task-service.ts
+++ b/packages/tm-core/src/services/task-service.ts
@@ -143,7 +143,41 @@ export class TaskService {
 			includeSubtasks: true
 		});
 
-		return result.tasks.find((t) => t.id === taskId) || null;
+		// Check if this is a subtask (contains a dot)
+		if (taskId.includes('.')) {
+			const [parentId, subtaskId] = taskId.split('.');
+			const parentTask = result.tasks.find((t) => String(t.id) === parentId);
+			
+			if (!parentTask || !parentTask.subtasks) {
+				return null;
+			}
+
+			const subtask = parentTask.subtasks.find((st) => String(st.id) === subtaskId);
+			if (!subtask) {
+				return null;
+			}
+
+			// Return a Task-like object for the subtask with the full dotted ID
+			return {
+				id: taskId,
+				title: subtask.title || `Subtask ${subtaskId}`,
+				description: subtask.description || '',
+				status: subtask.status || 'pending',
+				priority: subtask.priority || parentTask.priority || 'medium',
+				dependencies: subtask.dependencies || [],
+				details: subtask.details || '',
+				testStrategy: subtask.testStrategy || '',
+				subtasks: [],
+				tags: parentTask.tags || [],
+				assignee: subtask.assignee || parentTask.assignee,
+				complexity: subtask.complexity || parentTask.complexity,
+				createdAt: parentTask.createdAt,
+				updatedAt: parentTask.updatedAt
+			};
+		}
+
+		// Handle regular task lookup
+		return result.tasks.find((t) => String(t.id) === String(taskId)) || null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue where 'tm show' command could not find subtasks by their dotted notation ID (e.g., '8.1').

The getTask method now checks if the task ID contains a dot and properly searches within parent task subtasks, returning a Task-like object with the full dotted ID.

This mirrors the fix already implemented in updateTaskStatus method for consistent subtask handling across the codebase.

Fixes #1253

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Subtasks can be accessed via dotted IDs (e.g., "parent.subtask") and are shown as full task entries with sensible defaults, resolved dependencies, parent context, and inherited metadata.
  - Regular task lookup for non-dotted IDs remains unchanged.

- Bug Fixes
  - "tm show" correctly locates and displays subtasks when using dotted notation.
  - Retrieving non-existent subtasks now returns no result without affecting top-level task retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->