### PR TITLE
fix: remove deprecated generateTaskFiles calls from MCP tools

### DIFF
--- a/scripts/modules/task-manager/add-subtask.js
+++ b/scripts/modules/task-manager/add-subtask.js
@@ -1,8 +1,5 @@
-import path from 'path';
-
 import { log, readJSON, writeJSON, getCurrentTag } from '../utils.js';
 import { isTaskDependentOn } from '../task-manager.js';
-import generateTaskFiles from './generate-task-files.js';
 
 /**
  * Add a subtask to a parent task
@@ -142,11 +139,7 @@ async function addSubtask(
 		// Write the updated tasks back to the file with proper context
 		writeJSON(tasksPath, data, projectRoot, tag);
 
-		// Generate task files if requested
-		if (generateFiles) {
-			log('info', 'Regenerating task files...');
-			await generateTaskFiles(tasksPath, path.dirname(tasksPath), context);
-		}
+		// Note: Task file generation is no longer supported and has been removed
 
 		return newSubtask;
 	} catch (error) {

--- a/scripts/modules/task-manager/move-task.js
+++ b/scripts/modules/task-manager/move-task.js
@@ -6,7 +6,6 @@ import {
 	setTasksForTag,
 	traverseDependencies
 } from '../utils.js';
-import generateTaskFiles from './generate-task-files.js';
 import {
 	findCrossTagDependencies,
 	getDependentTaskIds,
@@ -142,13 +141,7 @@ async function moveTask(
 			results.push(result);
 		}
 
-		// Generate files once at the end if requested
-		if (generateFiles) {
-			await generateTaskFiles(tasksPath, path.dirname(tasksPath), {
-				tag: tag,
-				projectRoot: projectRoot
-			});
-		}
+		// Note: Task file generation is no longer supported and has been removed
 
 		return {
 			message: `Successfully moved ${sourceIds.length} tasks/subtasks`,
@@ -209,12 +202,7 @@ async function moveTask(
 	// The writeJSON function will filter out _rawTaggedData automatically
 	writeJSON(tasksPath, rawData, options.projectRoot, tag);
 
-	if (generateFiles) {
-		await generateTaskFiles(tasksPath, path.dirname(tasksPath), {
-			tag: tag,
-			projectRoot: projectRoot
-		});
-	}
+	// Note: Task file generation is no longer supported and has been removed
 
 	return result;
 }

--- a/scripts/modules/task-manager/remove-subtask.js
+++ b/scripts/modules/task-manager/remove-subtask.js
@@ -1,6 +1,4 @@
-import path from 'path';
 import { log, readJSON, writeJSON } from '../utils.js';
-import generateTaskFiles from './generate-task-files.js';
 
 /**
  * Remove a subtask from its parent task
@@ -108,11 +106,7 @@ async function removeSubtask(
 		// Write the updated tasks back to the file with proper context
 		writeJSON(tasksPath, data, projectRoot, tag);
 
-		// Generate task files if requested
-		if (generateFiles) {
-			log('info', 'Regenerating task files...');
-			await generateTaskFiles(tasksPath, path.dirname(tasksPath), context);
-		}
+		// Note: Task file generation is no longer supported and has been removed
 
 		return convertedTask;
 	} catch (error) {


### PR DESCRIPTION
Removed generateTaskFiles() calls from add_subtask, remove_subtask, and move_task functions to fix MCP connection errors. The generateTaskFiles functionality is no longer supported and was causing "Cannot read properties of null (reading 'toString')" errors.

Fixes issue #1271 - MCP Connection Closed Error After Upgrading to v0.27.3

Generated with [Claude Code](https://claude.ai/code)