### PR TITLE
feat(project-root): enhance project root detection with boundary markers

### DIFF
--- a/.changeset/lazy-lies-argue.md
+++ b/.changeset/lazy-lies-argue.md
@@ -1,0 +1,9 @@
+---
+"task-master-ai": patch
+---
+
+Smarter project root detection with boundary markers
+
+- Prevents Task Master from incorrectly detecting `.taskmaster` folders in your home directory when working inside a different project
+- Now stops at project boundaries (`.git`, `package.json`, lock files) instead of searching all the way up to the filesystem root
+- Adds support for monorepo markers (`lerna.json`, `nx.json`, `turbo.json`) and additional lock files (`bun.lockb`, `deno.lock`)

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -24,7 +24,8 @@
 	"dependencies": {
 		"@tm/core": "*",
 		"fastmcp": "^3.23.0",
-		"zod": "^4.1.11"
+		"zod": "^4.1.11",
+		"dotenv": "^16.6.1"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/apps/mcp/src/shared/utils.ts
+++ b/apps/mcp/src/shared/utils.ts
@@ -2,6 +2,7 @@
  * Shared utilities for MCP tools
  */
 
+import dotenv from 'dotenv';
 import fs from 'node:fs';
 import path from 'node:path';
 import {
@@ -395,6 +396,13 @@ export function withToolContext<TArgs extends { projectRoot?: string }>(
 			args: TArgs & { projectRoot: string },
 			context: Context<undefined>
 		) => {
+			// Load project .env if it exists (won't overwrite MCP-provided env vars)
+			// This ensures project-specific env vars are available to tool execution
+			const envPath = path.join(args.projectRoot, '.env');
+			if (fs.existsSync(envPath)) {
+				dotenv.config({ path: envPath });
+			}
+
 			// Create tmCore instance
 			const tmCore = await createTmCore({
 				projectPath: args.projectRoot,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "task-master-ai",
-	"version": "0.39.0",
+	"version": "0.40.0-rc.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "task-master-ai",
-			"version": "0.39.0",
+			"version": "0.40.0-rc.1",
 			"license": "MIT WITH Commons-Clause",
 			"workspaces": [
 				"apps/*",
@@ -1850,7 +1850,7 @@
 				"react-dom": "^19.0.0",
 				"tailwind-merge": "^3.3.1",
 				"tailwindcss": "4.1.11",
-				"task-master-ai": "*",
+				"task-master-ai": "0.40.0-rc.1",
 				"typescript": "^5.9.2"
 			},
 			"engines": {
@@ -1971,6 +1971,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@tm/core": "*",
+				"dotenv": "^16.6.1",
 				"fastmcp": "^3.23.0",
 				"zod": "^4.1.11"
 			},

--- a/packages/tm-core/src/common/utils/project-root-finder.test.ts
+++ b/packages/tm-core/src/common/utils/project-root-finder.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @fileoverview Integration tests for project root detection
+ *
+ * These tests verify real-world scenarios for project root detection,
+ * particularly edge cases around:
+ * - Empty directories (tm init scenario)
+ * - .taskmaster in home/parent directories that should be ignored
+ * - Monorepo detection
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findProjectRoot } from './project-root-finder.js';
+
+describe('findProjectRoot - Integration Tests', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		// Create a temporary directory structure for testing
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-integration-test-'));
+	});
+
+	afterEach(() => {
+		// Clean up temp directory
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	describe('Empty directory scenarios (tm init)', () => {
+		it('should find .taskmaster in immediate parent (depth=1) even without boundary marker', () => {
+			// Scenario: User is in a subdirectory of a project that only has .taskmaster
+			// (no .git or package.json). This is a valid use case for projects where
+			// user ran `tm init` but not `git init`.
+			//
+			// Structure:
+			//   /project/.taskmaster
+			//   /project/src/ (start here)
+			//
+			// NOTE: For `tm init` command specifically, the command should use
+			// process.cwd() directly instead of findProjectRoot() to avoid
+			// finding a stray .taskmaster in a parent directory.
+
+			const projectDir = tempDir;
+			const srcDir = path.join(projectDir, 'src');
+
+			fs.mkdirSync(path.join(projectDir, '.taskmaster'));
+			fs.mkdirSync(srcDir);
+
+			const result = findProjectRoot(srcDir);
+
+			// Immediate parent (depth=1) is trusted even without boundary marker
+			expect(result).toBe(projectDir);
+		});
+
+		it('should return startDir when running from completely empty directory', () => {
+			// Scenario: User runs `tm init` in a brand new, completely empty directory
+			// No markers anywhere in the tree
+			//
+			// Structure:
+			//   /tmp/test/empty-project/ (empty)
+
+			const emptyProjectDir = path.join(tempDir, 'empty-project');
+			fs.mkdirSync(emptyProjectDir);
+
+			const result = findProjectRoot(emptyProjectDir);
+
+			// Should return the empty directory itself
+			expect(result).toBe(emptyProjectDir);
+		});
+
+		it('should return startDir when no boundary markers exist but .taskmaster exists in distant parent', () => {
+			// Scenario: Deep directory structure with .taskmaster only at top level
+			// No boundary markers (.git, package.json, etc.) anywhere
+			//
+			// Structure:
+			//   /tmp/home/.taskmaster (should be IGNORED - too far up)
+			//   /tmp/home/code/projects/my-app/ (empty - no markers)
+
+			const homeDir = tempDir;
+			const deepProjectDir = path.join(homeDir, 'code', 'projects', 'my-app');
+
+			fs.mkdirSync(path.join(homeDir, '.taskmaster'));
+			fs.mkdirSync(deepProjectDir, { recursive: true });
+
+			const result = findProjectRoot(deepProjectDir);
+
+			// Should return the deep directory, not home
+			expect(result).toBe(deepProjectDir);
+		});
+	});
+
+	describe('Project with boundary markers', () => {
+		it('should find .taskmaster when at same level as .git', () => {
+			// Scenario: Normal project setup with both .taskmaster and .git
+			//
+			// Structure:
+			//   /tmp/project/.taskmaster
+			//   /tmp/project/.git
+
+			const projectDir = tempDir;
+
+			fs.mkdirSync(path.join(projectDir, '.taskmaster'));
+			fs.mkdirSync(path.join(projectDir, '.git'));
+
+			const result = findProjectRoot(projectDir);
+
+			expect(result).toBe(projectDir);
+		});
+
+		it('should find .taskmaster in parent when subdirectory has no markers', () => {
+			// Scenario: Running from a subdirectory of an initialized project
+			//
+			// Structure:
+			//   /tmp/project/.taskmaster
+			//   /tmp/project/.git
+			//   /tmp/project/src/components/ (no markers)
+
+			const projectDir = tempDir;
+			const srcDir = path.join(projectDir, 'src', 'components');
+
+			fs.mkdirSync(path.join(projectDir, '.taskmaster'));
+			fs.mkdirSync(path.join(projectDir, '.git'));
+			fs.mkdirSync(srcDir, { recursive: true });
+
+			const result = findProjectRoot(srcDir);
+
+			expect(result).toBe(projectDir);
+		});
+
+		it('should stop at .git and NOT find .taskmaster beyond it', () => {
+			// Scenario: Project has .git but no .taskmaster, parent has .taskmaster
+			// Should use project with .git, not parent with .taskmaster
+			//
+			// Structure:
+			//   /tmp/home/.taskmaster (should be IGNORED)
+			//   /tmp/home/my-project/.git (boundary marker)
+
+			const homeDir = tempDir;
+			const projectDir = path.join(homeDir, 'my-project');
+
+			fs.mkdirSync(path.join(homeDir, '.taskmaster'));
+			fs.mkdirSync(path.join(projectDir, '.git'), { recursive: true });
+
+			const result = findProjectRoot(projectDir);
+
+			expect(result).toBe(projectDir);
+		});
+
+		it('should stop at package.json and NOT find .taskmaster beyond it', () => {
+			// Scenario: JS project with package.json but no .taskmaster
+			//
+			// Structure:
+			//   /tmp/home/.taskmaster (should be IGNORED)
+			//   /tmp/home/my-project/package.json (boundary)
+
+			const homeDir = tempDir;
+			const projectDir = path.join(homeDir, 'my-project');
+
+			fs.mkdirSync(path.join(homeDir, '.taskmaster'));
+			fs.mkdirSync(projectDir);
+			fs.writeFileSync(path.join(projectDir, 'package.json'), '{}');
+
+			const result = findProjectRoot(projectDir);
+
+			expect(result).toBe(projectDir);
+		});
+	});
+
+	describe('Monorepo scenarios', () => {
+		it('should find monorepo root .taskmaster from package subdirectory', () => {
+			// Scenario: Monorepo with .taskmaster at root, packages without their own markers
+			//
+			// Structure:
+			//   /tmp/monorepo/.taskmaster
+			//   /tmp/monorepo/.git
+			//   /tmp/monorepo/packages/my-package/src/
+
+			const monorepoRoot = tempDir;
+			const packageSrcDir = path.join(
+				monorepoRoot,
+				'packages',
+				'my-package',
+				'src'
+			);
+
+			fs.mkdirSync(path.join(monorepoRoot, '.taskmaster'));
+			fs.mkdirSync(path.join(monorepoRoot, '.git'));
+			fs.mkdirSync(packageSrcDir, { recursive: true });
+
+			const result = findProjectRoot(packageSrcDir);
+
+			expect(result).toBe(monorepoRoot);
+		});
+
+		it('should return package root when package has its own boundary marker', () => {
+			// Scenario: Monorepo where individual package has its own package.json
+			// Package should be treated as its own project
+			//
+			// Structure:
+			//   /tmp/monorepo/.taskmaster
+			//   /tmp/monorepo/packages/my-package/package.json (boundary)
+
+			const monorepoRoot = tempDir;
+			const packageDir = path.join(monorepoRoot, 'packages', 'my-package');
+
+			fs.mkdirSync(path.join(monorepoRoot, '.taskmaster'));
+			fs.mkdirSync(packageDir, { recursive: true });
+			fs.writeFileSync(path.join(packageDir, 'package.json'), '{}');
+
+			const result = findProjectRoot(packageDir);
+
+			// Package has its own boundary, so it should be returned
+			expect(result).toBe(packageDir);
+		});
+
+		it('should return package root when package has its own .taskmaster', () => {
+			// Scenario: Nested Task Master initialization
+			//
+			// Structure:
+			//   /tmp/monorepo/.taskmaster
+			//   /tmp/monorepo/packages/my-package/.taskmaster
+
+			const monorepoRoot = tempDir;
+			const packageDir = path.join(monorepoRoot, 'packages', 'my-package');
+
+			fs.mkdirSync(path.join(monorepoRoot, '.taskmaster'));
+			fs.mkdirSync(path.join(packageDir, '.taskmaster'), { recursive: true });
+
+			const result = findProjectRoot(packageDir);
+
+			// Package has its own .taskmaster, so it should be returned
+			expect(result).toBe(packageDir);
+		});
+	});
+
+	describe('Environment variable loading context', () => {
+		it('should document that .env loading should use process.cwd(), not findProjectRoot()', () => {
+			// IMPORTANT: For .env loading (e.g., TM_BASE_DOMAIN for auth),
+			// the code should use process.cwd() directly, NOT findProjectRoot().
+			//
+			// findProjectRoot() is designed to find the .taskmaster directory
+			// for task storage. It will traverse up to find .taskmaster in parent
+			// directories when appropriate.
+			//
+			// For environment variables, we want to load from WHERE the user
+			// is running the command, not where .taskmaster is located.
+			//
+			// This test documents this design decision and verifies findProjectRoot
+			// behavior when .taskmaster is in immediate parent (depth=1).
+
+			const projectDir = tempDir;
+			const subDir = path.join(projectDir, 'subdir');
+
+			fs.mkdirSync(path.join(projectDir, '.taskmaster'));
+			fs.mkdirSync(subDir);
+
+			const result = findProjectRoot(subDir);
+
+			// findProjectRoot WILL find parent's .taskmaster (depth=1 is trusted)
+			// This is correct for task storage - we want to use the parent's tasks.json
+			// For .env loading, callers should use process.cwd() instead
+			expect(result).toBe(projectDir);
+		});
+	});
+});

--- a/tests/unit/task-master.test.js
+++ b/tests/unit/task-master.test.js
@@ -93,9 +93,12 @@ describe('initTaskMaster', () => {
 		});
 
 		test('should find project root from deeply nested subdirectory', () => {
-			// Arrange - Create .taskmaster directory in temp dir
+			// Arrange - Create .taskmaster directory and a boundary marker in temp dir
+			// The boundary marker (.git) anchors .taskmaster to prevent false matches
+			// from stray .taskmaster dirs (e.g., in home directory)
 			const taskMasterDir = path.join(tempDir, TASKMASTER_DIR);
 			fs.mkdirSync(taskMasterDir, { recursive: true });
+			fs.mkdirSync(path.join(tempDir, '.git'), { recursive: true });
 
 			// Create deeply nested subdirectory and change to it
 			const deepDir = path.join(tempDir, 'src', 'components', 'ui');


### PR DESCRIPTION


# What type of PR is this?
<!-- Check one -->

 - [ ] 🐛 Bug fix
 - [x] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->
- Improved detection logic to prevent false positives from stray `.taskmaster` directories in home directories.
- Now stops searching at project boundaries defined by `.git`, `package.json`, and other lock files.
- Added support for monorepo markers like `lerna.json`, `nx.json`, and `turbo.json`.
- Introduced integration tests to validate various project root detection scenarios.

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [ ] Created changeset: `npm run changeset`
- [ ] Tests pass: `npm test`
- [ ] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect project root detection in home directories when working inside different projects
  * Now stops at project boundaries (.git, package.json, lock files) instead of searching to filesystem root

* **New Features**
  * Added support for monorepo markers and additional lock file types

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->