### PR TITLE
Update link for Microsoft Research RPG Paper

### DIFF
--- a/apps/docs/capabilities/rpg-method.mdx
+++ b/apps/docs/capabilities/rpg-method.mdx
@@ -317,7 +317,7 @@ Without test strategy, the AI won't know what to test during implementation.
 
 - [PRD Creation and Parsing Guide](/getting-started/quick-start/prd-quick)
 - [Task Structure Documentation](/capabilities/task-structure)
-- [Microsoft Research RPG Paper](https://arxiv.org/abs/2410.21376) (Original methodology)
+- [Microsoft Research RPG Paper](https://arxiv.org/html/2509.16198) (Original methodology)
 
 ---
 


### PR DESCRIPTION
Fix: #1570

# What type of PR is this?


 -  🐛 Bug fix

## Description
This PR updates the wrong link for the **Microsoft Research RPG Paper** to point to the correct and currently accessible resource. 


## Related Issues
Fixes #1570

## How to Test This

- Go to: https://docs.task-master.dev/capabilities/rpg-method#further-reading
- Click on **Microsoft Research RPG Paper** under Further Reading Section of the page.

**Expected result:**

The link should redirect to the correct Microsoft Research RPG Paper and load successfully.



## Changelog Entry

Updated the Microsoft Research RPG Paper link to the correct source.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation to point to the correct source for the RPG methodology.
> 
> - Replaces the "Microsoft Research RPG Paper" link in `apps/docs/capabilities/rpg-method.mdx` (Further Reading) with `https://arxiv.org/html/2509.16198`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa07acb1200a04dd48a9265884268c0f686d3d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference link in the RPG method documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->