### PR TITLE
fix: prevent task number collisions when moving tasks between tags

### DIFF
--- a/mcp-server/src/core/direct-functions/move-task-cross-tag.js
+++ b/mcp-server/src/core/direct-functions/move-task-cross-tag.js
@@ -121,7 +121,7 @@ export async function moveTaskCrossTagDirect(args, log, context = {}) {
 			const renumberedTasks = (result.movedTasks || []).filter(
 				(t) => t.newId !== undefined
 			);
-			let message = `Successfully moved ${sourceIds.length} task(s) from "${args.sourceTag}" to "${args.targetTag}"`;
+			let message = `Successfully moved ${(result.movedTasks || []).length} task(s) from "${args.sourceTag}" to "${args.targetTag}"`;
 			if (renumberedTasks.length > 0) {
 				const renumberDetails = renumberedTasks
 					.map((t) => `${t.originalId} → ${t.newId}`)

--- a/scripts/modules/task-manager/move-task.js
+++ b/scripts/modules/task-manager/move-task.js
@@ -895,6 +895,15 @@ async function executeMoveOperation(
 		// Apply the new ID to the task
 		taskToMove.id = assignedId;
 
+		// Update subtask parentTaskId to match the new assigned ID
+		if (Array.isArray(taskToMove.subtasks)) {
+			taskToMove.subtasks.forEach((subtask) => {
+				if (subtask.parentTaskId === normalizedTaskId) {
+					subtask.parentTaskId = assignedId;
+				}
+			});
+		}
+
 		// Update internal subtask dependency references that pointed to the old parent ID
 		if (Array.isArray(taskToMove.subtasks)) {
 			taskToMove.subtasks.forEach((subtask) => {
@@ -959,7 +968,13 @@ async function executeMoveOperation(
 						Number.isFinite(normalizedDep) &&
 						idRemapping.has(normalizedDep)
 					) {
-						return idRemapping.get(normalizedDep);
+						const newParentId = idRemapping.get(normalizedDep);
+						// Preserve dotted subtask suffix (e.g., "1.2" -> "5.2" when 1 remaps to 5)
+						if (typeof dep === 'string' && dep.includes('.')) {
+							const dotIndex = dep.indexOf('.');
+							return `${newParentId}${dep.slice(dotIndex)}`;
+						}
+						return newParentId;
 					}
 					return dep;
 				});
@@ -974,7 +989,13 @@ async function executeMoveOperation(
 								Number.isFinite(normalizedDep) &&
 								idRemapping.has(normalizedDep)
 							) {
-								return idRemapping.get(normalizedDep);
+								const newParentId = idRemapping.get(normalizedDep);
+								// Preserve dotted subtask suffix (e.g., "1.2" -> "5.2" when 1 remaps to 5)
+								if (typeof dep === 'string' && dep.includes('.')) {
+									const dotIndex = dep.indexOf('.');
+									return `${newParentId}${dep.slice(dotIndex)}`;
+								}
+								return newParentId;
 							}
 							return dep;
 						});

--- a/tests/integration/move-task-cross-tag.integration.test.js
+++ b/tests/integration/move-task-cross-tag.integration.test.js
@@ -608,6 +608,95 @@ describe('Cross-Tag Task Movement Integration Tests', () => {
 			// Source tag should be empty
 			expect(writtenData.backlog.tasks).toHaveLength(0);
 		});
+
+		it('should preserve dotted subtask suffix when remapping dependencies on ID collision', async () => {
+			// Setup: Task 1 depends on "2.3" (subtask 3 of task 2).
+			// Target already has task 2, so task 2 must be renumbered.
+			// After renumbering, task 1's dep "2.3" should become "<newId>.3", not just <newId>.
+			const conflictingData = {
+				backlog: {
+					tasks: [
+						{
+							id: 1,
+							title: 'Task A',
+							tag: 'backlog',
+							dependencies: ['2.3'],
+							subtasks: [
+								{
+									id: 1,
+									parentTaskId: 1,
+									dependencies: ['2.1'],
+									title: 'Subtask A.1'
+								}
+							]
+						},
+						{
+							id: 2,
+							title: 'Task B',
+							tag: 'backlog',
+							dependencies: [],
+							subtasks: [
+								{
+									id: 1,
+									parentTaskId: 2,
+									dependencies: [],
+									title: 'Subtask B.1'
+								},
+								{
+									id: 3,
+									parentTaskId: 2,
+									dependencies: [],
+									title: 'Subtask B.3'
+								}
+							]
+						}
+					]
+				},
+				'in-progress': {
+					tasks: [
+						{
+							id: 2, // Conflicts with backlog task 2
+							title: 'Existing Task',
+							tag: 'in-progress',
+							dependencies: []
+						}
+					]
+				}
+			};
+
+			mockUtils.readJSON.mockReturnValue(conflictingData);
+
+			const result = await moveTasksBetweenTags(
+				testDataPath,
+				[1, 2],
+				'backlog',
+				'in-progress',
+				{},
+				{ projectRoot: '/test/project' }
+			);
+
+			expect(mockUtils.writeJSON).toHaveBeenCalled();
+			const writtenData = mockUtils.writeJSON.mock.calls[0][1];
+			const targetTasks = writtenData['in-progress'].tasks;
+
+			// Task 2 was renumbered to 3 (next available after existing 2)
+			const renamedTask = targetTasks.find((t) => t.title === 'Task B');
+			expect(renamedTask).toBeDefined();
+			expect(renamedTask.id).toBe(3);
+
+			// Task B's subtasks should have updated parentTaskId
+			renamedTask.subtasks.forEach((st) => {
+				expect(st.parentTaskId).toBe(3);
+			});
+
+			// Task 1's dependency "2.3" should become "3.3" (not just 3)
+			const taskA = targetTasks.find((t) => t.title === 'Task A');
+			expect(taskA).toBeDefined();
+			expect(taskA.dependencies).toContain('3.3');
+
+			// Task A's subtask dep "2.1" should become "3.1" (not just 3)
+			expect(taskA.subtasks[0].dependencies).toContain('3.1');
+		});
 	});
 
 	describe('Edge Cases', () => {


### PR DESCRIPTION
## Summary
- When moving tasks between tags, if a task's ID already exists in the target tag, the task is now automatically renumbered to the next available ID instead of throwing a `TASK_ALREADY_EXISTS` error
- Dependencies within the moved batch are updated to reflect new IDs (both task-level and subtask-level dependencies)
- The response message and MCP tool output now include details about any renumbered tasks (e.g., `1 → 5`)
- A tip is provided suggesting `task-master validate-dependencies` when renumbering occurs

## Test plan
- [x] Existing unit tests pass (47 cross-tag move tests)
- [x] Existing integration tests pass (updated ID collision test to verify auto-renumber behavior)
- [x] All 76 move-task related tests pass
- [ ] Manual test: create tasks with same IDs in two different tags, move one to the other, verify renumbering
- [ ] Manual test: move multiple tasks with dependencies where some get renumbered, verify dependency updates

Fixes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Moving tasks between tags now auto-renumbers conflicting IDs instead of failing.
  * Success messages include renumbering details and a tip to validate dependencies.
  * Dependencies and subtask parent references are updated to preserve relationships (including dotted subtask references) after renumbering.

* **Tests**
  * Integration tests updated/added to verify automatic renumbering and dependency remapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->