### PR TITLE
fix: correct CLI command names for expand operations in llms-install.md

### DIFF
--- a/llms-install.md
+++ b/llms-install.md
@@ -125,7 +125,7 @@ Once installed, users can:
 
 - Create new tasks with `add-task` or parse a PRD (scripts/prd.txt) into tasks with `parse-prd`
 - Set up model preferences with `models` tool
-- Expand tasks into subtasks with `expand-all` and `expand-task`
+- Expand tasks into subtasks with `task-master expand --all` or `task-master expand --id=<id>`
 - Explore advanced features like research mode and complexity analysis
 
 For detailed documentation, refer to the Task Master docs directory.``


### PR DESCRIPTION
## Summary

- Fixes incorrect `expand-task` and `expand-all` references in `llms-install.md` to the actual CLI syntax: `task-master expand --id=<id>` and `task-master expand --all`
- The MCP tool `expand_task` maps to the CLI `expand` command (not `expand-task`) — `assets/AGENTS.md` already documented this correctly, only `llms-install.md` had the wrong names

## Test plan

- [ ] Verify `llms-install.md` "Next Steps" section shows correct CLI commands
- [ ] Confirm no other user-facing docs reference `expand-task` as a CLI command

Fixes #1640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command syntax for task expansion operations to use the new `task-master expand` format with flag-based options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->