### PR TITLE
fix: add terminal-link to root dependencies for global install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "task-master-ai",
-	"version": "0.36.0-rc.0",
+	"version": "0.36.0-rc.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "task-master-ai",
-			"version": "0.36.0-rc.0",
+			"version": "0.36.0-rc.1",
 			"license": "MIT WITH Commons-Clause",
 			"workspaces": [
 				"apps/*",
@@ -69,6 +69,7 @@
 				"ora": "^8.2.0",
 				"simple-git": "^3.28.0",
 				"steno": "^4.0.2",
+				"terminal-link": "^5.0.0",
 				"turndown": "^7.2.2",
 				"undici": "^7.16.0",
 				"uuid": "^11.1.0",
@@ -203,7 +204,7 @@
 				"react-dom": "^19.0.0",
 				"tailwind-merge": "^3.3.1",
 				"tailwindcss": "4.1.11",
-				"task-master-ai": "0.36.0-rc.0",
+				"task-master-ai": "0.36.0-rc.1",
 				"typescript": "^5.9.2"
 			},
 			"engines": {
@@ -34418,20 +34419,6 @@
 			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
 			"license": "MIT"
 		},
-		"node_modules/tsup/node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/tsx": {
 			"version": "4.20.6",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
@@ -34898,6 +34885,7 @@
 			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/unist": "^3.0.0",
 				"bail": "^2.0.0",
@@ -35595,21 +35583,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/walker": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -36195,7 +36168,7 @@
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 		"ora": "^8.2.0",
 		"simple-git": "^3.28.0",
 		"steno": "^4.0.2",
+		"terminal-link": "^5.0.0",
 		"turndown": "^7.2.2",
 		"undici": "^7.16.0",
 		"uuid": "^11.1.0",


### PR DESCRIPTION
## Problem

When users install `task-master-ai@rc` globally and run `tm list`, they get:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'terminal-link' imported from .../dist/dependency-manager-DIOZ_B7q.js
```

## Root Cause

The `terminal-link` package is used by `apps/cli/src/ui/formatters/link-formatters.ts` but was only listed as a dependency in `apps/cli/package.json`, not in the root `package.json`.

Since the bundler (tsdown) keeps npm dependencies external (only bundling `@tm/*` workspace packages), when users install `task-master-ai` globally, only the dependencies from the root `package.json` are installed — so `terminal-link` was missing.

## Fix

Added `"terminal-link": "^5.0.0"` to root `package.json` dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->