### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ task-master move --from=5 --from-tag=backlog --to-tag=in-progress --ignore-depen
 task-master rules add windsurf,roo,vscode
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/eyaltoledano-claude-task-master).
+
 ## Tool Loading Configuration
 
 ### Optimizing MCP Tool Loading


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/eyaltoledano-claude-task-master).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about hosted deployment availability with a link to access the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->