### PR TITLE
fix: Ensure FileStorage.close() is called in export operations

### DIFF
--- a/.changeset/fix-filestorage-cleanup.md
+++ b/.changeset/fix-filestorage-cleanup.md
@@ -1,6 +1,5 @@
 ---
-"@tm/cli": patch
-"@tm/core": patch
+"task-master-ai": patch
 ---
 
 Fix FileStorage resource leaks by ensuring close() is called in try/finally blocks

--- a/.changeset/fix-filestorage-cleanup.md
+++ b/.changeset/fix-filestorage-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@tm/cli": patch
+"@tm/core": patch
+---
+
+Fix FileStorage resource leaks by ensuring close() is called in try/finally blocks

--- a/apps/cli/src/commands/export.command.ts
+++ b/apps/cli/src/commands/export.command.ts
@@ -232,8 +232,13 @@ export class ExportCommand extends Command {
 			}
 
 			const fileStorage = new FileStorage(projectRoot);
-			await fileStorage.initialize();
-			const tagsResult = await fileStorage.getTagsWithStats();
+			let tagsResult;
+			try {
+				await fileStorage.initialize();
+				tagsResult = await fileStorage.getTagsWithStats();
+			} finally {
+				await fileStorage.close();
+			}
 
 			if (!tagsResult.tags || tagsResult.tags.length === 0) {
 				console.log(chalk.yellow('\nNo local tags found in tasks.json.\n'));
@@ -389,8 +394,13 @@ export class ExportCommand extends Command {
 
 			spinner = ora('Loading tasks...').start();
 			const fileStorage = new FileStorage(projectRoot);
-			await fileStorage.initialize();
-			const tasks = await fileStorage.loadTasks(options?.tag);
+			let tasks;
+			try {
+				await fileStorage.initialize();
+				tasks = await fileStorage.loadTasks(options?.tag);
+			} finally {
+				await fileStorage.close();
+			}
 			spinner.succeed(`${tasks.length} tasks`);
 
 			if (!tasks || tasks.length === 0) {
@@ -494,8 +504,13 @@ export class ExportCommand extends Command {
 			}
 
 			const fileStorage = new FileStorage(projectRoot);
-			await fileStorage.initialize();
-			const tasks = await fileStorage.loadTasks(options?.tag);
+			let tasks;
+			try {
+				await fileStorage.initialize();
+				tasks = await fileStorage.loadTasks(options?.tag);
+			} finally {
+				await fileStorage.close();
+			}
 
 			if (!tasks || tasks.length === 0) {
 				console.log(
@@ -717,55 +732,60 @@ export class ExportCommand extends Command {
 		const fileStorage = new FileStorage(projectRoot);
 		await fileStorage.initialize();
 
-		const exportPromises: Promise<ExportResult>[] = tags.map(async (tag) => {
-			try {
-				// Load tasks from LOCAL FileStorage to count parent tasks vs subtasks
-				const tasks = await fileStorage.loadTasks(tag);
-				const parentTaskCount = tasks.length;
-				const subtaskCount = tasks.reduce(
-					(acc, t) => acc + (t.subtasks?.length || 0),
-					0
-				);
+		let results: ExportResult[];
+		try {
+			const exportPromises: Promise<ExportResult>[] = tags.map(async (tag) => {
+				try {
+					// Load tasks from LOCAL FileStorage to count parent tasks vs subtasks
+					const tasks = await fileStorage.loadTasks(tag);
+					const parentTaskCount = tasks.length;
+					const subtaskCount = tasks.reduce(
+						(acc, t) => acc + (t.subtasks?.length || 0),
+						0
+					);
 
-				const result =
-					await this.taskMasterCore!.integration.generateBriefFromTasks({
-						tag,
-						options: {
-							generateTitle: true,
-							generateDescription: true,
-							preserveHierarchy: true,
-							preserveDependencies: true
-						}
-					});
+					const result =
+						await this.taskMasterCore!.integration.generateBriefFromTasks({
+							tag,
+							options: {
+								generateTitle: true,
+								generateDescription: true,
+								preserveHierarchy: true,
+								preserveDependencies: true
+							}
+						});
 
-				if (result.success && result.brief) {
-					// Track exported tag
-					await this.trackExportedTag(tag, result.brief.id, result.brief.url);
+					if (result.success && result.brief) {
+						// Track exported tag
+						await this.trackExportedTag(tag, result.brief.id, result.brief.url);
+						return {
+							tag,
+							success: true,
+							brief: result.brief,
+							parentTaskCount,
+							subtaskCount
+						};
+					}
 					return {
 						tag,
-						success: true,
-						brief: result.brief,
-						parentTaskCount,
-						subtaskCount
+						success: false,
+						error: result.error?.message || 'Unknown error'
+					};
+				} catch (error: any) {
+					return {
+						tag,
+						success: false,
+						error: error.message || 'Export failed'
 					};
 				}
-				return {
-					tag,
-					success: false,
-					error: result.error?.message || 'Unknown error'
-				};
-			} catch (error: any) {
-				return {
-					tag,
-					success: false,
-					error: error.message || 'Export failed'
-				};
-			}
-		});
+			});
 
-		// Wait for all exports to complete
-		const results = await Promise.all(exportPromises);
-		spinner.stop();
+			// Wait for all exports to complete
+			results = await Promise.all(exportPromises);
+			spinner.stop();
+		} finally {
+			await fileStorage.close();
+		}
 
 		// Display results
 		const successful = results.filter((r) => r.success);

--- a/apps/cli/src/commands/export.command.ts
+++ b/apps/cli/src/commands/export.command.ts
@@ -730,10 +730,10 @@ export class ExportCommand extends Command {
 			return;
 		}
 		const fileStorage = new FileStorage(projectRoot);
-		await fileStorage.initialize();
 
 		let results: ExportResult[];
 		try {
+			await fileStorage.initialize();
 			const exportPromises: Promise<ExportResult>[] = tags.map(async (tag) => {
 				try {
 					// Load tasks from LOCAL FileStorage to count parent tasks vs subtasks

--- a/packages/tm-core/src/modules/integration/services/export.service.spec.ts
+++ b/packages/tm-core/src/modules/integration/services/export.service.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * @fileoverview Tests for FileStorage cleanup in ExportService
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Use vi.hoisted to define mocks that will be available during hoisting
+const { mockInitialize, mockLoadTasks, mockClose, MockFileStorage, MockAuthDomain } = vi.hoisted(() => {
+	const mockInitialize = vi.fn().mockResolvedValue(undefined);
+	const mockLoadTasks = vi.fn().mockResolvedValue([]);
+	const mockClose = vi.fn().mockResolvedValue(undefined);
+
+	class MockFileStorage {
+		initialize = mockInitialize;
+		loadTasks = mockLoadTasks;
+		close = mockClose;
+	}
+
+	class MockAuthDomain {
+		getApiBaseUrl() {
+			return 'https://api.example.com';
+		}
+	}
+
+	return { mockInitialize, mockLoadTasks, mockClose, MockFileStorage, MockAuthDomain };
+});
+
+// Mock FileStorage module
+vi.mock('../../storage/adapters/file-storage/index.js', () => ({
+	FileStorage: MockFileStorage
+}));
+
+vi.mock('../../auth/auth-domain.js', () => ({
+	AuthDomain: MockAuthDomain
+}));
+
+import { ExportService } from './export.service.js';
+import type { ConfigManager } from '../../config/managers/config-manager.js';
+import type { AuthManager } from '../../auth/managers/auth-manager.js';
+
+describe('ExportService - FileStorage cleanup', () => {
+	let exportService: ExportService;
+	let mockConfigManager: ConfigManager;
+	let mockAuthManager: AuthManager;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		// Reset mock implementations
+		mockInitialize.mockResolvedValue(undefined);
+		mockLoadTasks.mockResolvedValue([]);
+		mockClose.mockResolvedValue(undefined);
+
+		mockConfigManager = {
+			getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+			getActiveTag: vi.fn().mockReturnValue('default')
+		} as unknown as ConfigManager;
+
+		mockAuthManager = {
+			hasValidSession: vi.fn().mockResolvedValue(true),
+			getContext: vi.fn().mockResolvedValue({
+				orgId: 'test-org',
+				briefId: 'test-brief'
+			}),
+			getAccessToken: vi.fn().mockResolvedValue('test-token'),
+			getOrganizations: vi.fn().mockResolvedValue([{ id: 'test-org' }])
+		} as unknown as AuthManager;
+
+		exportService = new ExportService(mockConfigManager, mockAuthManager);
+	});
+
+	describe('exportTasks - FileStorage cleanup', () => {
+		it('should close FileStorage after successful task loading', async () => {
+			mockLoadTasks.mockResolvedValue([]);
+
+			const result = await exportService.exportTasks({});
+
+			expect(mockInitialize).toHaveBeenCalledOnce();
+			expect(mockClose).toHaveBeenCalledOnce();
+			expect(result.success).toBe(false); // No tasks to export
+			expect(result.message).toBe('No tasks found to export');
+		});
+
+		it('should close FileStorage even when loadTasks throws an error', async () => {
+			const testError = new Error('Failed to load tasks');
+			mockLoadTasks.mockRejectedValue(testError);
+
+			await expect(exportService.exportTasks({})).rejects.toThrow(
+				'Failed to load tasks'
+			);
+
+			expect(mockInitialize).toHaveBeenCalledOnce();
+			expect(mockClose).toHaveBeenCalledOnce();
+		});
+
+		it('should close FileStorage even when initialize throws an error', async () => {
+			const testError = new Error('Failed to initialize storage');
+			mockInitialize.mockRejectedValue(testError);
+
+			await expect(exportService.exportTasks({})).rejects.toThrow(
+				'Failed to initialize storage'
+			);
+
+			expect(mockInitialize).toHaveBeenCalledOnce();
+			expect(mockClose).toHaveBeenCalledOnce();
+		});
+
+		it('should close FileStorage with tasks loaded successfully', async () => {
+			const mockTasks = [
+				{
+					id: 1,
+					title: 'Test Task',
+					status: 'pending',
+					description: 'Test description'
+				}
+			];
+			mockLoadTasks.mockResolvedValue(mockTasks);
+
+			// Mock fetch to prevent actual API call
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						successCount: 1,
+						totalTasks: 1,
+						failedCount: 0,
+						results: []
+					})
+			});
+
+			const result = await exportService.exportTasks({});
+
+			expect(mockClose).toHaveBeenCalledOnce();
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('generateBriefFromTasks - FileStorage cleanup', () => {
+		it('should close FileStorage after successful task loading', async () => {
+			mockLoadTasks.mockResolvedValue([]);
+
+			const result = await exportService.generateBriefFromTasks({});
+
+			expect(mockInitialize).toHaveBeenCalledOnce();
+			expect(mockClose).toHaveBeenCalledOnce();
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe('NO_TASKS');
+		});
+
+		it('should close FileStorage even when loadTasks throws an error', async () => {
+			const testError = new Error('Storage read error');
+			mockLoadTasks.mockRejectedValue(testError);
+
+			await expect(exportService.generateBriefFromTasks({})).rejects.toThrow(
+				'Storage read error'
+			);
+
+			expect(mockInitialize).toHaveBeenCalledOnce();
+			expect(mockClose).toHaveBeenCalledOnce();
+		});
+
+		it('should close FileStorage even when initialize throws an error', async () => {
+			const testError = new Error('Storage init failed');
+			mockInitialize.mockRejectedValue(testError);
+
+			await expect(exportService.generateBriefFromTasks({})).rejects.toThrow(
+				'Storage init failed'
+			);
+
+			expect(mockInitialize).toHaveBeenCalledOnce();
+			expect(mockClose).toHaveBeenCalledOnce();
+		});
+
+		it('should close FileStorage before making API call', async () => {
+			const mockTasks = [
+				{
+					id: 1,
+					title: 'Test Task',
+					status: 'pending',
+					description: 'Test',
+					dependencies: []
+				}
+			];
+			mockLoadTasks.mockResolvedValue(mockTasks);
+
+			// Track call order
+			const callOrder: string[] = [];
+			mockClose.mockImplementation(() => {
+				callOrder.push('close');
+				return Promise.resolve();
+			});
+
+			// Mock fetch
+			global.fetch = vi.fn().mockImplementation(() => {
+				callOrder.push('fetch');
+				return Promise.resolve({
+					ok: true,
+					headers: {
+						get: () => 'application/json'
+					},
+					json: () =>
+						Promise.resolve({
+							success: true,
+							brief: {
+								id: 'brief-123',
+								url: 'https://example.com/brief',
+								title: 'Test Brief',
+								description: 'Test',
+								taskCount: 1
+							},
+							taskMapping: []
+						})
+				});
+			});
+
+			const result = await exportService.generateBriefFromTasks({});
+
+			// Verify close was called before fetch
+			expect(mockClose).toHaveBeenCalledOnce();
+			expect(callOrder).toEqual(['close', 'fetch']);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('FileStorage cleanup on authentication errors', () => {
+		it('exportTasks should not create FileStorage when auth check fails', async () => {
+			// Create a fresh mock to track FileStorage instantiation
+			vi.clearAllMocks();
+
+			mockAuthManager.hasValidSession = vi.fn().mockResolvedValue(false);
+			exportService = new ExportService(mockConfigManager, mockAuthManager);
+
+			await expect(exportService.exportTasks({})).rejects.toThrow(
+				'Authentication required'
+			);
+
+			// FileStorage methods should not be called when auth fails early
+			expect(mockInitialize).not.toHaveBeenCalled();
+			expect(mockLoadTasks).not.toHaveBeenCalled();
+			expect(mockClose).not.toHaveBeenCalled();
+		});
+
+		it('generateBriefFromTasks should not create FileStorage when auth check fails', async () => {
+			// Create a fresh mock to track FileStorage instantiation
+			vi.clearAllMocks();
+
+			mockAuthManager.hasValidSession = vi.fn().mockResolvedValue(false);
+			exportService = new ExportService(mockConfigManager, mockAuthManager);
+
+			await expect(exportService.generateBriefFromTasks({})).rejects.toThrow(
+				'Authentication required'
+			);
+
+			// FileStorage methods should not be called when auth fails early
+			expect(mockInitialize).not.toHaveBeenCalled();
+			expect(mockLoadTasks).not.toHaveBeenCalled();
+			expect(mockClose).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/tm-core/src/modules/integration/services/export.service.spec.ts
+++ b/packages/tm-core/src/modules/integration/services/export.service.spec.ts
@@ -229,7 +229,7 @@ describe('ExportService - FileStorage cleanup', () => {
 							},
 							taskMapping: []
 						})
-				} as Response);
+				} as unknown as Response);
 			});
 
 			const result = await exportService.generateBriefFromTasks({});

--- a/packages/tm-core/src/modules/integration/services/export.service.spec.ts
+++ b/packages/tm-core/src/modules/integration/services/export.service.spec.ts
@@ -5,7 +5,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Use vi.hoisted to define mocks that will be available during hoisting
-const { mockInitialize, mockLoadTasks, mockClose, MockFileStorage, MockAuthDomain } = vi.hoisted(() => {
+const {
+	mockInitialize,
+	mockLoadTasks,
+	mockClose,
+	MockFileStorage,
+	MockAuthDomain
+} = vi.hoisted(() => {
 	const mockInitialize = vi.fn().mockResolvedValue(undefined);
 	const mockLoadTasks = vi.fn().mockResolvedValue([]);
 	const mockClose = vi.fn().mockResolvedValue(undefined);
@@ -22,7 +28,13 @@ const { mockInitialize, mockLoadTasks, mockClose, MockFileStorage, MockAuthDomai
 		}
 	}
 
-	return { mockInitialize, mockLoadTasks, mockClose, MockFileStorage, MockAuthDomain };
+	return {
+		mockInitialize,
+		mockLoadTasks,
+		mockClose,
+		MockFileStorage,
+		MockAuthDomain
+	};
 });
 
 // Mock FileStorage module


### PR DESCRIPTION
## Summary

- Fixes FileStorage resource leaks by wrapping usage in try/finally blocks
- Ensures `close()` is called on both success and error paths
- Adds unit tests for FileStorage cleanup behavior

## Changes Made

**apps/cli/src/commands/export.command.ts** (4 locations):
- `listAndSelectTag()` - wraps FileStorage usage with try/finally
- `handleTagSelection()` - wraps FileStorage usage with try/finally  
- `performExportToTag()` - wraps FileStorage usage with try/finally
- `performExportAll()` - wraps Promise.all with try/finally

**packages/tm-core/src/modules/integration/services/export.service.ts** (2 locations):
- `exportTasks()` - wraps FileStorage usage with try/finally
- `generateBriefFromTasks()` - wraps FileStorage usage with try/finally

**packages/tm-core/src/modules/integration/services/export.service.spec.ts** (new):
- Tests verifying `close()` is called after successful operations
- Tests verifying `close()` is called even when `loadTasks()` throws
- Tests verifying `close()` is called even when `initialize()` throws
- Tests verifying FileStorage is not created when auth fails early

## Test plan

- [x] TypeScript type checks pass
- [x] All 841 existing tests pass
- [x] New export.service.spec.ts tests pass (10 tests)
- [x] Unhappy path tests verify cleanup on errors

Closes #1585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file-storage/resource leaks across export and brief-generation flows (interactive, single- and multi-tag exports), ensuring storage is always closed on success or error.
  * Contained per-tag export failures so each tag reports a structured result without breaking the overall export.
  * Added authentication guards to prevent export/brief generation when not signed in.

* **Tests**
  * Added tests validating cleanup ordering, error paths, authentication behavior, and export/brief outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding `try/finally` cleanup around `FileStorage` usage plus new unit tests; behavior should be unchanged aside from preventing resource leaks.
> 
> **Overview**
> Prevents `FileStorage` resource leaks during export by wrapping all CLI and core export reads in `try/finally` blocks and calling `close()` on both success and error paths, including multi-tag exports.
> 
> Adds a new `ExportService` test suite to assert `close()` is always invoked (and invoked before outbound API calls) and that auth failures short-circuit without creating/using storage. **Includes a patch changeset** for release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403aaa62732b19fcd504778e89ae1ef750aced08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->