### PR TITLE
feat: add search/find command for tasks

### DIFF
--- a/apps/cli/src/command-registry.ts
+++ b/apps/cli/src/command-registry.ts
@@ -18,6 +18,7 @@ import { LoginCommand } from './commands/login.command.js';
 import { LogoutCommand } from './commands/logout.command.js';
 import { NextCommand } from './commands/next.command.js';
 import { SetStatusCommand } from './commands/set-status.command.js';
+import { SearchCommand } from './commands/search.command.js';
 import { ShowCommand } from './commands/show.command.js';
 import { StartCommand } from './commands/start.command.js';
 import { TagsCommand } from './commands/tags.command.js';
@@ -51,6 +52,12 @@ export class CommandRegistry {
 			name: 'show',
 			description: 'Display detailed information about a specific task',
 			commandClass: ShowCommand as any,
+			category: 'task'
+		},
+		{
+			name: 'search',
+			description: 'Search tasks by keyword across title, description, details, and test strategy',
+			commandClass: SearchCommand as any,
 			category: 'task'
 		},
 		{

--- a/apps/cli/src/commands/search.command.ts
+++ b/apps/cli/src/commands/search.command.ts
@@ -1,0 +1,431 @@
+/**
+ * @fileoverview SearchCommand using Commander's native class pattern
+ * Extends Commander.Command for better integration with the framework
+ *
+ * Implements issue #1453 — search/find tasks across title, description,
+ * details, testStrategy, and subtask titles/descriptions.
+ */
+
+import {
+	STATUS_ICONS,
+	TASK_STATUSES,
+	createTmCore,
+	type Task,
+	type TaskStatus,
+	type TmCore
+} from '@tm/core';
+import type { StorageType, Subtask } from '@tm/core';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { displayCommandHeader } from '../utils/display-helpers.js';
+import { displayError } from '../utils/error-handler.js';
+import { getProjectRoot } from '../utils/project-root.js';
+import * as ui from '../utils/ui.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Options interface for the search command
+ */
+export interface SearchCommandOptions {
+	status?: string;
+	tag?: string;
+	includeSubtasks?: boolean;
+	format?: 'text' | 'json' | 'compact';
+	json?: boolean;
+	compact?: boolean;
+	project?: string;
+	silent?: boolean;
+}
+
+/**
+ * A task match — the parent task plus optional matching subtasks
+ */
+export interface TaskMatch {
+	task: Task;
+	/** Subtasks that matched the query (populated when --include-subtasks is given) */
+	matchingSubtasks: Subtask[];
+}
+
+/**
+ * Result type from the search command
+ */
+export interface SearchTasksResult {
+	query: string;
+	matches: TaskMatch[];
+	totalTasks: number;
+	tag?: string;
+	storageType: Exclude<StorageType, 'auto'>;
+}
+
+// ---------------------------------------------------------------------------
+// Helper — case-insensitive substring search
+// ---------------------------------------------------------------------------
+
+function matchesQuery(text: string | undefined | null, query: string): boolean {
+	if (!text) return false;
+	return text.toLowerCase().includes(query);
+}
+
+/**
+ * Return true if a task matches the query on any of the searched fields.
+ * Searched fields: title, description, details, testStrategy
+ */
+function taskMatchesQuery(task: Task, queryLower: string): boolean {
+	return (
+		matchesQuery(task.title, queryLower) ||
+		matchesQuery(task.description, queryLower) ||
+		matchesQuery(task.details, queryLower) ||
+		matchesQuery(task.testStrategy, queryLower)
+	);
+}
+
+/**
+ * Return true if a subtask matches the query on title or description.
+ */
+function subtaskMatchesQuery(subtask: Subtask, queryLower: string): boolean {
+	return (
+		matchesQuery(subtask.title, queryLower) ||
+		matchesQuery(subtask.description, queryLower) ||
+		matchesQuery(subtask.details, queryLower) ||
+		matchesQuery(subtask.testStrategy, queryLower)
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Command class
+// ---------------------------------------------------------------------------
+
+/**
+ * SearchCommand extending Commander's Command class.
+ * This is a thin presentation layer over @tm/core.
+ */
+export class SearchCommand extends Command {
+	private tmCore?: TmCore;
+	private lastResult?: SearchTasksResult;
+
+	constructor(name?: string) {
+		super(name || 'search');
+
+		this.description('Search tasks by keyword across title, description, details, and test strategy')
+			.alias('find')
+			.argument('<query>', 'Search query (case-insensitive substring match)')
+			.option(
+				'-s, --status <status>',
+				'Filter results by status (e.g., pending, done, in-progress)'
+			)
+			.option('-t, --tag <tag>', 'Tag context to search in')
+			.option(
+				'--include-subtasks',
+				'Also search and display matching subtasks'
+			)
+			.option(
+				'-f, --format <format>',
+				'Output format (text, json, compact)',
+				'text'
+			)
+			.option('--json', 'Output in JSON format (shorthand for --format json)')
+			.option(
+				'-c, --compact',
+				'Output in compact format (shorthand for --format compact)'
+			)
+			.option('--silent', 'Suppress output (useful for programmatic usage)')
+			.option(
+				'-p, --project <path>',
+				'Project root directory (auto-detected if not provided)'
+			)
+			.action(async (query: string, options: SearchCommandOptions) => {
+				await this.executeCommand(query, options);
+			});
+	}
+
+	// -------------------------------------------------------------------------
+	// Execution
+	// -------------------------------------------------------------------------
+
+	private async executeCommand(
+		query: string,
+		options: SearchCommandOptions
+	): Promise<void> {
+		try {
+			if (!this.validateOptions(options)) {
+				process.exit(1);
+			}
+
+			await this.initializeCore(getProjectRoot(options.project));
+
+			const result = await this.searchTasks(query, options);
+
+			this.lastResult = result;
+
+			if (!options.silent) {
+				this.displayResults(result, options);
+			}
+		} catch (error: any) {
+			displayError(error);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Validation
+	// -------------------------------------------------------------------------
+
+	private validateOptions(options: SearchCommandOptions): boolean {
+		const validFormats = ['text', 'json', 'compact'];
+		if (options.format && !validFormats.includes(options.format)) {
+			console.error(chalk.red(`Invalid format: ${options.format}`));
+			console.error(chalk.gray(`Valid formats: ${validFormats.join(', ')}`));
+			return false;
+		}
+
+		if (options.status) {
+			const statuses = options.status.split(',').map((s) => s.trim());
+			for (const status of statuses) {
+				if (!TASK_STATUSES.includes(status as TaskStatus)) {
+					console.error(chalk.red(`Invalid status: ${status}`));
+					console.error(
+						chalk.gray(`Valid statuses: ${TASK_STATUSES.join(', ')}`)
+					);
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// Core initialisation
+	// -------------------------------------------------------------------------
+
+	private async initializeCore(projectRoot: string): Promise<void> {
+		if (!this.tmCore) {
+			this.tmCore = await createTmCore({ projectPath: projectRoot });
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Search logic
+	// -------------------------------------------------------------------------
+
+	private async searchTasks(
+		query: string,
+		options: SearchCommandOptions
+	): Promise<SearchTasksResult> {
+		if (!this.tmCore) {
+			throw new Error('TmCore not initialized');
+		}
+
+		const queryLower = query.toLowerCase();
+
+		// Parse optional status filter
+		const statusFilter =
+			options.status
+				? options.status.split(',').map((s) => s.trim() as TaskStatus)
+				: undefined;
+
+		// Fetch all tasks (with subtasks so we can search them)
+		const listResult = await this.tmCore.tasks.list({
+			tag: options.tag,
+			includeSubtasks: true
+		});
+
+		const matches: TaskMatch[] = [];
+
+		for (const task of listResult.tasks) {
+			// Apply status filter if specified
+			if (statusFilter && !statusFilter.includes(task.status)) {
+				continue;
+			}
+
+			const taskMatches = taskMatchesQuery(task, queryLower);
+
+			// Check subtasks
+			const matchingSubtasks: Subtask[] = options.includeSubtasks
+				? (task.subtasks || []).filter((st) =>
+						subtaskMatchesQuery(st, queryLower)
+					)
+				: [];
+
+			// Include the task if the task itself matches, or if any subtask matched
+			// (when --include-subtasks is set)
+			if (taskMatches || matchingSubtasks.length > 0) {
+				matches.push({ task, matchingSubtasks });
+			}
+		}
+
+		return {
+			query,
+			matches,
+			totalTasks: listResult.total,
+			tag: listResult.tag,
+			storageType: listResult.storageType as Exclude<StorageType, 'auto'>
+		};
+	}
+
+	// -------------------------------------------------------------------------
+	// Display
+	// -------------------------------------------------------------------------
+
+	private displayResults(
+		result: SearchTasksResult,
+		options: SearchCommandOptions
+	): void {
+		// Resolve format
+		let format: 'text' | 'json' | 'compact' = options.format || 'text';
+		if (options.json) format = 'json';
+		else if (options.compact) format = 'compact';
+
+		switch (format) {
+			case 'json':
+				this.displayJson(result);
+				break;
+			case 'compact':
+				this.displayCompact(result, options);
+				break;
+			case 'text':
+			default:
+				this.displayText(result, options);
+				break;
+		}
+	}
+
+	private displayJson(result: SearchTasksResult): void {
+		console.log(
+			JSON.stringify(
+				{
+					query: result.query,
+					matches: result.matches,
+					metadata: {
+						totalTasksSearched: result.totalTasks,
+						matchCount: result.matches.length,
+						tag: result.tag,
+						storageType: result.storageType
+					}
+				},
+				null,
+				2
+			)
+		);
+	}
+
+	private displayCompact(
+		result: SearchTasksResult,
+		options: SearchCommandOptions
+	): void {
+		displayCommandHeader(this.tmCore, {
+			tag: result.tag || 'master',
+			storageType: result.storageType
+		});
+
+		if (result.matches.length === 0) {
+			console.log(chalk.yellow(`No tasks found matching "${result.query}"`));
+			return;
+		}
+
+		for (const { task, matchingSubtasks } of result.matches) {
+			const icon = STATUS_ICONS[task.status];
+			console.log(`${chalk.cyan(task.id)} ${icon} ${task.title}`);
+
+			if (options.includeSubtasks && matchingSubtasks.length > 0) {
+				for (const subtask of matchingSubtasks) {
+					const subIcon = STATUS_ICONS[subtask.status];
+					console.log(
+						`  ${chalk.gray(String(subtask.id))} ${subIcon} ${chalk.gray(subtask.title)}`
+					);
+				}
+			}
+		}
+	}
+
+	private displayText(
+		result: SearchTasksResult,
+		options: SearchCommandOptions
+	): void {
+		displayCommandHeader(this.tmCore, {
+			tag: result.tag || 'master',
+			storageType: result.storageType
+		});
+
+		console.log(
+			chalk.blue.bold(
+				`\nSearch results for "${chalk.white(result.query)}":`
+			)
+		);
+
+		if (result.matches.length === 0) {
+			ui.displayWarning(
+				`No tasks found matching "${result.query}". Try a different keyword or broaden your search.`
+			);
+			return;
+		}
+
+		console.log(
+			chalk.gray(
+				`Found ${result.matches.length} matching task(s) out of ${result.totalTasks} total.\n`
+			)
+		);
+
+		// Build a flat list of tasks (with subtasks collapsed under the parent) for the table
+		const tasksForTable = result.matches.map(({ task }) => task);
+
+		console.log(
+			ui.createTaskTable(tasksForTable, {
+				showSubtasks: options.includeSubtasks,
+				showDependencies: true
+			})
+		);
+
+		// If --include-subtasks, summarise which subtasks matched
+		if (options.includeSubtasks) {
+			const subtaskMatches = result.matches.filter(
+				({ matchingSubtasks }) => matchingSubtasks.length > 0
+			);
+
+			if (subtaskMatches.length > 0) {
+				console.log(chalk.blue.bold('\nMatching subtasks:\n'));
+				for (const { task, matchingSubtasks } of subtaskMatches) {
+					for (const subtask of matchingSubtasks) {
+						const icon = STATUS_ICONS[subtask.status];
+						console.log(
+							`  ${chalk.cyan(`${task.id}.${subtask.id}`)} ${icon} ${subtask.title}`
+						);
+					}
+				}
+				console.log();
+			}
+		}
+
+		// Hint
+		console.log(
+			chalk.gray(
+				`Tip: Use ${chalk.white('task-master show <id>')} to view full task details.`
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Programmatic API
+	// -------------------------------------------------------------------------
+
+	getLastResult(): SearchTasksResult | undefined {
+		return this.lastResult;
+	}
+
+	async cleanup(): Promise<void> {
+		if (this.tmCore) {
+			this.tmCore = undefined;
+		}
+	}
+
+	/**
+	 * Register this command on an existing program
+	 */
+	static register(program: Command, name?: string): SearchCommand {
+		const searchCommand = new SearchCommand(name);
+		program.addCommand(searchCommand);
+		return searchCommand;
+	}
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,6 +5,7 @@
 
 // Commands
 export { ListTasksCommand } from './commands/list.command.js';
+export { SearchCommand } from './commands/search.command.js';
 export { ShowCommand } from './commands/show.command.js';
 export { NextCommand } from './commands/next.command.js';
 export { AuthCommand } from './commands/auth.command.js';

--- a/apps/mcp/src/tools/tasks/index.ts
+++ b/apps/mcp/src/tools/tasks/index.ts
@@ -7,3 +7,4 @@ export { registerGetTasksTool } from './get-tasks.tool.js';
 export { registerGetTaskTool } from './get-task.tool.js';
 export { registerGenerateTool } from './generate.tool.js';
 export { registerSetTaskStatusTool } from './set-task-status.tool.js';
+export { registerSearchTasksTool } from './search-tasks.tool.js';

--- a/apps/mcp/src/tools/tasks/search-tasks.tool.ts
+++ b/apps/mcp/src/tools/tasks/search-tasks.tool.ts
@@ -1,0 +1,213 @@
+/**
+ * @fileoverview search_tasks MCP tool
+ * Search tasks by keyword across title, description, details, testStrategy,
+ * and (optionally) subtask titles/descriptions.
+ *
+ * Implements issue #1453.
+ */
+
+import { z } from 'zod';
+import { handleApiResult, withToolContext } from '../../shared/utils.js';
+import type { ToolContext } from '../../shared/types.js';
+import type { Task, TaskStatus, Subtask } from '@tm/core';
+import { TASK_STATUSES } from '@tm/core';
+import type { FastMCP } from 'fastmcp';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const SearchTasksSchema = z.object({
+	projectRoot: z
+		.string()
+		.describe('The directory of the project. Must be an absolute path.'),
+	query: z
+		.string()
+		.min(1)
+		.describe('Search query — case-insensitive substring matched against task title, description, details, and testStrategy'),
+	status: z
+		.string()
+		.optional()
+		.describe(
+			"Filter results by status (e.g., 'pending', 'done') or multiple statuses separated by commas (e.g., 'pending,in-progress')"
+		),
+	includeSubtasks: z
+		.boolean()
+		.optional()
+		.describe(
+			'Also search subtask titles, descriptions, details, and testStrategy fields. Matching subtasks are included in the response.'
+		),
+	tag: z.string().optional().describe('Tag context to operate on')
+});
+
+type SearchTasksArgs = z.infer<typeof SearchTasksSchema>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function matchesQuery(text: string | undefined | null, query: string): boolean {
+	if (!text) return false;
+	return text.toLowerCase().includes(query);
+}
+
+function taskMatchesQuery(task: Task, queryLower: string): boolean {
+	return (
+		matchesQuery(task.title, queryLower) ||
+		matchesQuery(task.description, queryLower) ||
+		matchesQuery(task.details, queryLower) ||
+		matchesQuery(task.testStrategy, queryLower)
+	);
+}
+
+function subtaskMatchesQuery(subtask: Subtask, queryLower: string): boolean {
+	return (
+		matchesQuery(subtask.title, queryLower) ||
+		matchesQuery(subtask.description, queryLower) ||
+		matchesQuery(subtask.details, queryLower) ||
+		matchesQuery(subtask.testStrategy, queryLower)
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the search_tasks tool with the MCP server
+ */
+export function registerSearchTasksTool(server: FastMCP) {
+	server.addTool({
+		name: 'search_tasks',
+		description:
+			'Search tasks by keyword across title, description, details, and testStrategy. Optionally also searches subtasks. Returns matching tasks with their IDs and status.',
+		parameters: SearchTasksSchema,
+		annotations: {
+			title: 'Search Tasks',
+			readOnlyHint: true
+		},
+		execute: withToolContext(
+			'search-tasks',
+			async (args: SearchTasksArgs, { log, tmCore }: ToolContext) => {
+				const { projectRoot, query, status, includeSubtasks, tag } = args;
+
+				try {
+					log.info(
+						`Searching tasks in ${projectRoot} for "${query}"${status ? ` with status: ${status}` : ''}${tag ? ` in tag: ${tag}` : ''}`
+					);
+
+					// Validate status values if provided
+					if (status) {
+						const statuses = status.split(',').map((s) => s.trim());
+						const invalid = statuses.filter(
+							(s) => !TASK_STATUSES.includes(s as TaskStatus)
+						);
+						if (invalid.length > 0) {
+							return handleApiResult({
+								result: {
+									success: false,
+									error: {
+										message: `Invalid status value(s): ${invalid.join(', ')}. Valid values: ${TASK_STATUSES.join(', ')}`
+									}
+								},
+								log,
+								projectRoot
+							});
+						}
+					}
+
+					// Fetch all tasks (with subtasks for subtask search)
+					const listResult = await tmCore.tasks.list({
+						tag,
+						includeSubtasks: true
+					});
+
+					const queryLower = query.toLowerCase();
+
+					// Parse status filter
+					const statusFilter = status
+						? status.split(',').map((s) => s.trim() as TaskStatus)
+						: undefined;
+
+					// Run search
+					interface TaskMatch {
+						task: Task;
+						matchingSubtasks: Array<{ id: number | string; title: string; status: string; description: string }>;
+					}
+
+					const matches: TaskMatch[] = [];
+
+					for (const task of listResult.tasks) {
+						if (statusFilter && !statusFilter.includes(task.status)) {
+							continue;
+						}
+
+						const taskHit = taskMatchesQuery(task, queryLower);
+
+						const matchingSubtasks: Array<{ id: number | string; title: string; status: string; description: string }> =
+							includeSubtasks
+								? (task.subtasks || [])
+										.filter((st) => subtaskMatchesQuery(st, queryLower))
+										.map((st) => ({
+											id: st.id,
+											title: st.title,
+											status: st.status,
+											description: st.description
+										}))
+								: [];
+
+						if (taskHit || matchingSubtasks.length > 0) {
+							matches.push({
+								task,
+								matchingSubtasks
+							});
+						}
+					}
+
+					log.info(
+						`Search for "${query}" returned ${matches.length} matching task(s) out of ${listResult.total} total`
+					);
+
+					return handleApiResult({
+						result: {
+							success: true,
+							data: {
+								query,
+								matches: matches.map(({ task, matchingSubtasks }) => ({
+									id: task.id,
+									title: task.title,
+									status: task.status,
+									priority: task.priority,
+									description: task.description,
+									matchingSubtasks
+								})),
+								stats: {
+									totalTasksSearched: listResult.total,
+									matchCount: matches.length
+								}
+							}
+						},
+						log,
+						projectRoot,
+						tag: listResult.tag
+					});
+				} catch (error: any) {
+					log.error(`Error in search-tasks: ${error.message}`);
+					if (error.stack) {
+						log.debug(error.stack);
+					}
+					return handleApiResult({
+						result: {
+							success: false,
+							error: {
+								message: `Failed to search tasks: ${error.message}`
+							}
+						},
+						log,
+						projectRoot
+					});
+				}
+			}
+		)
+	});
+}

--- a/mcp-server/src/tools/tool-registry.js
+++ b/mcp-server/src/tools/tool-registry.js
@@ -49,6 +49,7 @@ import {
 	registerGenerateTool,
 	registerGetTaskTool,
 	registerGetTasksTool,
+	registerSearchTasksTool,
 	registerSetTaskStatusTool
 } from '@tm/mcp';
 
@@ -69,6 +70,7 @@ export const toolRegistry = {
 	scope_down_task: registerScopeDownTool,
 	get_tasks: registerGetTasksTool,
 	get_task: registerGetTaskTool,
+	search_tasks: registerSearchTasksTool,
 	next_task: registerNextTaskTool,
 	complexity_report: registerComplexityReportTool,
 	set_task_status: registerSetTaskStatusTool,
@@ -129,7 +131,8 @@ export const standardTools = [
 	'add_subtask',
 	'remove_task',
 	'add_task',
-	'complexity_report'
+	'complexity_report',
+	'search_tasks'
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds `task-master search <query>` (aliased as `find`) that searches tasks across title, description, details, and testStrategy fields using case-insensitive substring matching.

### CLI
- New `SearchCommand` at `apps/cli/src/commands/search.command.ts`
- Registered in CommandRegistry under the 'task' category
- Supports `--status`, `--tag`, `--include-subtasks`, `--format`/`--json`/`--compact`, `--silent`, and `--project` flags
- When `--include-subtasks` is given, also searches subtask fields and lists matching subtasks under their parent

### MCP
- New `search_tasks` tool at `apps/mcp/src/tools/tasks/search-tasks.tool.ts`
- Registered in `mcp-server/src/tools/tool-registry.js`
- Parameters: `projectRoot`, `query`, `status`, `includeSubtasks`, `tag`
- Returns matches with id, title, status, priority, description, matchingSubtasks, and aggregate stats

## Test plan

- [ ] `task-master search "auth"` returns tasks with "auth" in title/description/details
- [ ] `task-master search "auth" --status done` filters by status
- [ ] `task-master search "auth" --include-subtasks` searches and displays subtask matches
- [ ] `task-master find "auth"` works as alias
- [ ] MCP `search_tasks` tool returns correct results via Claude/Cursor

Closes #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Introduced a new task search command enabling users to search and filter tasks by query, status, and tags
* Search supports multiple output formats (text, JSON, compact) and optional subtask inclusion
* Integrated search functionality across CLI and MCP tools for cross-platform task discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->