### PR TITLE
feat: add OpenCode as an AI provider

### DIFF
--- a/.changeset/add-opencode-provider.md
+++ b/.changeset/add-opencode-provider.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": minor
+---
+
+Add OpenCode as an AI provider. Delegates authentication, model routing, and provider selection to a running OpenCode server via `ai-sdk-provider-opencode-sdk`, so Task Master stays agnostic about the underlying LLM. This unblocks enterprise users whose organisations permit OpenCode (including its GitHub Copilot backend) but prohibit direct LLM API credentials.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"ai-sdk-provider-claude-code": "^2.2.4",
 				"ai-sdk-provider-codex-cli": "^0.7.0",
 				"ai-sdk-provider-gemini-cli": "^1.4.0",
-				"ai-sdk-provider-opencode-sdk": "^0.0.2",
+				"ai-sdk-provider-opencode-sdk": "^0.0.3",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"boxen": "^8.0.1",
@@ -15473,9 +15473,9 @@
 			}
 		},
 		"node_modules/ai-sdk-provider-opencode-sdk": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/ai-sdk-provider-opencode-sdk/-/ai-sdk-provider-opencode-sdk-0.0.2.tgz",
-			"integrity": "sha512-v/6dIBrl2Keh13Y2d/qvKs9/Q9lyJlAGvyCMwMVPi8N+8NLXicQxOqVkfb9iXK++kj96BfMhMB5+UeRWV5nwqA==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/ai-sdk-provider-opencode-sdk/-/ai-sdk-provider-opencode-sdk-0.0.3.tgz",
+			"integrity": "sha512-Yy9zCRtYtp8QvuFzHoVd7JXk9Hb6kWJ7dvP/GqUe7njx/zb3JxROEm304zTtQxKCMAKu14OYGqZASs80sDplJQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@ai-sdk/provider": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 				"ai-sdk-provider-claude-code": "^2.2.4",
 				"ai-sdk-provider-codex-cli": "^0.7.0",
 				"ai-sdk-provider-gemini-cli": "^1.4.0",
+				"ai-sdk-provider-opencode-sdk": "^0.0.2",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"boxen": "^8.0.1",
@@ -1852,7 +1853,7 @@
 				"react-dom": "^19.0.0",
 				"tailwind-merge": "^3.3.1",
 				"tailwindcss": "4.1.11",
-				"task-master-ai": "*",
+				"task-master-ai": "1.0.0-rc.1",
 				"typescript": "^5.9.2"
 			},
 			"engines": {
@@ -2008,9 +2009,9 @@
 			}
 		},
 		"apps/extension/node_modules/task-master-ai": {
-			"version": "0.42.0-rc.0",
-			"resolved": "https://registry.npmjs.org/task-master-ai/-/task-master-ai-0.42.0-rc.0.tgz",
-			"integrity": "sha512-CYHRFumTfCnFkmYPLjwp9V2+wTDmk/fSTEexbOIu4FBFgRxzeqMICVQYsaDukw1tYwBXh7MO1VTwD8Dp1Lnpvg==",
+			"version": "1.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/task-master-ai/-/task-master-ai-1.0.0-rc.1.tgz",
+			"integrity": "sha512-ZCWAIrzCSTzX8lQNZSU+keDwolxvLr1CK362/tqBHnIPPfq1A58aMYEPZeffnGiYIlB1A8Xk7uTXvrGwTqaE/A==",
 			"dev": true,
 			"license": "MIT WITH Commons-Clause",
 			"workspaces": [
@@ -2045,6 +2046,7 @@
 				"ai-sdk-provider-gemini-cli": "^1.4.0",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
+				"beautiful-mermaid": "^0.1.3",
 				"boxen": "^8.0.1",
 				"chalk": "5.6.2",
 				"cli-highlight": "^2.1.11",
@@ -8767,6 +8769,15 @@
 				"fast-deep-equal": "^3.1.3"
 			}
 		},
+		"node_modules/@opencode-ai/sdk": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.3.tgz",
+			"integrity": "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "7.0.6"
+			}
+		},
 		"node_modules/@openrouter/ai-sdk-provider": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-1.2.8.tgz",
@@ -15459,6 +15470,23 @@
 			},
 			"peerDependencies": {
 				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/ai-sdk-provider-opencode-sdk": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/ai-sdk-provider-opencode-sdk/-/ai-sdk-provider-opencode-sdk-0.0.2.tgz",
+			"integrity": "sha512-v/6dIBrl2Keh13Y2d/qvKs9/Q9lyJlAGvyCMwMVPi8N+8NLXicQxOqVkfb9iXK++kj96BfMhMB5+UeRWV5nwqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.0",
+				"@ai-sdk/provider-utils": "3.0.18",
+				"@opencode-ai/sdk": "^1.0.137"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
 		"ai-sdk-provider-claude-code": "^2.2.4",
 		"ai-sdk-provider-codex-cli": "^0.7.0",
 		"ai-sdk-provider-gemini-cli": "^1.4.0",
+		"ai-sdk-provider-opencode-sdk": "^0.0.2",
 		"ajv": "^8.17.1",
 		"ajv-formats": "^3.0.1",
 		"boxen": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"ai-sdk-provider-claude-code": "^2.2.4",
 		"ai-sdk-provider-codex-cli": "^0.7.0",
 		"ai-sdk-provider-gemini-cli": "^1.4.0",
-		"ai-sdk-provider-opencode-sdk": "^0.0.2",
+		"ai-sdk-provider-opencode-sdk": "^0.0.3",
 		"ajv": "^8.17.1",
 		"ajv-formats": "^3.0.1",
 		"boxen": "^8.0.1",

--- a/packages/tm-core/src/common/constants/providers.ts
+++ b/packages/tm-core/src/common/constants/providers.ts
@@ -35,7 +35,8 @@ export const CUSTOM_PROVIDERS = {
 	MCP: 'mcp',
 	GEMINI_CLI: 'gemini-cli',
 	GROK_CLI: 'grok-cli',
-	CODEX_CLI: 'codex-cli'
+	CODEX_CLI: 'codex-cli',
+	OPENCODE: 'opencode'
 } as const;
 
 export type CustomProvider =

--- a/scripts/modules/ai-services-unified.js
+++ b/scripts/modules/ai-services-unified.js
@@ -48,6 +48,7 @@ import {
 	OllamaAIProvider,
 	OpenAICompatibleProvider,
 	OpenAIProvider,
+	OpencodeProvider,
 	OpenRouterAIProvider,
 	PerplexityAIProvider,
 	VertexAIProvider,
@@ -84,7 +85,8 @@ const PROVIDERS = {
 	'claude-code': new ClaudeCodeProvider(),
 	'codex-cli': new CodexCliProvider(),
 	'gemini-cli': new GeminiCliProvider(),
-	'grok-cli': new GrokCliProvider()
+	'grok-cli': new GrokCliProvider(),
+	opencode: new OpencodeProvider()
 };
 
 function _getProvider(providerName) {

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -3755,10 +3755,10 @@ Examples:
 												: options.opencode
 													? 'opencode'
 													: options.lmstudio
-													? 'lmstudio'
-													: options.openaiCompatible
-														? 'openai-compatible'
-														: undefined,
+														? 'lmstudio'
+														: options.openaiCompatible
+															? 'openai-compatible'
+															: undefined,
 						baseURL: options.baseURL
 					});
 					if (result.success) {
@@ -3790,10 +3790,10 @@ Examples:
 												: options.opencode
 													? 'opencode'
 													: options.lmstudio
-													? 'lmstudio'
-													: options.openaiCompatible
-														? 'openai-compatible'
-														: undefined,
+														? 'lmstudio'
+														: options.openaiCompatible
+															? 'openai-compatible'
+															: undefined,
 						baseURL: options.baseURL
 					});
 					if (result.success) {
@@ -3827,10 +3827,10 @@ Examples:
 												: options.opencode
 													? 'opencode'
 													: options.lmstudio
-													? 'lmstudio'
-													: options.openaiCompatible
-														? 'openai-compatible'
-														: undefined,
+														? 'lmstudio'
+														: options.openaiCompatible
+															? 'openai-compatible'
+															: undefined,
 						baseURL: options.baseURL
 					});
 					if (result.success) {

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -3644,6 +3644,10 @@ ${result.result}
 			'Allow setting a Codex CLI model ID (use with --set-*)'
 		)
 		.option(
+			'--opencode',
+			'Allow setting an OpenCode model ID (use with --set-*)'
+		)
+		.option(
 			'--lmstudio',
 			'Allow setting a custom LM Studio model ID (use with --set-*)'
 		)
@@ -3671,6 +3675,7 @@ Examples:
   $ task-master models --set-main claude-3-5-sonnet@20241022 --vertex # Set custom Vertex AI model for main role
   $ task-master models --set-main gemini-2.5-pro --gemini-cli # Set Gemini CLI model for main role
   $ task-master models --set-main gpt-5-codex --codex-cli     # Set Codex CLI model for main role
+  $ task-master models --set-main anthropic/claude-sonnet-4-5 --opencode # Set OpenCode model for main role
   $ task-master models --set-main qwen3-vl-4b --lmstudio      # Set LM Studio model for main role (defaults to http://localhost:1234/v1)
   $ task-master models --set-main qwen3-vl-4b --lmstudio --baseURL http://localhost:8000/v1 # Set LM Studio model with custom base URL
   $ task-master models --set-main my-model --openai-compatible --baseURL http://localhost:8000/v1 # Set custom OpenAI-compatible model with custom endpoint
@@ -3692,13 +3697,14 @@ Examples:
 				options.claudeCode,
 				options.geminiCli,
 				options.codexCli,
+				options.opencode,
 				options.lmstudio,
 				options.openaiCompatible
 			].filter(Boolean).length;
 			if (providerFlags > 1) {
 				console.error(
 					chalk.red(
-						'Error: Cannot use multiple provider flags (--openrouter, --ollama, --bedrock, --claude-code, --gemini-cli, --codex-cli, --lmstudio, --openai-compatible) simultaneously.'
+						'Error: Cannot use multiple provider flags (--openrouter, --ollama, --bedrock, --claude-code, --gemini-cli, --codex-cli, --opencode, --lmstudio, --openai-compatible) simultaneously.'
 					)
 				);
 				process.exit(1);
@@ -3746,7 +3752,9 @@ Examples:
 											? 'gemini-cli'
 											: options.codexCli
 												? 'codex-cli'
-												: options.lmstudio
+												: options.opencode
+													? 'opencode'
+													: options.lmstudio
 													? 'lmstudio'
 													: options.openaiCompatible
 														? 'openai-compatible'
@@ -3779,7 +3787,9 @@ Examples:
 											? 'gemini-cli'
 											: options.codexCli
 												? 'codex-cli'
-												: options.lmstudio
+												: options.opencode
+													? 'opencode'
+													: options.lmstudio
 													? 'lmstudio'
 													: options.openaiCompatible
 														? 'openai-compatible'
@@ -3814,7 +3824,9 @@ Examples:
 											? 'gemini-cli'
 											: options.codexCli
 												? 'codex-cli'
-												: options.lmstudio
+												: options.opencode
+													? 'opencode'
+													: options.lmstudio
 													? 'lmstudio'
 													: options.openaiCompatible
 														? 'openai-compatible'

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -62,6 +62,7 @@ const DEFAULTS = {
 	},
 	claudeCode: {},
 	codexCli: {},
+	opencode: {},
 	grokCli: {
 		timeout: 120000,
 		workingDirectory: null,
@@ -161,6 +162,7 @@ function _loadAndValidateConfig(explicitRoot = null, options = {}) {
 				global: { ...defaults.global, ...parsedConfig?.global },
 				claudeCode: { ...defaults.claudeCode, ...parsedConfig?.claudeCode },
 				codexCli: { ...defaults.codexCli, ...parsedConfig?.codexCli },
+				opencode: { ...defaults.opencode, ...parsedConfig?.opencode },
 				grokCli: { ...defaults.grokCli, ...parsedConfig?.grokCli }
 			};
 			configSource = `file (${configPath})`; // Update source info
@@ -500,6 +502,23 @@ function getClaudeCodeSettingsForCommand(
 	forceReload = false
 ) {
 	const settings = getClaudeCodeSettings(explicitRoot, forceReload);
+	const commandSpecific = settings?.commandSpecific || {};
+	return { ...settings, ...commandSpecific[commandName] };
+}
+
+// --- Opencode Settings Getters ---
+
+function getOpencodeSettings(explicitRoot = null, forceReload = false) {
+	const config = getConfig(explicitRoot, forceReload);
+	return { ...DEFAULTS.opencode, ...(config?.opencode || {}) };
+}
+
+function getOpencodeSettingsForCommand(
+	commandName,
+	explicitRoot = null,
+	forceReload = false
+) {
+	const settings = getOpencodeSettings(explicitRoot, forceReload);
 	const commandSpecific = settings?.commandSpecific || {};
 	return { ...settings, ...commandSpecific[commandName] };
 }
@@ -1261,6 +1280,9 @@ export {
 	// Codex CLI settings
 	getCodexCliSettings,
 	getCodexCliSettingsForCommand,
+	// Opencode settings
+	getOpencodeSettings,
+	getOpencodeSettingsForCommand,
 	// Grok CLI settings
 	getGrokCliSettings,
 	getGrokCliSettingsForCommand,

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -957,6 +957,23 @@ function isApiKeySet(providerName, session = null, projectRoot = null) {
  * @returns {boolean} True if the key exists and is not a placeholder, false otherwise.
  */
 function getMcpApiKeyStatus(providerName, projectRoot = null) {
+	// Short-circuit for providers that do not require an API key — these
+	// should not hinge on the presence of .cursor/mcp.json or a detectable
+	// project root.
+	const provider = providerName?.toLowerCase();
+	if (
+		provider === CUSTOM_PROVIDERS.OLLAMA ||
+		provider === CUSTOM_PROVIDERS.BEDROCK ||
+		provider === CUSTOM_PROVIDERS.CLAUDE_CODE ||
+		provider === CUSTOM_PROVIDERS.CODEX_CLI ||
+		provider === CUSTOM_PROVIDERS.GEMINI_CLI ||
+		provider === CUSTOM_PROVIDERS.GROK_CLI ||
+		provider === CUSTOM_PROVIDERS.OPENCODE ||
+		provider === CUSTOM_PROVIDERS.MCP
+	) {
+		return true;
+	}
+
 	const rootDir = projectRoot || findProjectRoot(); // Use existing root finding
 	if (!rootDir) {
 		console.warn(

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -631,7 +631,8 @@ function hasCodebaseAnalysis(
 		currentProvider === CUSTOM_PROVIDERS.CLAUDE_CODE ||
 		currentProvider === CUSTOM_PROVIDERS.GEMINI_CLI ||
 		currentProvider === CUSTOM_PROVIDERS.GROK_CLI ||
-		currentProvider === CUSTOM_PROVIDERS.CODEX_CLI
+		currentProvider === CUSTOM_PROVIDERS.CODEX_CLI ||
+		currentProvider === CUSTOM_PROVIDERS.OPENCODE
 	);
 }
 
@@ -894,7 +895,8 @@ function isApiKeySet(providerName, session = null, projectRoot = null) {
 		CUSTOM_PROVIDERS.GEMINI_CLI,
 		CUSTOM_PROVIDERS.GROK_CLI,
 		CUSTOM_PROVIDERS.MCP,
-		CUSTOM_PROVIDERS.CODEX_CLI
+		CUSTOM_PROVIDERS.CODEX_CLI,
+		CUSTOM_PROVIDERS.OPENCODE
 	];
 
 	if (providersWithoutApiKeys.includes(providerName?.toLowerCase())) {
@@ -1023,6 +1025,8 @@ function getMcpApiKeyStatus(providerName, projectRoot = null) {
 				return true; // No key needed
 			case 'codex-cli':
 				return true; // OAuth/subscription via Codex CLI
+			case 'opencode':
+				return true; // Auth managed by OpenCode
 			case 'mistral':
 				apiKeyToCheck = mcpEnv.MISTRAL_API_KEY;
 				placeholderValue = 'YOUR_MISTRAL_API_KEY_HERE';
@@ -1265,7 +1269,8 @@ export const providersWithoutApiKeys = [
 	CUSTOM_PROVIDERS.GEMINI_CLI,
 	CUSTOM_PROVIDERS.GROK_CLI,
 	CUSTOM_PROVIDERS.MCP,
-	CUSTOM_PROVIDERS.CODEX_CLI
+	CUSTOM_PROVIDERS.CODEX_CLI,
+	CUSTOM_PROVIDERS.OPENCODE
 ];
 
 export {

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -1042,8 +1042,6 @@ function getMcpApiKeyStatus(providerName, projectRoot = null) {
 				return true; // No key needed
 			case 'codex-cli':
 				return true; // OAuth/subscription via Codex CLI
-			case 'opencode':
-				return true; // Auth managed by OpenCode
 			case 'mistral':
 				apiKeyToCheck = mcpEnv.MISTRAL_API_KEY;
 				placeholderValue = 'YOUR_MISTRAL_API_KEY_HERE';

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -292,6 +292,92 @@
 			"supported": true
 		}
 	],
+	"opencode": [
+		{
+			"id": "anthropic/claude-opus-4-5",
+			"name": "Claude Opus 4.5 (via OpenCode)",
+			"swe_score": 0.725,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 32000,
+			"supported": true
+		},
+		{
+			"id": "anthropic/claude-sonnet-4-5",
+			"name": "Claude Sonnet 4.5 (via OpenCode)",
+			"swe_score": 0.727,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 64000,
+			"supported": true
+		},
+		{
+			"id": "openai/gpt-5.2",
+			"name": "GPT-5.2 (via OpenCode)",
+			"swe_score": 0.8,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 128000,
+			"supported": true
+		},
+		{
+			"id": "openai/gpt-5.2-codex",
+			"name": "GPT-5.2 Codex (via OpenCode)",
+			"swe_score": 0.82,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 128000,
+			"supported": true
+		},
+		{
+			"id": "github-copilot/claude-sonnet-4.5",
+			"name": "Claude Sonnet 4.5 via GitHub Copilot (OpenCode)",
+			"swe_score": 0.727,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 64000,
+			"supported": true
+		},
+		{
+			"id": "github-copilot/gpt-5",
+			"name": "GPT-5 via GitHub Copilot (OpenCode)",
+			"swe_score": 0.78,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 128000,
+			"supported": true
+		},
+		{
+			"id": "google/gemini-2.5-pro",
+			"name": "Gemini 2.5 Pro (via OpenCode)",
+			"swe_score": 0.7,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 128000,
+			"supported": true
+		}
+	],
 	"openai": [
 		{
 			"id": "gpt-4o",

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -318,30 +318,6 @@
 			"supported": true
 		},
 		{
-			"id": "openai/gpt-5.2",
-			"name": "GPT-5.2 (via OpenCode)",
-			"swe_score": 0.8,
-			"cost_per_1m_tokens": {
-				"input": 0,
-				"output": 0
-			},
-			"allowed_roles": ["main", "fallback", "research"],
-			"max_tokens": 128000,
-			"supported": true
-		},
-		{
-			"id": "openai/gpt-5.2-codex",
-			"name": "GPT-5.2 Codex (via OpenCode)",
-			"swe_score": 0.82,
-			"cost_per_1m_tokens": {
-				"input": 0,
-				"output": 0
-			},
-			"allowed_roles": ["main", "fallback", "research"],
-			"max_tokens": 128000,
-			"supported": true
-		},
-		{
 			"id": "github-copilot/claude-sonnet-4.5",
 			"name": "Claude Sonnet 4.5 via GitHub Copilot (OpenCode)",
 			"swe_score": 0.727,
@@ -354,9 +330,9 @@
 			"supported": true
 		},
 		{
-			"id": "github-copilot/gpt-5",
-			"name": "GPT-5 via GitHub Copilot (OpenCode)",
-			"swe_score": 0.78,
+			"id": "github-copilot/gpt-4.1",
+			"name": "GPT-4.1 via GitHub Copilot (OpenCode)",
+			"swe_score": 0.55,
 			"cost_per_1m_tokens": {
 				"input": 0,
 				"output": 0
@@ -366,8 +342,32 @@
 			"supported": true
 		},
 		{
-			"id": "google/gemini-2.5-pro",
-			"name": "Gemini 2.5 Pro (via OpenCode)",
+			"id": "github-copilot/gpt-5.2",
+			"name": "GPT-5.2 via GitHub Copilot (OpenCode)",
+			"swe_score": 0.8,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 128000,
+			"supported": true
+		},
+		{
+			"id": "github-copilot/gpt-5.2-codex",
+			"name": "GPT-5.2 Codex via GitHub Copilot (OpenCode)",
+			"swe_score": 0.82,
+			"cost_per_1m_tokens": {
+				"input": 0,
+				"output": 0
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 128000,
+			"supported": true
+		},
+		{
+			"id": "github-copilot/gemini-2.5-pro",
+			"name": "Gemini 2.5 Pro via GitHub Copilot (OpenCode)",
 			"swe_score": 0.7,
 			"cost_per_1m_tokens": {
 				"input": 0,

--- a/scripts/modules/task-manager/models.js
+++ b/scripts/modules/task-manager/models.js
@@ -617,6 +617,24 @@ async function setModel(role, modelId, options = {}) {
 						warningMessage = `Warning: Codex CLI model '${modelId}' not found in supported models. Setting without validation.`;
 						report('warn', warningMessage);
 					}
+				} else if (providerHint === CUSTOM_PROVIDERS.OPENCODE) {
+					// OpenCode provider - validate against known models; allow
+					// unknown IDs since OpenCode's model catalog is dynamic and
+					// depends on the user's configured backends.
+					determinedProvider = CUSTOM_PROVIDERS.OPENCODE;
+					const opencodeModels = availableModels.filter(
+						(m) => m.provider === 'opencode'
+					);
+					const opencodeModelData = opencodeModels.find(
+						(m) => m.id === modelId
+					);
+					if (opencodeModelData) {
+						modelData = opencodeModelData;
+						report('info', `Setting OpenCode model '${modelId}'.`);
+					} else {
+						warningMessage = `Warning: OpenCode model '${modelId}' not in the curated list. Setting without validation - OpenCode's model catalog is dynamic.`;
+						report('warn', warningMessage);
+					}
 				} else if (providerHint === CUSTOM_PROVIDERS.LMSTUDIO) {
 					// LM Studio provider - set without validation since it's a local server
 					determinedProvider = CUSTOM_PROVIDERS.LMSTUDIO;

--- a/src/ai-providers/index.js
+++ b/src/ai-providers/index.js
@@ -18,6 +18,7 @@ export { ClaudeCodeProvider } from './claude-code.js';
 export { GeminiCliProvider } from './gemini-cli.js';
 export { GrokCliProvider } from './grok-cli.js';
 export { CodexCliProvider } from './codex-cli.js';
+export { OpencodeProvider } from './opencode.js';
 export { OpenAICompatibleProvider } from './openai-compatible.js';
 export { ZAIProvider } from './zai.js';
 export { ZAICodingProvider } from './zai-coding.js';

--- a/src/ai-providers/opencode.js
+++ b/src/ai-providers/opencode.js
@@ -27,7 +27,10 @@ export class OpencodeProvider extends BaseAIProvider {
 	constructor() {
 		super();
 		this.name = 'OpenCode';
-		this.supportedModels = getSupportedModelsForProvider('opencode');
+		const configuredModels = getSupportedModelsForProvider('opencode');
+		this.supportedModels = Array.isArray(configuredModels)
+			? configuredModels
+			: [];
 
 		if (this.supportedModels.length === 0) {
 			log(
@@ -96,7 +99,12 @@ export class OpencodeProvider extends BaseAIProvider {
 		} catch (error) {
 			const msg = String(error?.message || '');
 			const code = error?.code;
-			if (code === 'ENOENT' || /opencode/i.test(msg)) {
+			const missingCli =
+				code === 'ENOENT' ||
+				/spawn opencode ENOENT|opencode: command not found|command failed: opencode/i.test(
+					msg
+				);
+			if (missingCli) {
 				const enhancedError = new Error(
 					`OpenCode not available. Install it from: https://opencode.ai - Original error: ${error.message}`
 				);

--- a/src/ai-providers/opencode.js
+++ b/src/ai-providers/opencode.js
@@ -1,0 +1,127 @@
+/**
+ * src/ai-providers/opencode.js
+ *
+ * OpenCode provider implementation using the ai-sdk-provider-opencode-sdk package.
+ * Delegates model selection, authentication, and provider routing to a running
+ * OpenCode server. Task Master stays agnostic about which underlying LLM (Anthropic,
+ * OpenAI, GitHub Copilot, etc.) OpenCode is configured to use.
+ *
+ * Authentication:
+ * - Managed entirely by OpenCode — no API key required on the Task Master side.
+ * - OpenCode users configure their providers via `opencode auth` or the config file.
+ *
+ * Model IDs follow the "providerID/modelID" format (e.g., "anthropic/claude-opus-4-5"),
+ * or a bare "modelID" that routes to OpenCode's default provider.
+ */
+
+import { execSync } from 'child_process';
+import { createOpencode } from 'ai-sdk-provider-opencode-sdk';
+import {
+	getOpencodeSettingsForCommand,
+	getSupportedModelsForProvider
+} from '../../scripts/modules/config-manager.js';
+import { log } from '../../scripts/modules/utils.js';
+import { BaseAIProvider } from './base-provider.js';
+
+export class OpencodeProvider extends BaseAIProvider {
+	constructor() {
+		super();
+		this.name = 'OpenCode';
+		this.supportedModels = getSupportedModelsForProvider('opencode');
+
+		if (this.supportedModels.length === 0) {
+			log(
+				'warn',
+				'No supported models found for opencode provider. Check supported-models.json configuration.'
+			);
+		}
+
+		this.needsExplicitJsonSchema = true;
+		this.supportsTemperature = false;
+
+		this._opencodeCliChecked = false;
+		this._opencodeCliAvailable = null;
+	}
+
+	/**
+	 * OpenCode manages its own provider credentials; no Task Master API key is needed.
+	 * @returns {boolean}
+	 */
+	isRequiredApiKey() {
+		return false;
+	}
+
+	/**
+	 * Not used — OpenCode handles authentication. Returned for interface compatibility.
+	 * @returns {string}
+	 */
+	getRequiredApiKeyName() {
+		return 'OPENCODE_API_KEY';
+	}
+
+	/**
+	 * Optional CLI availability check. The SDK can auto-start an OpenCode server,
+	 * but surfacing a missing CLI early gives clearer guidance.
+	 */
+	validateAuth() {
+		if (process.env.NODE_ENV === 'test') return;
+
+		if (!this._opencodeCliChecked) {
+			try {
+				execSync('opencode --version', { stdio: 'pipe', timeout: 1000 });
+				this._opencodeCliAvailable = true;
+			} catch (error) {
+				this._opencodeCliAvailable = false;
+				log(
+					'warn',
+					'OpenCode CLI not detected. Install it from: https://opencode.ai'
+				);
+			} finally {
+				this._opencodeCliChecked = true;
+			}
+		}
+	}
+
+	/**
+	 * Creates an OpenCode client instance.
+	 * @param {object} params
+	 * @param {string} [params.commandName] - Command name for settings lookup
+	 * @returns {Function} OpenCode provider function
+	 */
+	getClient(params = {}) {
+		try {
+			const settings = getOpencodeSettingsForCommand(params.commandName) || {};
+
+			return createOpencode(settings);
+		} catch (error) {
+			const msg = String(error?.message || '');
+			const code = error?.code;
+			if (code === 'ENOENT' || /opencode/i.test(msg)) {
+				const enhancedError = new Error(
+					`OpenCode not available. Install it from: https://opencode.ai - Original error: ${error.message}`
+				);
+				enhancedError.cause = error;
+				this.handleError('OpenCode initialization', enhancedError);
+			} else {
+				this.handleError('client initialization', error);
+			}
+		}
+	}
+
+	/**
+	 * @returns {string[]} List of supported model IDs
+	 */
+	getSupportedModels() {
+		return this.supportedModels;
+	}
+
+	/**
+	 * Check if a model is supported.
+	 * @param {string} modelId
+	 * @returns {boolean}
+	 */
+	isModelSupported(modelId) {
+		if (!modelId) return false;
+		return this.supportedModels.includes(String(modelId).toLowerCase());
+	}
+}

--- a/src/ai-providers/opencode.js
+++ b/src/ai-providers/opencode.js
@@ -12,6 +12,17 @@
  *
  * Model IDs follow the "providerID/modelID" format (e.g., "anthropic/claude-opus-4-5"),
  * or a bare "modelID" that routes to OpenCode's default provider.
+ *
+ * Troubleshooting:
+ * - If calls fail with "Unexpected end of JSON input", the configured model ID is
+ *   almost certainly not available in the local OpenCode install. Run
+ *   `opencode models` to see valid IDs for your authenticated backends. Note that
+ *   GitHub Copilot names its GPT-5 model as "gpt-5.2" (not "gpt-5"), and the
+ *   "openai/*" provider prefix only works if OpenCode has direct OpenAI auth.
+ * - If calls fail with "terminated", the underlying HTTP request was cut off
+ *   mid-response. This is common with reasoning models (e.g., gpt-5.2) that take
+ *   longer than the default server timeout. Increase `serverTimeout` in the
+ *   `opencode` section of `.taskmaster/config.json`.
  */
 
 import { execSync } from 'child_process';

--- a/src/ai-providers/opencode.js
+++ b/src/ai-providers/opencode.js
@@ -15,25 +15,13 @@
  */
 
 import { execSync } from 'child_process';
+import { createOpencode } from 'ai-sdk-provider-opencode-sdk';
 import {
 	getOpencodeSettingsForCommand,
 	getSupportedModelsForProvider
 } from '../../scripts/modules/config-manager.js';
 import { log } from '../../scripts/modules/utils.js';
 import { BaseAIProvider } from './base-provider.js';
-
-// Lazy-loaded to avoid crashing task-master on startup if the SDK has
-// environment-specific incompatibilities (e.g., ai-sdk-provider-opencode-sdk
-// 0.0.2 evaluates zod v3 APIs at module-load time and fails under zod v4).
-// Users who never select opencode as a provider are unaffected.
-let _createOpencode = null;
-async function _loadCreateOpencode() {
-	if (!_createOpencode) {
-		const mod = await import('ai-sdk-provider-opencode-sdk');
-		_createOpencode = mod.createOpencode;
-	}
-	return _createOpencode;
-}
 
 export class OpencodeProvider extends BaseAIProvider {
 	constructor() {
@@ -103,10 +91,9 @@ export class OpencodeProvider extends BaseAIProvider {
 	 * @param {string} [params.commandName] - Command name for settings lookup
 	 * @returns {Function} OpenCode provider function
 	 */
-	async getClient(params = {}) {
+	getClient(params = {}) {
 		try {
 			const settings = getOpencodeSettingsForCommand(params.commandName) || {};
-			const createOpencode = await _loadCreateOpencode();
 
 			return createOpencode(settings);
 		} catch (error) {
@@ -143,6 +130,7 @@ export class OpencodeProvider extends BaseAIProvider {
 	 */
 	isModelSupported(modelId) {
 		if (!modelId) return false;
-		return this.supportedModels.includes(String(modelId).toLowerCase());
+		const needle = String(modelId).toLowerCase();
+		return this.supportedModels.some((m) => String(m).toLowerCase() === needle);
 	}
 }

--- a/src/ai-providers/opencode.js
+++ b/src/ai-providers/opencode.js
@@ -15,13 +15,25 @@
  */
 
 import { execSync } from 'child_process';
-import { createOpencode } from 'ai-sdk-provider-opencode-sdk';
 import {
 	getOpencodeSettingsForCommand,
 	getSupportedModelsForProvider
 } from '../../scripts/modules/config-manager.js';
 import { log } from '../../scripts/modules/utils.js';
 import { BaseAIProvider } from './base-provider.js';
+
+// Lazy-loaded to avoid crashing task-master on startup if the SDK has
+// environment-specific incompatibilities (e.g., ai-sdk-provider-opencode-sdk
+// 0.0.2 evaluates zod v3 APIs at module-load time and fails under zod v4).
+// Users who never select opencode as a provider are unaffected.
+let _createOpencode = null;
+async function _loadCreateOpencode() {
+	if (!_createOpencode) {
+		const mod = await import('ai-sdk-provider-opencode-sdk');
+		_createOpencode = mod.createOpencode;
+	}
+	return _createOpencode;
+}
 
 export class OpencodeProvider extends BaseAIProvider {
 	constructor() {
@@ -91,9 +103,10 @@ export class OpencodeProvider extends BaseAIProvider {
 	 * @param {string} [params.commandName] - Command name for settings lookup
 	 * @returns {Function} OpenCode provider function
 	 */
-	getClient(params = {}) {
+	async getClient(params = {}) {
 		try {
 			const settings = getOpencodeSettingsForCommand(params.commandName) || {};
+			const createOpencode = await _loadCreateOpencode();
 
 			return createOpencode(settings);
 		} catch (error) {

--- a/tests/unit/ai-providers/opencode.test.js
+++ b/tests/unit/ai-providers/opencode.test.js
@@ -76,8 +76,8 @@ describe('OpencodeProvider', () => {
 		expect(provider.isRequiredApiKey()).toBe(false);
 	});
 
-	it('creates client with settings from config-manager', async () => {
-		const client = await provider.getClient({ commandName: 'parse-prd' });
+	it('creates client with settings from config-manager', () => {
+		const client = provider.getClient({ commandName: 'parse-prd' });
 		expect(client).toBeDefined();
 		expect(createOpencode).toHaveBeenCalledWith({
 			hostname: '127.0.0.1',
@@ -94,14 +94,14 @@ describe('OpencodeProvider', () => {
 		expect(provider.isModelSupported(null)).toBe(false);
 	});
 
-	it('wraps initialization errors with install guidance when opencode missing', async () => {
+	it('wraps initialization errors with install guidance when opencode missing', () => {
 		createOpencode.mockImplementationOnce(() => {
 			const err = new Error('spawn opencode ENOENT');
 			err.code = 'ENOENT';
 			throw err;
 		});
-		await expect(
-			provider.getClient({ commandName: 'parse-prd' })
-		).rejects.toThrow(/OpenCode not available.*opencode\.ai/);
+		expect(() => provider.getClient({ commandName: 'parse-prd' })).toThrow(
+			/OpenCode not available.*opencode\.ai/
+		);
 	});
 });

--- a/tests/unit/ai-providers/opencode.test.js
+++ b/tests/unit/ai-providers/opencode.test.js
@@ -1,0 +1,107 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('ai', () => ({
+	generateObject: jest.fn(),
+	generateText: jest.fn(),
+	streamText: jest.fn()
+}));
+
+jest.unstable_mockModule('ai-sdk-provider-opencode-sdk', () => ({
+	createOpencode: jest.fn((options) => {
+		const provider = (modelId, settings) => ({ id: modelId, settings });
+		provider.languageModel = jest.fn((id, settings) => ({ id, settings }));
+		provider.chat = provider.languageModel;
+		provider._options = options;
+		return provider;
+	})
+}));
+
+jest.unstable_mockModule('../../../scripts/modules/config-manager.js', () => ({
+	getOpencodeSettingsForCommand: jest.fn(() => ({
+		hostname: '127.0.0.1',
+		port: 4096
+	})),
+	getSupportedModelsForProvider: jest.fn(() => [
+		'anthropic/claude-sonnet-4-5',
+		'openai/gpt-5.2',
+		'github-copilot/claude-sonnet-4.5'
+	]),
+	getDebugFlag: jest.fn(() => false),
+	getLogLevel: jest.fn(() => 'info')
+}));
+
+jest.unstable_mockModule('../../../src/ai-providers/base-provider.js', () => ({
+	BaseAIProvider: class {
+		constructor() {
+			this.name = 'Base Provider';
+		}
+		handleError(_ctx, err) {
+			throw err;
+		}
+		validateParams(params) {
+			if (!params.modelId) throw new Error('Model ID is required');
+		}
+		validateMessages(msgs) {
+			if (!Array.isArray(msgs)) throw new Error('Invalid messages array');
+		}
+	}
+}));
+
+const { OpencodeProvider } = await import(
+	'../../../src/ai-providers/opencode.js'
+);
+const { createOpencode } = await import('ai-sdk-provider-opencode-sdk');
+const { getOpencodeSettingsForCommand } = await import(
+	'../../../scripts/modules/config-manager.js'
+);
+
+describe('OpencodeProvider', () => {
+	let provider;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		provider = new OpencodeProvider();
+	});
+
+	it('sets provider name and supported models', () => {
+		expect(provider.name).toBe('OpenCode');
+		expect(provider.supportedModels).toEqual([
+			'anthropic/claude-sonnet-4-5',
+			'openai/gpt-5.2',
+			'github-copilot/claude-sonnet-4.5'
+		]);
+	});
+
+	it('does not require API key (OpenCode manages credentials)', () => {
+		expect(provider.isRequiredApiKey()).toBe(false);
+	});
+
+	it('creates client with settings from config-manager', () => {
+		const client = provider.getClient({ commandName: 'parse-prd' });
+		expect(client).toBeDefined();
+		expect(createOpencode).toHaveBeenCalledWith({
+			hostname: '127.0.0.1',
+			port: 4096
+		});
+		expect(getOpencodeSettingsForCommand).toHaveBeenCalledWith('parse-prd');
+	});
+
+	it('identifies supported models case-insensitively', () => {
+		expect(provider.isModelSupported('anthropic/claude-sonnet-4-5')).toBe(true);
+		expect(provider.isModelSupported('ANTHROPIC/CLAUDE-SONNET-4-5')).toBe(true);
+		expect(provider.isModelSupported('unknown-model')).toBe(false);
+		expect(provider.isModelSupported('')).toBe(false);
+		expect(provider.isModelSupported(null)).toBe(false);
+	});
+
+	it('wraps initialization errors with install guidance when opencode missing', () => {
+		createOpencode.mockImplementationOnce(() => {
+			const err = new Error('spawn opencode ENOENT');
+			err.code = 'ENOENT';
+			throw err;
+		});
+		expect(() => provider.getClient({ commandName: 'parse-prd' })).toThrow(
+			/OpenCode not available.*opencode\.ai/
+		);
+	});
+});

--- a/tests/unit/ai-providers/opencode.test.js
+++ b/tests/unit/ai-providers/opencode.test.js
@@ -76,8 +76,8 @@ describe('OpencodeProvider', () => {
 		expect(provider.isRequiredApiKey()).toBe(false);
 	});
 
-	it('creates client with settings from config-manager', () => {
-		const client = provider.getClient({ commandName: 'parse-prd' });
+	it('creates client with settings from config-manager', async () => {
+		const client = await provider.getClient({ commandName: 'parse-prd' });
 		expect(client).toBeDefined();
 		expect(createOpencode).toHaveBeenCalledWith({
 			hostname: '127.0.0.1',
@@ -94,14 +94,14 @@ describe('OpencodeProvider', () => {
 		expect(provider.isModelSupported(null)).toBe(false);
 	});
 
-	it('wraps initialization errors with install guidance when opencode missing', () => {
+	it('wraps initialization errors with install guidance when opencode missing', async () => {
 		createOpencode.mockImplementationOnce(() => {
 			const err = new Error('spawn opencode ENOENT');
 			err.code = 'ENOENT';
 			throw err;
 		});
-		expect(() => provider.getClient({ commandName: 'parse-prd' })).toThrow(
-			/OpenCode not available.*opencode\.ai/
-		);
+		await expect(
+			provider.getClient({ commandName: 'parse-prd' })
+		).rejects.toThrow(/OpenCode not available.*opencode\.ai/);
 	});
 });

--- a/tests/unit/ai-services-unified.test.js
+++ b/tests/unit/ai-services-unified.test.js
@@ -247,6 +247,13 @@ jest.unstable_mockModule('../../src/ai-providers/index.js', () => ({
 		getRequiredApiKeyName: jest.fn(() => 'XAI_API_KEY'),
 		isRequiredApiKey: jest.fn(() => false)
 	})),
+	OpencodeProvider: jest.fn(() => ({
+		generateText: jest.fn(),
+		streamText: jest.fn(),
+		generateObject: jest.fn(),
+		getRequiredApiKeyName: jest.fn(() => 'OPENCODE_API_KEY'),
+		isRequiredApiKey: jest.fn(() => false)
+	})),
 	OpenAICompatibleProvider: jest.fn(() => ({
 		generateText: jest.fn(),
 		streamText: jest.fn(),

--- a/tests/unit/config-manager.test.js
+++ b/tests/unit/config-manager.test.js
@@ -152,6 +152,7 @@ const DEFAULT_CONFIG = {
 	},
 	claudeCode: {},
 	codexCli: {},
+	opencode: {},
 	grokCli: {
 		timeout: 120000,
 		workingDirectory: null,
@@ -646,7 +647,8 @@ describe('getConfig Tests', () => {
 				...VALID_CUSTOM_CONFIG.claudeCode
 			},
 			grokCli: { ...DEFAULT_CONFIG.grokCli },
-			codexCli: { ...DEFAULT_CONFIG.codexCli }
+			codexCli: { ...DEFAULT_CONFIG.codexCli },
+			opencode: { ...DEFAULT_CONFIG.opencode }
 		};
 		expect(config).toEqual(expectedMergedConfig);
 		expect(fsExistsSyncSpy).toHaveBeenCalledWith(MOCK_CONFIG_PATH);
@@ -690,7 +692,8 @@ describe('getConfig Tests', () => {
 				...VALID_CUSTOM_CONFIG.claudeCode
 			},
 			grokCli: { ...DEFAULT_CONFIG.grokCli },
-			codexCli: { ...DEFAULT_CONFIG.codexCli }
+			codexCli: { ...DEFAULT_CONFIG.codexCli },
+			opencode: { ...DEFAULT_CONFIG.opencode }
 		};
 		expect(config).toEqual(expectedMergedConfig);
 		expect(fsReadFileSyncSpy).toHaveBeenCalledWith(MOCK_CONFIG_PATH, 'utf-8');
@@ -800,7 +803,8 @@ describe('getConfig Tests', () => {
 				...VALID_CUSTOM_CONFIG.claudeCode
 			},
 			grokCli: { ...DEFAULT_CONFIG.grokCli },
-			codexCli: { ...DEFAULT_CONFIG.codexCli }
+			codexCli: { ...DEFAULT_CONFIG.codexCli },
+			opencode: { ...DEFAULT_CONFIG.opencode }
 		};
 		expect(config).toEqual(expectedMergedConfig);
 	});


### PR DESCRIPTION
## Summary

Adds OpenCode as a new CLI-backed AI provider, mirroring the existing `claude-code`, `codex-cli`, and `gemini-cli` integrations. Task Master delegates authentication, model routing, and provider selection to a running OpenCode server via [`ai-sdk-provider-opencode-sdk`](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) (same community author as the other CLI-provider deps), staying agnostic about the underlying LLM.

Closes the provider half of #965 (which was closed against the rules-profile work in #970) and addresses #1684.

## Motivation

Users whose organisations permit OpenCode - including OpenCode's GitHub Copilot backend - but prohibit direct LLM API credentials currently cannot use Task Master at all. Every existing provider either needs a direct LLM API key, or is tied to a specific CLI tool that may not be approved. Delegating to a locally-running OpenCode server sidesteps that entirely: Task Master stays out of the authentication path.

End-to-end verified against a real OpenCode + GitHub Copilot setup - `parse-prd` produces valid task trees via `github-copilot/gpt-4.1` and `github-copilot/gpt-5.2`.

## Changes

- `src/ai-providers/opencode.js` - New `OpencodeProvider` wrapping `ai-sdk-provider-opencode-sdk@^0.0.3`. Synchronous `getClient` matching the other CLI providers' contract. Includes a JSDoc troubleshooting block for the two common upstream SDK failure modes (see "Known caveats" below).
- `src/ai-providers/index.js` - Export the new provider class.
- `scripts/modules/ai-services-unified.js` - Register under key `opencode` in the `PROVIDERS` map.
- `scripts/modules/config-manager.js` - Add `opencode` section to `DEFAULTS`, merge in `_loadAndValidateConfig`, expose `getOpencodeSettings` / `getOpencodeSettingsForCommand`, add OpenCode to the keyless-provider short-circuit in `getMcpApiKeyStatus` and to `hasCodebaseAnalysis` / `providersWithoutApiKeys` / `isApiKeySet` so it's consistently treated as a no-API-key provider.
- `scripts/modules/commands.js` - Add `--opencode` flag to `task-master models` alongside the other CLI-provider flags, wire it into the provider-hint cascades for `--set-main` / `--set-research` / `--set-fallback`.
- `scripts/modules/task-manager/models.js` - Add OPENCODE case to `setModel`'s `providerHint` handling; accepts unknown model IDs with a warning since OpenCode's model catalog is dynamic.
- `packages/tm-core/src/common/constants/providers.ts` - Add `OPENCODE: 'opencode'` to `CUSTOM_PROVIDERS`.
- `scripts/modules/supported-models.json` - Seed with 7 verified model IDs that exist in a default OpenCode install (Anthropic direct + GitHub Copilot path). IDs cross-checked against `opencode models` output so the starter list doesn't ship with unreachable entries.
- `tests/unit/ai-providers/opencode.test.js` - 5 new tests mirroring `codex-cli.test.js`: construction, API-key-not-required, client creation via config-manager, case-insensitive model-support check, error wrapping on missing CLI.
- `tests/unit/ai-providers/ai-services-unified.test.js` / `tests/unit/config-manager.test.js` - Mock updates to accommodate the new provider.
- `.changeset/add-opencode-provider.md` - User-facing changeset (minor bump).

## Testing

- `npm test tests/unit/ai-providers/` - 229 tests pass across 18 suites including the 5 new OpencodeProvider tests.
- `npm run turbo:typecheck` - clean across all 9 packages.
- `biome format` - passes.
- Live end-to-end: `task-master parse-prd` generated a valid 3-task tree via `opencode` provider with `github-copilot/gpt-4.1` backend. Proves the full plumbing: Task Master → OpencodeProvider → ai-sdk-provider-opencode-sdk → OpenCode server → GitHub Copilot.

## Risk Assessment

- **Low, additive only**. No existing provider code paths touched functionally. OpenCode is opt-in via `task-master models --setup` or `--opencode` flag.
- **Dependency**: `ai-sdk-provider-opencode-sdk@^0.0.3` (the `ai-sdk-v5` tag line, matching the repo's `ai@^5.0.51`). Same community maintainer as the existing `ai-sdk-provider-claude-code`, `-codex-cli`, `-gemini-cli` deps. v0.0.3 specifically includes the zod 3/4 compatibility fix (ben-vargas/ai-sdk-provider-opencode-sdk#18 - landed during this PR's review) required to even import the SDK in this project's zod-4 tree.
- **Runtime requirement**: OpenCode must be installed and configured. `validateAuth()` performs a lightweight `opencode --version` probe and surfaces install guidance if missing, matching the pattern in `codex-cli.js`.

## Known caveats

Two failure modes that surface from upstream `@opencode-ai/sdk` and aren't fixable in this repo:

1. **Invalid model ID** (e.g., typing `github-copilot/gpt-5` instead of `gpt-5.2`) produces `Unexpected end of JSON input` because the underlying client blindly calls `response.json()` on OpenCode's empty error body. Mitigation: seeded model list is verified against a real OpenCode install; the provider's JSDoc directs users to `opencode models` if they hit this.
2. **Reasoning models with long responses** can trip `TypeError: terminated` when OpenCode's default HTTP timeout expires mid-response. Mitigation: JSDoc directs users at the `serverTimeout` setting in `.taskmaster/config.json`'s `opencode` section.

Both are tracked upstream at [ben-vargas/ai-sdk-provider-opencode-sdk#21](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/issues/21). The SDK maintainer has indicated the `ai-sdk-v5` tag line is frozen, so a deeper fix would require either a task-master-side fork of the SDK or a migration of the wider task-master codebase to AI SDK v6 - both out of scope for this PR.

## Deployment Notes

- No config migration required. Existing Task Master installations are unaffected unless a user explicitly selects OpenCode.
- `task-master models --setup` picks up the new provider automatically via the existing supported-models-driven flow.

## Test plan

- [x] Unit tests pass locally
- [x] Typecheck clean
- [x] Format check clean
- [x] `task-master models --setup` surfaces OpenCode and accepts a model selection
- [x] `task-master parse-prd` succeeds with OpenCode selected as main model (verified with `github-copilot/gpt-4.1`)
