### PR TITLE
fix: improve display of subtasks based on storageType

### DIFF
--- a/.changeset/five-areas-heal.md
+++ b/.changeset/five-areas-heal.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix subtasks not showing parent task when displaying in cli (eg. tm show 10)

--- a/apps/cli/src/commands/next.command.ts
+++ b/apps/cli/src/commands/next.command.ts
@@ -211,7 +211,8 @@ export class NextCommand extends Command {
 		displayTaskDetails(task, {
 			customHeader,
 			headerColor: 'green',
-			showSuggestedActions: true
+			showSuggestedActions: true,
+			storageType: result.storageType
 		});
 	}
 

--- a/apps/cli/src/commands/show.command.ts
+++ b/apps/cli/src/commands/show.command.ts
@@ -272,7 +272,8 @@ export class ShowCommand extends Command {
 		displayTaskDetails(result.task, {
 			statusFilter: options.status,
 			showSuggestedActions: true,
-			originalTaskId: result.originalTaskId
+			originalTaskId: result.originalTaskId,
+			storageType: result.storageType
 		});
 	}
 

--- a/apps/cli/src/commands/start.command.ts
+++ b/apps/cli/src/commands/start.command.ts
@@ -7,6 +7,7 @@
 import { spawn } from 'child_process';
 import {
 	type StartTaskResult as CoreStartTaskResult,
+	type StorageType,
 	type TmCore,
 	createTmCore
 } from '@tm/core';
@@ -16,8 +17,8 @@ import { Command } from 'commander';
 import ora, { type Ora } from 'ora';
 import { displayTaskDetails } from '../ui/components/task-detail.component.js';
 import { displayError } from '../utils/error-handler.js';
-import * as ui from '../utils/ui.js';
 import { getProjectRoot } from '../utils/project-root.js';
+import * as ui from '../utils/ui.js';
 
 /**
  * CLI-specific options interface for the start command
@@ -36,7 +37,7 @@ export interface StartCommandOptions {
  * Extends the core result with CLI-specific display information
  */
 export interface StartCommandResult extends CoreStartTaskResult {
-	storageType?: string;
+	storageType?: Exclude<StorageType, 'auto'>;
 }
 
 /**
@@ -366,7 +367,8 @@ export class StartCommand extends Command {
 
 			displayTaskDetails(task, {
 				customHeader: headerText,
-				headerColor: 'yellow'
+				headerColor: 'yellow',
+				storageType: result.storageType
 			});
 
 			// Show claude-code prompt

--- a/apps/cli/src/ui/components/task-detail.component.ts
+++ b/apps/cli/src/ui/components/task-detail.component.ts
@@ -3,7 +3,7 @@
  * Displays detailed task information in a structured format
  */
 
-import type { Subtask, Task } from '@tm/core';
+import type { StorageType, Subtask, Task } from '@tm/core';
 import boxen from 'boxen';
 import chalk from 'chalk';
 import Table from 'cli-table3';
@@ -198,7 +198,9 @@ export function displaySubtasks(
 		status: any;
 		description?: string;
 		dependencies?: string[];
-	}>
+	}>,
+	parentTaskId?: string | number,
+	storageType?: Exclude<StorageType, 'auto'>
 ): void {
 	const terminalWidth = process.stdout.columns * 0.95 || 100;
 	// Display subtasks header
@@ -233,7 +235,13 @@ export function displaySubtasks(
 	});
 
 	subtasks.forEach((subtask) => {
-		const subtaskId = String(subtask.id);
+		// Format subtask ID based on storage type:
+		// - File storage: Show parent prefix (e.g., 10.1, 10.2)
+		// - API storage: Show subtask ID only (e.g., 1, 2)
+		const subtaskId =
+			storageType === 'file' && parentTaskId
+				? `${parentTaskId}.${subtask.id}`
+				: String(subtask.id);
 
 		// Format dependencies
 		const deps =
@@ -285,6 +293,7 @@ export function displayTaskDetails(
 		customHeader?: string;
 		headerColor?: string;
 		originalTaskId?: string;
+		storageType?: Exclude<StorageType, 'auto'>;
 	}
 ): void {
 	const {
@@ -292,7 +301,8 @@ export function displayTaskDetails(
 		showSuggestedActions = false,
 		customHeader,
 		headerColor = 'blue',
-		originalTaskId
+		originalTaskId,
+		storageType
 	} = options || {};
 
 	// Display header - either custom or default
@@ -338,7 +348,7 @@ export function displayTaskDetails(
 			console.log(chalk.gray(`  No subtasks with status '${statusFilter}'`));
 		} else if (filteredSubtasks.length > 0) {
 			console.log(); // Empty line for spacing
-			displaySubtasks(filteredSubtasks);
+			displaySubtasks(filteredSubtasks, task.id, storageType);
 		}
 	}
 


### PR DESCRIPTION
# What type of PR is this?
<!-- Check one -->

 - [ ] 🐛 Bug fix
 - [ ] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [ ] Created changeset: `npm run changeset`
- [ ] Tests pass: `npm test`
- [ ] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subtasks not displaying their parent task information correctly in CLI commands, ensuring proper task hierarchy representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->