### PR TITLE
fix: resolve PR number extraction in forward-port workflow

### DIFF
--- a/.github/workflows/forward-port.yml
+++ b/.github/workflows/forward-port.yml
@@ -141,7 +141,7 @@ jobs:
             --label "automated" \
             --body "$BODY")
 
-          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          PR_NUMBER=$(basename "$PR_URL")
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- Fix forward-port CI workflow failing with exit code 1
- Replace `grep -oE '[0-9]+$'` with `basename` to extract PR number from URL
- The `$'` sequence in the grep regex was being consumed by bash's ANSI-C quoting, breaking the command

## Test plan
- [ ] Trigger the forward-port workflow and verify the PR creation step succeeds
- [ ] Verify `PR_NUMBER` is correctly extracted from the `gh pr create` output URL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to CI workflow scripting; main risk is mis-parsing unexpected `gh` output formats, but `basename` is simpler and less error-prone than the previous regex.
> 
> **Overview**
> Fixes the forward-port workflow’s PR-number extraction by replacing the `grep -oE '[0-9]+$'` parsing with `basename "$PR_URL"`, avoiding bash/regex quoting issues that could cause the job to fail and preventing follow-up steps (like labeling) from breaking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c4725fe33e435605f05b1f92fa4c7611f261909. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->