### PR TITLE
chore: update README docs links to tryhamster.com/docs/taskmaster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Apply standard software engineering principles:
 ## Documentation Guidelines
 
 - **Documentation location**: Write docs in `apps/docs/` (Mintlify site source), not `docs/`
-- **Documentation URL**: Reference docs at <https://docs.task-master.dev>, not local file paths
+- **Documentation URL**: Reference docs at <https://tryhamster.com/docs/taskmaster>, not local file paths
 
 ## Changeset Guidelines
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://discord.gg/taskmasterai" target="_blank"><img src="https://dcbadge.limes.pink/api/server/https://discord.gg/taskmasterai?style=flat" alt="Discord"></a> |
-  <a href="https://docs.task-master.dev" target="_blank">Docs</a>
+  <a href="https://tryhamster.com/docs/taskmaster" target="_blank">Docs</a>
 </p>
 
 <p align="center">
@@ -39,20 +39,26 @@ A task management system for AI-driven development with Claude, designed to work
 
 ## Documentation
 
-📚 **[View Full Documentation](https://docs.task-master.dev)**
+📚 **[View Full Documentation](https://tryhamster.com/docs/taskmaster)**
 
-For detailed guides, API references, and comprehensive examples, visit our documentation site.
+### Quick Links
 
-### Quick Reference
-
-The following documentation is also available in the `docs` directory:
-
-- [Configuration Guide](docs/configuration.md) - Set up environment variables and customize Task Master
-- [Tutorial](docs/tutorial.md) - Step-by-step guide to getting started with Task Master
-- [Command Reference](docs/command-reference.md) - Complete list of all available commands
-- [Task Structure](docs/task-structure.md) - Understanding the task format and features
-- [Example Interactions](docs/examples.md) - Common Cursor AI interaction examples
-- [Migration Guide](docs/migration-guide.md) - Guide to migrating to the new project structure
+- [Quick Start Guide](https://tryhamster.com/docs/taskmaster/getting-started/quick-start/quick-start)
+- [Installation](https://tryhamster.com/docs/taskmaster/getting-started/quick-start/installation)
+- [API Keys & Providers](https://tryhamster.com/docs/taskmaster/getting-started/api-keys)
+- [Supported Editors](https://tryhamster.com/docs/taskmaster/ide-setup/supported-editors)
+- [MCP Tools Reference](https://tryhamster.com/docs/taskmaster/capabilities/mcp)
+- [CLI Commands Reference](https://tryhamster.com/docs/taskmaster/capabilities/cli-root-commands)
+- [Task Structure](https://tryhamster.com/docs/taskmaster/capabilities/task-structure)
+- [Task Dependencies](https://tryhamster.com/docs/taskmaster/task-workflow/dependencies)
+- [Tags & Workstreams](https://tryhamster.com/docs/taskmaster/task-workflow/tags)
+- [Research Command](https://tryhamster.com/docs/taskmaster/task-workflow/research)
+- [Loop Command](https://tryhamster.com/docs/taskmaster/automation/loop)
+- [AI Providers Overview](https://tryhamster.com/docs/taskmaster/ai-providers/overview)
+- [Team Collaboration](https://tryhamster.com/docs/taskmaster/team/overview)
+- [Best Practices](https://tryhamster.com/docs/taskmaster/best-practices)
+- [FAQ](https://tryhamster.com/docs/taskmaster/getting-started/faq)
+- [Changelog](CHANGELOG.md)
 
 #### Quick Install for Cursor 1.0+ (One-Click)
 

--- a/apps/extension/src/webview/components/EmptyState.tsx
+++ b/apps/extension/src/webview/components/EmptyState.tsx
@@ -111,7 +111,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({ currentTag }) => {
 					{/* Documentation link */}
 					<div className="flex justify-center pt-4">
 						<a
-							href="https://docs.task-master.dev"
+							href="https://tryhamster.com/docs/taskmaster"
 							className="inline-flex items-center gap-2 text-vscode-textLink-foreground hover:text-vscode-textLink-activeForeground transition-colors"
 							onClick={(e) => {
 								e.preventDefault();
@@ -120,7 +120,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({ currentTag }) => {
 									const vscode = window.acquireVsCodeApi();
 									vscode.postMessage({
 										type: 'openExternal',
-										url: 'https://docs.task-master.dev'
+										url: 'https://tryhamster.com/docs/taskmaster'
 									});
 								}
 							}}

--- a/docs/examples/codex-cli-usage.md
+++ b/docs/examples/codex-cli-usage.md
@@ -460,4 +460,4 @@ task-master complexity-report
 
 ---
 
-For more examples and advanced usage, see the [full documentation](https://docs.task-master.dev).
+For more examples and advanced usage, see the [full documentation](https://tryhamster.com/docs/taskmaster).


### PR DESCRIPTION
## Summary

- Replace the README `Quick Reference` block (which pointed to local `docs/*.md` files) with a curated list of 16 quick links to the new docs site, all verified live on `tryhamster.com/docs/taskmaster`
- Swap every `docs.task-master.dev` href in the repo over to `tryhamster.com/docs/taskmaster` — README header, VS Code extension empty state, codex-cli usage docs, and the canonical docs URL in `CLAUDE.md`. CHANGELOG entries left alone as historical record
- `Changelog` quick link falls back to the repo `CHANGELOG.md` since the docs site doesn't host one today

Closes HAM-3459.

## Test plan

- [ ] Preview the README on GitHub and spot-check that all quick links render and resolve
- [ ] Load the VS Code extension empty state and confirm the "View TaskMaster Documentation" link opens `tryhamster.com/docs/taskmaster`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates are limited to documentation/link destinations and a README reorganization, with no runtime logic changes beyond opening a different external URL in the extension webview.
> 
> **Overview**
> Updates the repo’s canonical documentation URL from `https://docs.task-master.dev` to `https://tryhamster.com/docs/taskmaster` across `README.md`, `CLAUDE.md`, the VS Code extension empty state, and a Codex CLI usage doc.
> 
> Replaces the README’s local `docs/*` “Quick Reference” section with a curated set of direct links into the new docs site (keeping `CHANGELOG.md` as an in-repo link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d439eb21f51e0a8d4eae396850f70b7488ac1e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to a new domain.
  * Expanded quick reference links to include comprehensive external documentation resources and guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->