### PR TITLE
fix(loop): improve error handling and use dangerously-skip-permissions

### DIFF
--- a/.changeset/loop-error-handling.md
+++ b/.changeset/loop-error-handling.md
@@ -1,0 +1,10 @@
+---
+"task-master-ai": "patch"
+---
+
+Improve loop command error handling and use dangerously-skip-permissions
+
+- Add proper spawn error handling (ENOENT, EACCES) with actionable messages
+- Return error info from checkSandboxAuth and runInteractiveAuth instead of silent failures
+- Use --dangerously-skip-permissions for unattended loop execution
+- Fix null exit code masking issue

--- a/.changeset/loop-sandbox-optional.md
+++ b/.changeset/loop-sandbox-optional.md
@@ -1,6 +1,5 @@
 ---
-"@tm/core": patch
-"@tm/cli": patch
+"task-master-ai": patch
 ---
 
 Make Docker sandbox mode opt-in for loop command

--- a/apps/cli/src/commands/loop.command.ts
+++ b/apps/cli/src/commands/loop.command.ts
@@ -6,9 +6,9 @@ import path from 'node:path';
 import {
 	type LoopConfig,
 	type LoopResult,
+	PRESET_NAMES,
 	type TmCore,
-	createTmCore,
-	PRESET_NAMES
+	createTmCore
 } from '@tm/core';
 import chalk from 'chalk';
 import { Command } from 'commander';
@@ -127,9 +127,13 @@ export class LoopCommand extends Command {
 
 	private handleSandboxAuth(): void {
 		console.log(chalk.dim('Checking sandbox auth...'));
-		const isAuthed = this.tmCore.loop.checkSandboxAuth();
+		const authCheck = this.tmCore.loop.checkSandboxAuth();
 
-		if (isAuthed) {
+		if (authCheck.error) {
+			throw new Error(authCheck.error);
+		}
+
+		if (authCheck.ready) {
 			console.log(chalk.green('✓ Sandbox ready'));
 			return;
 		}
@@ -141,7 +145,10 @@ export class LoopCommand extends Command {
 		);
 		console.log(chalk.dim('Please complete auth, then Ctrl+C to continue.\n'));
 
-		this.tmCore.loop.runInteractiveAuth();
+		const authResult = this.tmCore.loop.runInteractiveAuth();
+		if (!authResult.success) {
+			throw new Error(authResult.error || 'Interactive authentication failed');
+		}
 		console.log(chalk.green('✓ Auth complete\n'));
 	}
 

--- a/packages/tm-core/src/modules/loop/loop-domain.ts
+++ b/packages/tm-core/src/modules/loop/loop-domain.ts
@@ -31,9 +31,9 @@ export class LoopDomain {
 
 	/**
 	 * Check if Docker sandbox auth is ready
-	 * @returns true if ready, false if auth needed
+	 * @returns Object with ready status and optional error message
 	 */
-	checkSandboxAuth(): boolean {
+	checkSandboxAuth(): { ready: boolean; error?: string } {
 		const service = new LoopService({ projectRoot: this.projectRoot });
 		return service.checkSandboxAuth();
 	}
@@ -41,10 +41,11 @@ export class LoopDomain {
 	/**
 	 * Run Docker sandbox session for user authentication
 	 * Blocks until user completes auth
+	 * @returns Object with success status and optional error message
 	 */
-	runInteractiveAuth(): void {
+	runInteractiveAuth(): { success: boolean; error?: string } {
 		const service = new LoopService({ projectRoot: this.projectRoot });
-		service.runInteractiveAuth();
+		return service.runInteractiveAuth();
 	}
 
 	// ========== Loop Operations ==========


### PR DESCRIPTION

# What type of PR is this?
<!-- Check one -->

 - [x] 🐛 Bug fix
 - [ ] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->
- Add proper spawn error handling with actionable messages:
  - ENOENT: "Claude CLI not installed" or "Docker not installed"
  - EACCES: "Permission denied"
- Return error info from checkSandboxAuth/runInteractiveAuth
- Use --dangerously-skip-permissions for unattended loop execution
- Fix null exit code masking (was `?? 1`, now explicit check)
- Update fileoverview comment to reflect CLI mode support

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [ ] Created changeset: `npm run changeset`
- [ ] Tests pass: `npm test`
- [ ] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dangerously-skip-permissions` flag for unattended loop execution.

* **Bug Fixes**
  * Improved error messages for missing Docker dependencies and permission issues.
  * Enhanced error reporting in authentication flows for clearer failure diagnostics.
  * Fixed null exit code handling in loop iterations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->