### PR TITLE
fix: update outdated Claude Code CLI install instructions

### DIFF
--- a/docs/examples/claude-code-usage.md
+++ b/docs/examples/claude-code-usage.md
@@ -59,16 +59,15 @@ task-master set-status --id=task-001 --status=in-progress
 
 ## Requirements
 
-1. Claude Code CLI must be installed and authenticated on your system
-2. Install the optional `@anthropic-ai/claude-code` package if you enable this provider:
+1. Claude Code CLI must be installed and authenticated on your system:
    ```bash
-   npm install @anthropic-ai/claude-code
+   curl -fsSL https://claude.ai/install.sh | sh
    ```
-3. Run Claude Code for the first time and authenticate with your Anthropic account:
+2. Run Claude Code for the first time and authenticate with your Anthropic account:
    ```bash
    claude
    ```
-4. No API key is required in your environment variables or MCP configuration
+3. No API key is required in your environment variables or MCP configuration
 
 ## Advanced Settings
 

--- a/packages/tm-core/src/modules/loop/services/loop.service.ts
+++ b/packages/tm-core/src/modules/loop/services/loop.service.ts
@@ -586,7 +586,7 @@ Loop iteration ${iteration} of ${config.iterations}${tagInfo}`;
 		if (error.code === 'ENOENT') {
 			return sandbox
 				? 'Docker is not installed. Install Docker Desktop to use --sandbox mode.'
-				: 'Claude CLI is not installed. Install with: npm install -g @anthropic-ai/claude-code';
+				: 'Claude CLI is not installed. Install with: curl -fsSL https://claude.ai/install.sh | sh';
 		}
 
 		if (error.code === 'EACCES') {

--- a/src/ai-providers/claude-code.js
+++ b/src/ai-providers/claude-code.js
@@ -85,7 +85,7 @@ export class ClaudeCodeProvider extends BaseAIProvider {
 				_claudeCliAvailable = false;
 				log(
 					'warn',
-					'Claude Code CLI not detected. Install it with: npm install -g @anthropic-ai/claude-code'
+					'Claude Code CLI not detected. Install it with: curl -fsSL https://claude.ai/install.sh | sh'
 				);
 			} finally {
 				_claudeCliChecked = true;


### PR DESCRIPTION
## Summary

- Replaces deprecated `npm install -g @anthropic-ai/claude-code` with the current official installer: `curl -fsSL https://claude.ai/install.sh | sh`
- Updated in 3 files:
  - `src/ai-providers/claude-code.js` — warning message when CLI not detected
  - `packages/tm-core/src/modules/loop/services/loop.service.ts` — ENOENT error message
  - `docs/examples/claude-code-usage.md` — requirements/prerequisites section

## Test plan

- [ ] Verify warning/error messages display the correct install command when Claude Code CLI is not found
- [ ] Confirm docs reflect current installation method

Fixes #1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance for Claude CLI with a streamlined shell-based setup method for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->