### PR TITLE
Fix MCP server startup error: Ensure JSON Schema Draft 7 compatibility

### DIFF
--- a/mcp-server/src/fastmcp-wrapper.js
+++ b/mcp-server/src/fastmcp-wrapper.js
@@ -1,0 +1,34 @@
+import { FastMCP as OriginalFastMCP } from 'fastmcp';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+/**
+ * Custom FastMCP wrapper that ensures JSON Schema compatibility with MCP clients
+ * by forcing the use of JSON Schema Draft 7 for all Zod schema conversions
+ */
+export class FastMCP extends OriginalFastMCP {
+  constructor(options) {
+    super(options);
+    
+    // Override the internal method that handles tool schema conversion
+    const originalSetupToolHandlers = this._setupToolHandlers || function() {};
+    this._setupToolHandlers = (tools) => {
+      // Modify each tool to ensure proper JSON Schema conversion
+      const modifiedTools = tools.map(tool => {
+        if (tool.parameters && typeof tool.parameters === 'object' && '_def' in tool.parameters) {
+          // Create a wrapper for the tool with modified schema generation
+          return {
+            ...tool,
+            _originalParameters: tool.parameters,
+            get inputSchema() {
+              // Generate schema with explicit Draft 7 target
+              return zodToJsonSchema(this._originalParameters, { target: 'jsonSchema7' });
+            }
+          };
+        }
+        return tool;
+      });
+      
+      return originalSetupToolHandlers.call(this, modifiedTools);
+    };
+  }
+}

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -1,4 +1,3 @@
-import { FastMCP } from 'fastmcp';
 import path from 'path';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
@@ -8,6 +7,9 @@ import { registerTaskMasterTools } from './tools/index.js';
 import ProviderRegistry from '../../src/provider-registry/index.js';
 import { MCPProvider } from './providers/mcp-provider.js';
 import packageJson from '../../package.json' with { type: 'json' };
+
+// Use our custom FastMCP wrapper to ensure JSON Schema compatibility
+import { FastMCP } from './fastmcp-wrapper.js';
 
 // Load environment variables
 dotenv.config();

--- a/mcp-server/src/tools/initialize-project.js
+++ b/mcp-server/src/tools/initialize-project.js
@@ -7,53 +7,61 @@ import {
 import { initializeProjectDirect } from '../core/task-master-core.js';
 import { RULE_PROFILES } from '../../../src/constants/profiles.js';
 
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
 export function registerInitializeProjectTool(server) {
+	// Pre-convert Zod schema to JSON Schema with explicit Draft 7 target
+	const parametersSchema = z.object({
+		skipInstall: z
+			.boolean()
+			.optional()
+			.default(false)
+			.describe(
+				'Skip installing dependencies automatically. Never do this unless you are sure the project is already installed.'
+			),
+		addAliases: z
+			.boolean()
+			.optional()
+			.default(true)
+			.describe('Add shell aliases (tm, taskmaster) to shell config file.'),
+		initGit: z
+			.boolean()
+			.optional()
+			.default(true)
+			.describe('Initialize Git repository in project root.'),
+		storeTasksInGit: z
+			.boolean()
+			.optional()
+			.default(true)
+			.describe('Store tasks in Git (tasks.json and tasks/ directory).'),
+		yes: z
+			.boolean()
+			.optional()
+			.default(true)
+			.describe(
+				'Skip prompts and use default values. Always set to true for MCP tools.'
+			),
+		projectRoot: z
+			.string()
+			.describe(
+				'The root directory for the project. ALWAYS SET THIS TO THE PROJECT ROOT DIRECTORY. IF NOT SET, THE TOOL WILL NOT WORK.'
+			),
+		rules: z
+			.array(z.enum(RULE_PROFILES))
+			.optional()
+			.describe(
+				`List of rule profiles to include at initialization. If omitted, defaults to Cursor profile only. Available options: ${RULE_PROFILES.join(', ')}`
+			)
+	});
+	
+	// Convert to JSON Schema with explicit Draft 7 target
+	const jsonSchema = zodToJsonSchema(parametersSchema, { target: 'jsonSchema7' });
+	
 	server.addTool({
 		name: 'initialize_project',
 		description:
 			'Initializes a new Task Master project structure by calling the core initialization logic. Creates necessary folders and configuration files for Task Master in the current directory.',
-		parameters: z.object({
-			skipInstall: z
-				.boolean()
-				.optional()
-				.default(false)
-				.describe(
-					'Skip installing dependencies automatically. Never do this unless you are sure the project is already installed.'
-				),
-			addAliases: z
-				.boolean()
-				.optional()
-				.default(true)
-				.describe('Add shell aliases (tm, taskmaster) to shell config file.'),
-			initGit: z
-				.boolean()
-				.optional()
-				.default(true)
-				.describe('Initialize Git repository in project root.'),
-			storeTasksInGit: z
-				.boolean()
-				.optional()
-				.default(true)
-				.describe('Store tasks in Git (tasks.json and tasks/ directory).'),
-			yes: z
-				.boolean()
-				.optional()
-				.default(true)
-				.describe(
-					'Skip prompts and use default values. Always set to true for MCP tools.'
-				),
-			projectRoot: z
-				.string()
-				.describe(
-					'The root directory for the project. ALWAYS SET THIS TO THE PROJECT ROOT DIRECTORY. IF NOT SET, THE TOOL WILL NOT WORK.'
-				),
-			rules: z
-				.array(z.enum(RULE_PROFILES))
-				.optional()
-				.describe(
-					`List of rule profiles to include at initialization. If omitted, defaults to Cursor profile only. Available options: ${RULE_PROFILES.join(', ')}`
-				)
-		}),
+		parameters: jsonSchema,
 		execute: withNormalizedProjectRoot(async (args, context) => {
 			const { log } = context;
 			const session = context.session;

--- a/mcp-server/src/utils/schema-utils.js
+++ b/mcp-server/src/utils/schema-utils.js
@@ -1,0 +1,21 @@
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+/**
+ * Converts a Zod schema to JSON Schema with explicit target version
+ * @param {import('zod').ZodTypeAny} schema - The Zod schema to convert
+ * @param {string} target - The JSON Schema target version ('jsonSchema7' or 'jsonSchema2019-09')
+ * @returns {Promise<Object>} The JSON Schema object
+ */
+export async function convertZodToJSONSchema(schema, target = 'jsonSchema7') {
+  // Use zod-to-json-schema directly with target option
+  const jsonSchema = zodToJsonSchema(schema, { target });
+  
+  // Ensure the $schema property is set correctly
+  if (target === 'jsonSchema7') {
+    jsonSchema.$schema = 'http://json-schema.org/draft-07/schema#';
+  } else if (target === 'jsonSchema2019-09') {
+    jsonSchema.$schema = 'https://json-schema.org/draft/2019-09/schema#';
+  }
+  
+  return jsonSchema;
+}


### PR DESCRIPTION
## Issue
The Taskmaster AI MCP server fails to start in Augment IDE (WebStorm) with the following error:

```
⚠️  MCP server startup error: Invalid schema for tool initialize_project: no schema with key or ref "https://json-schema.org/draft/2020-12/schema" 
   Command: npx -y --package=task-master-ai task-master-ai
```

## Root Cause
The `initialize_project` tool is using **JSON Schema Draft 2020-12** (`https://json-schema.org/draft/2020-12/schema`), but the MCP client only supports older JSON Schema drafts (likely Draft-07 or Draft-04).

## Solution
This PR ensures that all Zod schemas are converted to JSON Schema Draft 7, which is compatible with most MCP clients. The changes:

1. Pre-convert Zod schemas to JSON Schema objects with explicit Draft 7 target before passing to fastmcp
2. Add utility functions for proper schema conversion
3. Create a wrapper for FastMCP to ensure consistent schema handling

## Testing
Tested with Augment IDE (WebStorm) to verify the MCP server now starts correctly.

Fixes #1284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized tool input schemas to JSON Schema Draft 7 for improved compatibility with clients and integrations.
- Refactor
  - Centralized conversion of Zod schemas to JSON Schema with a shared utility.
  - Updated tool registration to use pre-converted JSON Schemas for clearer, consistent validation.
  - Adopted a local wrapper to enforce schema standards while preserving existing behavior.
- Bug Fixes
  - Reduced schema version mismatches, improving reliability of tool input validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->