### PR TITLE
fix: strip commandSpecific before passing settings to createCodexCli

### DIFF
--- a/.changeset/fix-codex-commandspecific-leak.md
+++ b/.changeset/fix-codex-commandspecific-leak.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix: `codexCli.commandSpecific` config is no longer leaked into the Codex CLI provider's `defaultSettings`. Previously, using `commandSpecific` in the `codexCli` config block caused Codex CLI to reject the settings with "Invalid default settings: Unrecognized key: commandSpecific". The key is now stripped before the settings are forwarded to `createCodexCli()`.

--- a/src/ai-providers/codex-cli.js
+++ b/src/ai-providers/codex-cli.js
@@ -162,18 +162,23 @@ export class CodexCliProvider extends BaseAIProvider {
 			// Merge global + command-specific settings from config
 			const settings = getCodexCliSettingsForCommand(params.commandName) || {};
 
+			// Strip Task Master-only keys before forwarding to Codex CLI.
+			// `commandSpecific` is resolved internally and must not be passed through
+			// as a raw provider setting, or Codex CLI will reject it as unknown.
+			const { commandSpecific: _commandSpecific, ...safeSettings } = settings;
+
 			// Get validated reasoningEffort - always pass to override Codex CLI global config
 			const validatedReasoningEffort = this._getValidatedReasoningEffort(
 				params.modelId,
-				settings.reasoningEffort
+				safeSettings.reasoningEffort
 			);
 
 			// Inject API key only if explicitly provided; OAuth is the primary path
 			const defaultSettings = {
-				...settings,
+				...safeSettings,
 				reasoningEffort: validatedReasoningEffort,
 				...(params.apiKey
-					? { env: { ...(settings.env || {}), OPENAI_API_KEY: params.apiKey } }
+					? { env: { ...(safeSettings.env || {}), OPENAI_API_KEY: params.apiKey } }
 					: {})
 			};
 

--- a/tests/unit/ai-providers/codex-cli.test.js
+++ b/tests/unit/ai-providers/codex-cli.test.js
@@ -102,4 +102,15 @@ describe('CodexCliProvider', () => {
 		const second = createCodexCli.mock.calls[1][0];
 		expect(second.defaultSettings.env).toBeUndefined();
 	});
+
+	it('does not forward commandSpecific to createCodexCli', async () => {
+		getCodexCliSettingsForCommand.mockReturnValueOnce({
+			allowNpx: true,
+			commandSpecific: { 'parse-prd': { approvalMode: 'never' } }
+		});
+		await provider.getClient({ commandName: 'parse-prd' });
+		const call = createCodexCli.mock.calls[0][0];
+		expect(call.defaultSettings).not.toHaveProperty('commandSpecific');
+		expect(call.defaultSettings.allowNpx).toBe(true);
+	});
 });

--- a/tests/unit/ai-providers/codex-cli.test.js
+++ b/tests/unit/ai-providers/codex-cli.test.js
@@ -109,8 +109,12 @@ describe('CodexCliProvider', () => {
 			commandSpecific: { 'parse-prd': { approvalMode: 'never' } }
 		});
 		await provider.getClient({ commandName: 'parse-prd' });
+		expect(createCodexCli).toHaveBeenCalledTimes(1);
 		const call = createCodexCli.mock.calls[0][0];
 		expect(call.defaultSettings).not.toHaveProperty('commandSpecific');
 		expect(call.defaultSettings.allowNpx).toBe(true);
+		// Guard against future partial-merge regressions: ensure no override
+		// keys from commandSpecific leaked into the top-level defaultSettings.
+		expect(call.defaultSettings).not.toHaveProperty('approvalMode');
 	});
 });


### PR DESCRIPTION
Fixes #1679

## Problem

When `codexCli.commandSpecific` is present in the Task Master config, the resolved settings object (returned by `getCodexCliSettingsForCommand`) includes the `commandSpecific` key. This object is spread directly into `defaultSettings` and forwarded to `createCodexCli()`.

Codex CLI does not know about `commandSpecific` — it's a Task Master-level concept — so it rejects the settings with:

```
Warning: Invalid Codex CLI settings in config: [
  {
    "code": "custom",
    "path": ["commandSpecific"],
    "message": "Invalid command name in commandSpecific"
  }
]. Falling back to default.
```

## Solution

Destructure `commandSpecific` out of the resolved `settings` object before constructing `defaultSettings`. Only Task Master–agnostic keys are forwarded to `createCodexCli()`.

```js
const { commandSpecific: _commandSpecific, ...safeSettings } = settings;
```

## Testing

- Added a unit test verifying that when `getCodexCliSettingsForCommand` returns an object that includes `commandSpecific`, the resulting `createCodexCli` call does **not** contain `commandSpecific` in `defaultSettings`.
- Existing tests continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to Codex CLI provider settings sanitization with a targeted unit test; main risk is unintended omission of other provider settings during the destructuring/forwarding step.
> 
> **Overview**
> Fixes Codex CLI initialization failures by **stripping Task Master-only `codexCli.commandSpecific`** from the settings object before building `defaultSettings` passed to `createCodexCli()`.
> 
> Adds a unit test to ensure `commandSpecific` (and any nested override keys) are not forwarded, and includes a patch changeset documenting the bug fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752d96f55b2c5422a8dfb43e541720004776dba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration-forwarding bug in the Codex CLI provider that could cause initialization to fail with validation errors; settings are now filtered before provider initialization.

* **Tests**
  * Added a unit test to verify the provider no longer forwards unintended configuration keys and still passes allowed settings through.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->