### PR TITLE
fix: Add emoji variant selector to warning signs

### DIFF
--- a/.changeset/fix-emoji-box-titles.md
+++ b/.changeset/fix-emoji-box-titles.md
@@ -1,0 +1,5 @@
+---
+'@tm/cli': patch
+---
+
+Fix box title alignment by adding emoji variant selector to warning sign

--- a/apps/cli/src/commands/auth.command.ts
+++ b/apps/cli/src/commands/auth.command.ts
@@ -408,14 +408,14 @@ Examples:
 						}
 					} else {
 						console.log(
-							chalk.yellow('⚠ Context setup was skipped or encountered issues')
+							chalk.yellow('⚠️ Context setup was skipped or encountered issues')
 						);
 						console.log(
 							chalk.gray('  You can set up context later with "tm context"')
 						);
 					}
 				} catch (contextError) {
-					console.log(chalk.yellow('⚠ Context setup encountered an error'));
+					console.log(chalk.yellow('⚠️ Context setup encountered an error'));
 					console.log(
 						chalk.gray('  You can set up context later with "tm context"')
 					);
@@ -551,14 +551,14 @@ Examples:
 						}
 					} else {
 						console.log(
-							chalk.yellow('⚠ Context setup was skipped or encountered issues')
+							chalk.yellow('⚠️ Context setup was skipped or encountered issues')
 						);
 						console.log(
 							chalk.gray('  You can set up context later with "tm context"')
 						);
 					}
 				} catch (contextError) {
-					console.log(chalk.yellow('⚠ Context setup encountered an error'));
+					console.log(chalk.yellow('⚠️ Context setup encountered an error'));
 					console.log(
 						chalk.gray('  You can set up context later with "tm context"')
 					);

--- a/apps/cli/src/commands/autopilot/shared.ts
+++ b/apps/cli/src/commands/autopilot/shared.ts
@@ -216,7 +216,7 @@ export class OutputFormatter {
 				)
 			);
 		} else {
-			console.warn(chalk.yellow(`⚠ ${message}`));
+			console.warn(chalk.yellow(`⚠️ ${message}`));
 		}
 	}
 

--- a/apps/cli/src/commands/next.command.ts
+++ b/apps/cli/src/commands/next.command.ts
@@ -192,7 +192,7 @@ export class NextCommand extends Command {
 						padding: 1,
 						borderStyle: 'round',
 						borderColor: 'yellow',
-						title: '⚠ NO TASKS AVAILABLE ⚠',
+						title: '⚠️ NO TASKS AVAILABLE ⚠️',
 						titleAlignment: 'center'
 					}
 				)

--- a/apps/cli/src/commands/show.command.ts
+++ b/apps/cli/src/commands/show.command.ts
@@ -291,7 +291,7 @@ export class ShowCommand extends Command {
 		});
 
 		if (result.notFound.length > 0) {
-			console.log(chalk.yellow(`\n⚠ Not found: ${result.notFound.join(', ')}`));
+			console.log(chalk.yellow(`\n⚠️ Not found: ${result.notFound.join(', ')}`));
 		}
 
 		if (result.tasks.length === 0) {

--- a/apps/cli/src/ui/components/next-task.component.ts
+++ b/apps/cli/src/ui/components/next-task.component.ts
@@ -38,7 +38,7 @@ export function displayRecommendedNextTask(
 					padding: 1,
 					borderStyle: 'round',
 					borderColor: 'yellow',
-					title: '⚠ NO TASKS AVAILABLE ⚠',
+					title: '⚠️ NO TASKS AVAILABLE ⚠️',
 					titleAlignment: 'center'
 				}
 			)

--- a/apps/cli/src/utils/ui.ts
+++ b/apps/cli/src/utils/ui.ts
@@ -233,7 +233,7 @@ export function displayWarning(message: string): void {
 	const boxWidth = getBoxWidth();
 
 	console.log(
-		boxen(chalk.yellow.bold('⚠ ') + chalk.white(message), {
+		boxen(chalk.yellow.bold('⚠️ ') + chalk.white(message), {
 			padding: 1,
 			borderStyle: 'round',
 			borderColor: 'yellow',


### PR DESCRIPTION
Fixes #1394

## Problem

Warning signs weren't aligning correctly in boxen titles - title line was 1 character short on each side.

## Root Cause

The code uses plain **text presentation** `⚠` (U+26A0) instead of **emoji presentation** `⚠️` (U+26A0 + U+FE0F variant selector).

Boxen's `titleAlignment: 'center'` handles emoji presentation correctly (like `⚡`) but has a bug with text presentation characters.

## Solution

Add the emoji variant selector U+FE0F to force emoji presentation across all warning signs in the CLI:

```diff
- '⚠ NO TASKS AVAILABLE ⚠'
+ '⚠️ NO TASKS AVAILABLE ⚠️'
```

The variant selector is invisible but changes the bytes from `e2 9a a0` to `e2 9a a0 ef b8 8f`, forcing emoji rendering.

## Files Changed (7 files)

- `apps/cli/src/commands/next.command.ts` - box title
- `apps/cli/src/ui/components/next-task.component.ts` - box title
- `apps/cli/src/utils/ui.ts` - warning display
- `apps/cli/src/commands/auth.command.ts` - 4 warning messages
- `apps/cli/src/commands/show.command.ts` - not found warning  
- `apps/cli/src/commands/autopilot/shared.ts` - warning logger

All warning signs now render consistently as emoji presentation!