### PR TITLE
fix: remove leading whitespace from Accordion closing tags in docs

### DIFF
--- a/apps/docs/capabilities/task-structure.mdx
+++ b/apps/docs/capabilities/task-structure.mdx
@@ -209,7 +209,7 @@ The generated report contains:
 - Recommended number of subtasks based on complexity
 - AI-generated expansion prompts customized for each task
 - Ready-to-run expansion commands directly within each task analysis
-  </Accordion>
+</Accordion>
 
 <Accordion title="Viewing Complexity Report">
 The `complexity-report` command:
@@ -220,7 +220,7 @@ The `complexity-report` command:
 - Highlights tasks recommended for expansion based on threshold score
 - Includes ready-to-use expansion commands for each complex task
 - If no report exists, offers to generate one on the spot
-  </Accordion>
+</Accordion>
 
 <Accordion title="Smart Task Expansion">
 The `expand` command automatically checks for and uses the complexity report:
@@ -262,7 +262,7 @@ The `next` command:
   - Command to mark the task as in-progress
   - Command to mark the task as done
   - Commands for working with subtasks
-    </Accordion>
+</Accordion>
 
 <Accordion title="Viewing Specific Task Details">
 The `show` command:
@@ -273,7 +273,7 @@ The `show` command:
 - For subtasks, shows parent task relationship
 - Provides contextual action suggestions based on the task's state
 - Works with both regular tasks and subtasks (using the format taskId.subtaskId)
-  </Accordion>
+</Accordion>
 </AccordionGroup>
 
 ## Best Practices for AI-Driven Development


### PR DESCRIPTION
## Summary
- Fixes Mintlify deployment failure caused by indented `</Accordion>` closing tags
- The MDX parser was interpreting indented closing tags as list items instead of JSX

## Test plan
- [ ] Verify Mintlify deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs formatting fix**
> 
> - Remove indentation before `</Accordion>` across `task-structure.mdx` so the MDX parser treats them as JSX, not list items
> - No content changes; intended to resolve Mintlify parsing/deployment issues
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b929028aa1eedfafe6975ae2840c2070e4e58639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated documentation formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->