### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/weekly-metrics-discord.yml
+++ b/.github/workflows/weekly-metrics-discord.yml
@@ -38,7 +38,7 @@ jobs:
           echo "date_range=Past 14 days ($first_day to $last_day)" >> $GITHUB_ENV
 
       - name: Generate issue metrics
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: "repo:${{ github.repository }} is:issue created:${{ env.first_day }}..${{ env.last_day }}"
@@ -47,14 +47,14 @@ jobs:
           OUTPUT_FILE: issue_metrics.md
 
       - name: Generate PR created metrics
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: "repo:${{ github.repository }} is:pr created:${{ env.first_day }}..${{ env.last_day }}"
           OUTPUT_FILE: pr_created_metrics.md
 
       - name: Generate PR merged metrics
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: "repo:${{ github.repository }} is:pr is:merged merged:${{ env.first_day }}..${{ env.last_day }}"


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metrics generation workflow action reference for improved reliability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->