### PR TITLE
fix(models): update Codex CLI supported models to match current availability

### DIFF
--- a/.changeset/update-codex-cli-models.md
+++ b/.changeset/update-codex-cli-models.md
@@ -1,0 +1,10 @@
+---
+"task-master-ai": patch
+---
+
+Update Codex CLI supported models to match current available models
+
+- Remove deprecated models: gpt-5, gpt-5-codex, gpt-5.1
+- Add gpt-5.2-codex as the current default model
+- Add gpt-5.1-codex-mini for faster, cheaper option
+- Keep gpt-5.1-codex-max and gpt-5.2

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -130,41 +130,21 @@
 	],
 	"codex-cli": [
 		{
-			"id": "gpt-5",
-			"swe_score": 0.749,
+			"id": "gpt-5.2-codex",
+			"name": "GPT-5.2 Codex",
+			"swe_score": 0.82,
 			"cost_per_1m_tokens": {
 				"input": 0,
 				"output": 0
 			},
 			"allowed_roles": ["main", "fallback", "research"],
 			"max_tokens": 128000,
-			"supported": true
-		},
-		{
-			"id": "gpt-5-codex",
-			"swe_score": 0.749,
-			"cost_per_1m_tokens": {
-				"input": 0,
-				"output": 0
-			},
-			"allowed_roles": ["main", "fallback", "research"],
-			"max_tokens": 128000,
-			"supported": true
-		},
-		{
-			"id": "gpt-5.1",
-			"swe_score": 0.76,
-			"cost_per_1m_tokens": {
-				"input": 0,
-				"output": 0
-			},
-			"allowed_roles": ["main", "fallback", "research"],
-			"max_tokens": 128000,
-			"reasoning_efforts": ["none", "low", "medium", "high"],
+			"reasoning_efforts": ["none", "low", "medium", "high", "xhigh"],
 			"supported": true
 		},
 		{
 			"id": "gpt-5.1-codex-max",
+			"name": "GPT-5.1 Codex Max",
 			"swe_score": 0.78,
 			"cost_per_1m_tokens": {
 				"input": 0,
@@ -176,7 +156,21 @@
 			"supported": true
 		},
 		{
+			"id": "gpt-5.1-codex-mini",
+			"name": "GPT-5.1 Codex Mini",
+			"swe_score": 0.72,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 128000,
+			"reasoning_efforts": ["none", "low", "medium", "high"],
+			"supported": true
+		},
+		{
 			"id": "gpt-5.2",
+			"name": "GPT-5.2",
 			"swe_score": 0.8,
 			"cost_per_1m_tokens": {
 				"input": 0,


### PR DESCRIPTION
# What type of PR is this?
<!-- Check one -->

 - [ ] 🐛 Bug fix
 - [x] ✨ Feature
 - [ ] 🔌 Integration
 - [ ] 📝 Docs
 - [ ] 🧹 Refactor
 - [ ] Other:
## Description
<!-- What does this PR do? -->
- **fix(models): update Codex CLI supported models to match current availability**

## Related Issues
<!-- Link issues: Fixes #123 -->

## How to Test This
<!-- Quick steps to verify the changes work -->
```bash
# Example commands or steps
```

**Expected result:**
<!-- What should happen? -->

## Contributor Checklist

- [ ] Created changeset: `npm run changeset`
- [ ] Tests pass: `npm test`
- [ ] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [ ] Addressed CodeRabbit comments (if any)
- [ ] Linked related issues (if any)
- [ ] Manually tested the changes

## Changelog Entry
<!-- One line describing the change for users -->
<!-- Example: "Added Kiro IDE integration with automatic task status updates" -->

---

### For Maintainers

- [ ] PR title follows conventional commits
- [ ] Target branch correct
- [ ] Labels added
- [ ] Milestone assigned (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--ready` and `--blocking` filters to task list command for dependency-aware task viewing and high-impact task identification
  * Added `--sandbox` flag to loop command for Docker-based execution
  * Added `--ready` filter to tags command to display only tags with available work

* **Bug Fixes**
  * Fixed race conditions preventing concurrent file access across multiple instances
  * Improved loop command error handling with clearer, actionable error messages

* **Updates**
  * Updated supported AI models for Codex CLI with gpt-5.2-codex as default and gpt-5.1-codex-mini as faster option

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->