### PR TITLE
fix: replace bare U+26A0 warning sign with emoji-presentation ⚠️

### DIFF
--- a/apps/cli/src/commands/list.command.ts
+++ b/apps/cli/src/commands/list.command.ts
@@ -232,7 +232,7 @@ export class ListTasksCommand extends Command {
 							);
 						}
 					} else if (event.type === 'error' && event.error) {
-						console.error(chalk.red(`\n⚠ Watch error: ${event.error.message}`));
+						console.error(chalk.red(`\n⚠️ Watch error: ${event.error.message}`));
 					}
 				},
 				{ tag: options.tag }

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -4839,7 +4839,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm add-tag" is deprecated. Use "tm tags add" instead.'
+					'⚠️ Warning: "tm add-tag" is deprecated. Use "tm tags add" instead.'
 				)
 			);
 			console.log(
@@ -4993,7 +4993,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm delete-tag" is deprecated. Use "tm tags remove" instead.'
+					'⚠️ Warning: "tm delete-tag" is deprecated. Use "tm tags remove" instead.'
 				)
 			);
 			console.log(
@@ -5065,7 +5065,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm use-tag" is deprecated. Use "tm tags use" instead.'
+					'⚠️ Warning: "tm use-tag" is deprecated. Use "tm tags use" instead.'
 				)
 			);
 			console.log(
@@ -5123,7 +5123,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm rename-tag" is deprecated. Use "tm tags rename" instead.'
+					'⚠️ Warning: "tm rename-tag" is deprecated. Use "tm tags rename" instead.'
 				)
 			);
 			console.log(
@@ -5187,7 +5187,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm copy-tag" is deprecated. Use "tm tags copy" instead.'
+					'⚠️ Warning: "tm copy-tag" is deprecated. Use "tm tags copy" instead.'
 				)
 			);
 			console.log(

--- a/scripts/modules/error-formatter.js
+++ b/scripts/modules/error-formatter.js
@@ -394,7 +394,7 @@ export function displayFormattedError(error, options = {}) {
  * @param {string[]} [hints] - Optional hints
  */
 export function displayWarning(message, hints = []) {
-	let content = chalk.yellow.bold('⚠ Warning\n\n');
+	let content = chalk.yellow.bold('⚠️ Warning\n\n');
 	content += chalk.white(message);
 
 	if (hints && hints.length > 0) {

--- a/scripts/modules/prompt-manager.js
+++ b/scripts/modules/prompt-manager.js
@@ -67,7 +67,7 @@ export class PromptManager {
 			this.validatePrompt = this.ajv.compile(promptTemplateSchema);
 			log('debug', '✓ JSON schema validation enabled');
 		} catch (error) {
-			log('warn', `⚠ Schema validation disabled: ${error.message}`);
+			log('warn', `⚠️ Schema validation disabled: ${error.message}`);
 			this.validatePrompt = () => true; // Fallback to no validation
 		}
 	}

--- a/scripts/modules/task-manager/migrate.js
+++ b/scripts/modules/task-manager/migrate.js
@@ -15,7 +15,7 @@ const __dirname = path.dirname(__filename);
 // Create a simple log wrapper for CLI use
 const log = createLogWrapper({
 	info: (msg) => console.log(chalk.blue('ℹ'), msg),
-	warn: (msg) => console.log(chalk.yellow('⚠'), msg),
+	warn: (msg) => console.log(chalk.yellow('⚠️'), msg),
 	error: (msg) => console.error(chalk.red('✗'), msg),
 	success: (msg) => console.log(chalk.green('✓'), msg)
 });

--- a/scripts/modules/task-manager/tag-management.js
+++ b/scripts/modules/task-manager/tag-management.js
@@ -325,7 +325,7 @@ async function deleteTag(
 		if (!yes && taskCount > 0 && outputFormat === 'text') {
 			console.log(
 				boxen(
-					chalk.yellow.bold('⚠ WARNING: Tag Deletion') +
+					chalk.yellow.bold('⚠️ WARNING: Tag Deletion') +
 						`\n\nYou are about to delete tag "${chalk.cyan(tagName)}"` +
 						`\nThis will permanently delete ${chalk.red.bold(taskCount)} tasks` +
 						'\n\nThis action cannot be undone!',
@@ -417,7 +417,7 @@ async function deleteTag(
 						`\n\nTag Name: ${chalk.cyan(tagName)}` +
 						`\nTasks Deleted: ${chalk.yellow(taskCount)}` +
 						(isCurrentTag
-							? `\n${chalk.yellow('⚠ Switched current tag to "master"')}`
+							? `\n${chalk.yellow('⚠️ Switched current tag to "master"')}`
 							: ''),
 					{
 						padding: 1,


### PR DESCRIPTION
## Summary

- Replaces all 11 instances of bare `⚠` (U+26A0, text presentation) with `⚠️` (U+26A0 + U+FE0F, emoji presentation) across 6 files
- Text-presentation `⚠` is measured as 1 column by terminal width calculators (including boxen), causing box borders to misalign when it appears in titles or content
- Adding U+FE0F forces emoji presentation, which renderers correctly measure as 2 columns

### Files changed
- `scripts/modules/prompt-manager.js` — 1 instance
- `scripts/modules/error-formatter.js` — 1 instance  
- `scripts/modules/task-manager/tag-management.js` — 2 instances
- `scripts/modules/commands.js` — 5 instances (deprecation warnings)
- `scripts/modules/task-manager/migrate.js` — 1 instance
- `apps/cli/src/commands/list.command.ts` — 1 instance

## Test plan

- [ ] Run CLI commands that trigger warning boxes and verify alignment is correct
- [ ] Verify emoji renders consistently across macOS Terminal, iTerm2, and VS Code terminal

Fixes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated warning symbol emoji in CLI console output messages across all commands and utilities for improved visual consistency and clarity in user-facing warnings and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->