### PR TITLE
fix: display task complexity in list after analyze-complexity

### DIFF
--- a/.changeset/fix-complexity-tag-fallback.md
+++ b/.changeset/fix-complexity-tag-fallback.md
@@ -1,0 +1,5 @@
+---
+"@tm/core": patch
+---
+
+Fix complexity data not showing in `list` after `analyze-complexity` with tags. When tasks are stored under a non-master tag and the list command defaults to 'master', complexity data from the tag-specific report is now correctly loaded.

--- a/packages/tm-core/src/modules/storage/adapters/file-storage/file-storage.ts
+++ b/packages/tm-core/src/modules/storage/adapters/file-storage/file-storage.ts
@@ -129,6 +129,11 @@ export class FileStorage implements IStorage {
 			const rawData = await this.fileOps.readJson(filePath);
 			let tasks = this.formatHandler.extractTasks(rawData, resolvedTag);
 
+			// Resolve the actual tag used for task extraction (may differ from
+			// resolvedTag in legacy format when 'master' falls back to another tag).
+			// This ensures complexity enrichment uses the correct report file.
+			const actualTag = this.formatHandler.resolveTag(rawData, resolvedTag);
+
 			// Apply filters if provided
 			if (options) {
 				// Filter by status if specified
@@ -145,7 +150,7 @@ export class FileStorage implements IStorage {
 				}
 			}
 
-			return await this.enrichTasksWithComplexity(tasks, resolvedTag);
+			return await this.enrichTasksWithComplexity(tasks, actualTag);
 		} catch (error: any) {
 			if (error.code === 'ENOENT') {
 				return []; // File doesn't exist, return empty array

--- a/packages/tm-core/src/modules/storage/adapters/file-storage/format-handler.spec.ts
+++ b/packages/tm-core/src/modules/storage/adapters/file-storage/format-handler.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { FormatHandler } from './format-handler.js';
+
+describe('FormatHandler.resolveTag()', () => {
+	const handler = new FormatHandler();
+
+	it('should return the requested tag when it exists in legacy format', () => {
+		const data = { foo: { tasks: [{ id: '1', title: 'T1' }] } };
+		expect(handler.resolveTag(data, 'foo')).toBe('foo');
+	});
+
+	it('should fall back to first available tag when master is requested but absent', () => {
+		const data = { 'my-feature': { tasks: [{ id: '1', title: 'T1' }] } };
+		expect(handler.resolveTag(data, 'master')).toBe('my-feature');
+	});
+
+	it('should return master for standard format', () => {
+		const data = { tasks: [{ id: '1' }], metadata: { version: '1.0.0' } };
+		expect(handler.resolveTag(data, 'master')).toBe('master');
+	});
+
+	it('should return the requested tag for null data', () => {
+		expect(handler.resolveTag(null, 'master')).toBe('master');
+	});
+
+	it('should be consistent with extractTasks tag resolution', () => {
+		const data = {
+			'feature-a': {
+				tasks: [{ id: '1', title: 'T1', description: '', status: 'pending', priority: 'medium', dependencies: [], details: '', testStrategy: '', subtasks: [] }]
+			}
+		};
+		const tasks = handler.extractTasks(data, 'master');
+		const resolvedTag = handler.resolveTag(data, 'master');
+		expect(tasks).toHaveLength(1);
+		expect(resolvedTag).toBe('feature-a');
+	});
+});

--- a/packages/tm-core/src/modules/storage/adapters/file-storage/format-handler.ts
+++ b/packages/tm-core/src/modules/storage/adapters/file-storage/format-handler.ts
@@ -35,6 +35,35 @@ export class FormatHandler {
 	}
 
 	/**
+	 * Resolve the actual tag used to extract tasks.
+	 * In legacy format, if the requested tag doesn't exist but 'master' is requested,
+	 * it falls back to the first available tag. This method returns that resolved tag
+	 * so callers (e.g., complexity enrichment) use the correct tag for report lookups.
+	 */
+	resolveTag(data: any, tag: string): string {
+		if (!data) {
+			return tag;
+		}
+
+		const format = this.detectFormat(data);
+
+		if (format === 'legacy') {
+			if (tag in data) {
+				return tag;
+			}
+
+			const availableKeys = Object.keys(data).filter(
+				(key) => key !== 'tasks' && key !== 'metadata'
+			);
+			if (tag === 'master' && availableKeys.length > 0) {
+				return availableKeys[0];
+			}
+		}
+
+		return tag;
+	}
+
+	/**
 	 * Extract tasks from data for a specific tag
 	 */
 	extractTasks(data: any, tag: string): Task[] {

--- a/packages/tm-core/tests/integration/storage/complexity-tag-fallback.test.ts
+++ b/packages/tm-core/tests/integration/storage/complexity-tag-fallback.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { FileStorage } from '../../../src/modules/storage/adapters/file-storage/file-storage.js';
+
+describe('Complexity enrichment with tag fallback (issue #1614)', () => {
+	let tempDir: string;
+	let storage: FileStorage;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'taskmaster-test-'));
+		fs.mkdirSync(path.join(tempDir, '.taskmaster', 'tasks'), { recursive: true });
+		fs.mkdirSync(path.join(tempDir, '.taskmaster', 'reports'), { recursive: true });
+		storage = new FileStorage(tempDir);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('should enrich tasks with complexity when tag falls back from master to actual tag', async () => {
+		const tasksFile = path.join(tempDir, '.taskmaster', 'tasks', 'tasks.json');
+		fs.writeFileSync(tasksFile, JSON.stringify({
+			foo: {
+				tasks: [
+					{ id: '1', title: 'Task 1', description: '', status: 'pending', priority: 'high', dependencies: [], details: '', testStrategy: '', subtasks: [] },
+					{ id: '2', title: 'Task 2', description: '', status: 'pending', priority: 'medium', dependencies: ['1'], details: '', testStrategy: '', subtasks: [] }
+				],
+				metadata: { version: '1.0.0', lastModified: new Date().toISOString(), taskCount: 2, completedCount: 0, tags: ['foo'] }
+			}
+		}, null, 2));
+
+		const reportFile = path.join(tempDir, '.taskmaster', 'reports', 'task-complexity-report_foo.json');
+		fs.writeFileSync(reportFile, JSON.stringify({
+			meta: { generatedAt: new Date().toISOString(), taskCount: 2, thresholds: { high: 8, medium: 5 } },
+			complexityAnalysis: [
+				{ taskId: 1, taskTitle: 'Task 1', complexityScore: 7, recommendedSubtasks: 4, expansionPrompt: 'p', complexityReasoning: 'r' },
+				{ taskId: 2, taskTitle: 'Task 2', complexityScore: 3, recommendedSubtasks: 2, expansionPrompt: 'p', complexityReasoning: 'r' }
+			]
+		}, null, 2));
+
+		const tasks = await storage.loadTasks();
+		expect(tasks).toHaveLength(2);
+		const task1 = tasks.find((t) => String(t.id) === '1');
+		const task2 = tasks.find((t) => String(t.id) === '2');
+		expect(task1!.complexity).toBe(7);
+		expect(task2!.complexity).toBe(3);
+	});
+
+	it('should enrich tasks with complexity when explicit tag matches report', async () => {
+		const tasksFile = path.join(tempDir, '.taskmaster', 'tasks', 'tasks.json');
+		fs.writeFileSync(tasksFile, JSON.stringify({
+			bar: {
+				tasks: [{ id: '1', title: 'Task 1', description: '', status: 'pending', priority: 'medium', dependencies: [], details: '', testStrategy: '', subtasks: [] }],
+				metadata: { version: '1.0.0', lastModified: new Date().toISOString(), taskCount: 1, completedCount: 0, tags: ['bar'] }
+			}
+		}, null, 2));
+
+		const reportFile = path.join(tempDir, '.taskmaster', 'reports', 'task-complexity-report_bar.json');
+		fs.writeFileSync(reportFile, JSON.stringify({
+			meta: { generatedAt: new Date().toISOString(), taskCount: 1, thresholds: { high: 8, medium: 5 } },
+			complexityAnalysis: [{ taskId: 1, taskTitle: 'Task 1', complexityScore: 9, recommendedSubtasks: 6, expansionPrompt: 'p', complexityReasoning: 'r' }]
+		}, null, 2));
+
+		const tasks = await storage.loadTasks('bar');
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0].complexity).toBe(9);
+	});
+
+	it('should return undefined complexity when no report exists', async () => {
+		const tasksFile = path.join(tempDir, '.taskmaster', 'tasks', 'tasks.json');
+		fs.writeFileSync(tasksFile, JSON.stringify({
+			tasks: [{ id: '1', title: 'Task 1', description: '', status: 'pending', priority: 'medium', dependencies: [], details: '', testStrategy: '', subtasks: [] }],
+			metadata: { version: '1.0.0', lastModified: new Date().toISOString(), taskCount: 1, completedCount: 0 }
+		}, null, 2));
+
+		const tasks = await storage.loadTasks();
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0].complexity).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Fix complexity data showing as `N/A` in `list` output after running `analyze-complexity` with a tag
- Root cause: in legacy file format, `loadTasks('master')` falls back to the first available tag (e.g., `foo`) when loading tasks, but was still using `'master'` when looking up the complexity report — causing a file path mismatch (`task-complexity-report.json` vs `task-complexity-report_foo.json`)
- Add `FormatHandler.resolveTag()` to determine the actual tag used for task extraction, then pass it to `enrichTasksWithComplexity()` so the correct complexity report is loaded

## Test plan
- [ ] Run `task-master parse-prd --input .taskmaster/docs/prd.md --tag foo` then `task-master analyze-complexity --tag foo` then `task-master list` — complexity column should now show scores
- [ ] Run `npm run test -w @tm/core -- --run format-handler.spec --no-coverage` — 5 unit tests for resolveTag pass
- [ ] Run `npm run test -w @tm/core -- --run complexity-tag-fallback --no-coverage` — 3 integration tests pass (including the key regression test)
- [ ] Run `npm run test -w @tm/core -- --run file-storage-metadata --no-coverage` — all 18 existing tests pass (no regressions)
- [ ] Run `npm run typecheck -w @tm/core` — no type errors

Fixes #1614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where complexity analysis results would not appear in task list output when tasks were stored under non-master tags while using the default master tag. The system now correctly resolves and applies complexity data from tag-specific reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->