### PR TITLE
feat: add TM_ACTIVE_TAG for session-based tag isolation

### DIFF
--- a/.changeset/session-based-tags.md
+++ b/.changeset/session-based-tags.md
@@ -1,0 +1,5 @@
+---
+"@tm/core": minor
+---
+
+Enhanced TASKMASTER_TAG environment variable support for session-based tag isolation. Enables multiple Claude Code sessions to work on different tags simultaneously by setting TASKMASTER_TAG in each terminal session. Includes comprehensive test coverage and field name consistency fixes throughout the codebase.


### PR DESCRIPTION
## Summary

Enhances existing `TASKMASTER_TAG` environment variable to enable session-based tag isolation, allowing multiple Claude Code sessions to work on different tags simultaneously. This implements the solution proposed in #1306.

## Key Discovery

The `TASKMASTER_TAG` environment variable already existed in the codebase but had limited test coverage and field naming inconsistencies. This PR enhances and validates the existing functionality rather than adding new features.

## Changes Made

### Enhanced Test Coverage
- Added 21 comprehensive tests for runtime state management
- Added session isolation test scenarios validating multi-session independence
- Fixed test field naming consistency (`activeTag` → `currentTag`)
- All tests passing ✓

### Field Name Consistency
- Fixed inconsistent field naming throughout codebase
- Standardized on `currentTag` instead of `activeTag`
- Updated all references in tests and implementation

### Changeset
- Added changeset documenting session-based tag isolation feature
- Marked as minor version bump for enhanced functionality

## Usage Examples

### Basic Session-Based Tagging
```bash
# Terminal 1 - Weather data ingestion
export TASKMASTER_TAG=weather
tm list  # Shows only weather tasks

# Terminal 2 - Property data ingestion
export TASKMASTER_TAG=property
tm list  # Shows only property tasks

# Both sessions work independently without interference
```

### How It Works
Each terminal session with `TASKMASTER_TAG` set maintains its own tag context:
- Environment variable overrides global config
- Sessions remain isolated even if global config changes
- No temporary files or additional complexity needed

## Testing

```bash
# Run tests
npm run build
npx vitest run packages/tm-core/src/config/services/runtime-state-manager.service.spec.ts

# Result: 21 passed ✓
```

## Benefits

1. **Multi-session workflows**: Work on 4 different PRDs simultaneously in separate Claude Code sessions
2. **Session isolation**: Tag changes in one session don't affect others
3. **Simple implementation**: Just set an environment variable per terminal
4. **Zero breaking changes**: Existing workflows unchanged

## Related

- Fixes #1306
- Feature request for session-based tag isolation

## Risk Assessment

**Low** - Enhanced test coverage for existing feature, field name consistency fixes only

## Deployment Notes

None required - environment variable feature activates automatically when set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added session-based tag isolation via TASKMASTER_TAG, allowing multiple simultaneous sessions to use different tags per terminal.
- Refactor
  - Standardized tag terminology across the app for clearer behavior and consistency.
- Tests
  - Expanded coverage to validate per-session tag contexts and stability under concurrent usage.
- Chores
  - Recorded a minor release entry to capture these enhancements and consistency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->