### PR TITLE
fix(mcp-server): construct default tasks.json path when file parameter not provided

### DIFF
--- a/mcp-server/src/core/utils/path-utils.js
+++ b/mcp-server/src/core/utils/path-utils.js
@@ -69,11 +69,22 @@ export function resolveTasksPath(args, log = silentLogger) {
 
 	// Use core findTasksPath with explicit path and normalized projectRoot context
 	if (projectRoot) {
-		return coreFindTasksPath(explicitPath, { projectRoot }, log);
+		const foundPath = coreFindTasksPath(explicitPath, { projectRoot }, log);
+		// If core function returns null and no explicit path was provided,
+		// construct the expected default path as documented
+		if (foundPath === null && !explicitPath) {
+			const defaultPath = path.join(projectRoot, '.taskmaster', 'tasks', 'tasks.json');
+			log?.info?.(`Core findTasksPath returned null, using default path: ${defaultPath}`);
+			return defaultPath;
+		}
+		return foundPath;
 	}
 
 	// Fallback to core function without projectRoot context
-	return coreFindTasksPath(explicitPath, null, log);
+	const foundPath = coreFindTasksPath(explicitPath, null, log);
+	// Note: When no projectRoot is available, we can't construct a default path
+	// so we return null and let the calling code handle the error
+	return foundPath;
 }
 
 /**


### PR DESCRIPTION
Resolves issue where MCP tools fail with 'tasksJsonPath is required' error when the 'file' parameter is not provided, even though it should be optional.

## Changes
- Modified resolveTasksPath() to construct default path ${projectRoot}/.taskmaster/tasks/tasks.json
- Added fallback logic when core path finder returns null
- Maintains existing behavior when explicit file path is provided
- Added logging for debugging path resolution

Fixes #1272

Generated with [Claude Code](https://claude.ai/code)