### PR TITLE
fix: parse-prd with --input parameter not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "task-master-ai",
-	"version": "0.36.0-rc.1",
+	"version": "0.36.0-rc.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "task-master-ai",
-			"version": "0.36.0-rc.1",
+			"version": "0.36.0-rc.2",
 			"license": "MIT WITH Commons-Clause",
 			"workspaces": [
 				"apps/*",
@@ -204,7 +204,7 @@
 				"react-dom": "^19.0.0",
 				"tailwind-merge": "^3.3.1",
 				"tailwindcss": "4.1.11",
-				"task-master-ai": "0.36.0-rc.1",
+				"task-master-ai": "0.36.0-rc.2",
 				"typescript": "^5.9.2"
 			},
 			"engines": {

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -934,11 +934,14 @@ function registerCommands(programInstance) {
 		)
 		.option('--tag <tag>', 'Specify tag context for task operations')
 		.action(async (file, options) => {
+			// Resolve PRD path: prioritize --input option, then positional argument
+			const prdPath = options.input || file;
+
 			// Initialize TaskMaster
 			let taskMaster;
 			try {
 				const initOptions = {
-					prdPath: file || options.input || true,
+					prdPath: prdPath || true,
 					tag: options.tag
 				};
 				// Only include tasksPath if output is explicitly specified
@@ -978,7 +981,7 @@ function registerCommands(programInstance) {
 			const collaborationChoice = await promptHamsterCollaboration();
 			if (collaborationChoice === 'hamster') {
 				// User chose Hamster - send PRD to Hamster for brief creation
-				await handleParsePrdToHamster(file);
+				await handleParsePrdToHamster(taskMaster.getPrdPath());
 				return;
 			}
 


### PR DESCRIPTION
- enhance error handling in export service

# What type of PR is this?
<!-- Check one -->

 - [ ] 🐛 Bug fix
 - [ ] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [ ] Created changeset: `npm run changeset`
- [ ] Tests pass: `npm test`
- [ ] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution in the parse-prd command to ensure correct file handling and improved reliability.

* **Improvements**
  * Team invitations now gracefully handle cases where users are already members of the team instead of returning an error.
  * Enhanced error messaging for clearer feedback when invitation operations encounter issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->