### PR TITLE
feat: Add modifyJSON for atomic operations in legacy utils.js

### DIFF
--- a/.changeset/add-modifyjson-utils.md
+++ b/.changeset/add-modifyjson-utils.md
@@ -2,4 +2,4 @@
 "task-master-ai": patch
 ---
 
-Add modifyJSON function to legacy utils.js for atomic read-modify-write operations
+Add modifyJSON function for safer file updates

--- a/packages/tm-core/src/index.ts
+++ b/packages/tm-core/src/index.ts
@@ -49,6 +49,9 @@ export type {
 // Storage adapters - FileStorage for direct local file access
 export { FileStorage } from './modules/storage/index.js';
 
+// File operations - for atomic file modifications
+export { FileOperations } from './modules/storage/adapters/file-storage/file-operations.js';
+
 // Constants
 export * from './common/constants/index.js';
 


### PR DESCRIPTION
## Summary

- Adds `modifyJSON()` function for atomic read-modify-write operations
- Marks `writeJSON()` as deprecated with migration guidance
- Addresses part 2 of #1585 (legacy utils.js pattern)

## Changes Made

**scripts/modules/utils.js**:
- Added `modifyJSON(filepath, modifier, options)` function that:
  - Reads the file inside the lock
  - Applies the modifier callback
  - Writes the result atomically
  - Prevents race conditions from stale reads
- Marked `writeJSON()` as `@deprecated` with guidance to use `modifyJSON()`
- Exported `modifyJSON` for use by callers

## Technical Details

The new `modifyJSON` function follows the same pattern as `@tm/core`'s TypeScript `modifyJson`:

```javascript
// Before (race-prone):
const data = readJSON(filepath);
data.tasks.push(newTask);
writeJSON(filepath, data);

// After (atomic):
modifyJSON(filepath, (data) => {
    data.tasks.push(newTask);
    return data;
});
```

## Test plan

- [x] Format check passes
- [ ] CI checks

## Related

- Closes part 2 of #1585
- PR #1586 addresses part 1 (FileStorage cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an atomic JSON modification utility to safely perform read‑modify‑write operations with integrated file-locking to prevent concurrent data corruption.
* **Deprecated**
  * Marked the previous JSON write helper as deprecated in favor of the new atomic modify flow.
* **Chores**
  * Exposed the underlying file-operations capability via the public API so consumers can use the atomic utility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->