### PR TITLE
fix: replace retired task-master.dev URLs (HAM-3466)

### DIFF
--- a/.changeset/fix-sync-readme-dead-url.md
+++ b/.changeset/fix-sync-readme-dead-url.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix `task-master sync-readme` generating links to the retired `task-master.dev` domain. Exported READMEs now link to `https://tryhamster.com/product/taskmaster`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </div>
 
 <p align="center">
-  <a href="https://task-master.dev"><img src="./images/logo.png?raw=true" alt="Taskmaster logo"></a>
+  <a href="https://tryhamster.com/product/taskmaster"><img src="./images/logo.png?raw=true" alt="Taskmaster logo"></a>
 </p>
 
 <p align="center">
@@ -56,9 +56,16 @@ A task management system for AI-driven development with Claude, designed to work
 - [Loop Command](https://tryhamster.com/docs/taskmaster/automation/loop)
 - [AI Providers Overview](https://tryhamster.com/docs/taskmaster/ai-providers/overview)
 - [Team Collaboration](https://tryhamster.com/docs/taskmaster/team/overview)
-- [Best Practices](https://tryhamster.com/docs/taskmaster/best-practices)
+- [Best Practices](https://tryhamster.com/docs/taskmaster/best-practices/index)
 - [FAQ](https://tryhamster.com/docs/taskmaster/getting-started/faq)
 - [Changelog](CHANGELOG.md)
+
+### More from Hamster
+
+- [Hamster Studio](https://tryhamster.com/product/studio)
+- [Product & Engineering Methods](https://tryhamster.com/methods)
+- [Product & Engineering Skills](https://tryhamster.com/skills)
+- [Hamster Pricing](https://tryhamster.com/pricing)
 
 #### Quick Install for Cursor 1.0+ (One-Click)
 

--- a/scripts/modules/sync-readme.js
+++ b/scripts/modules/sync-readme.js
@@ -19,7 +19,7 @@ This project is managed using Task Master.
 }
 
 /**
- * Create UTM tracking URL for task-master.dev
+ * Create UTM tracking URL for the Taskmaster product page
  * @param {string} projectRoot - The project root path
  * @returns {string} - UTM tracked URL
  */
@@ -41,7 +41,7 @@ function createTaskMasterUrl(projectRoot) {
 		utm_content: 'task-export-link'
 	});
 
-	return `https://task-master.dev?${utmParams.toString()}`;
+	return `https://tryhamster.com/product/taskmaster?${utmParams.toString()}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

The `task-master.dev` domain is retired. This PR removes the last live references and applies the README updates from HAM-3466.

- README logo now points to `https://tryhamster.com/product/taskmaster`
- Best Practices doc link gains the `/index` suffix
- New "More from Hamster" section under Quick Links (Studio, Methods, Skills, Pricing)
- `task-master sync-readme` no longer writes dead `task-master.dev` links into user READMEs — now uses the Hamster product page (UTM params preserved)

CHANGELOG entries that reference `task-master.dev` are intentionally left alone — historical release notes shouldn't be rewritten.

## Test plan

- [ ] Verify rendered README on GitHub: logo link, Best Practices link, "More from Hamster" section appear correctly
- [ ] Run `task-master sync-readme` in a sample project and confirm the generated `Powered by [Task Master](...)` link points to `tryhamster.com/product/taskmaster` with intact UTM params

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation links and the `sync-readme` URL generator, with no impact on task data or command flow beyond the hyperlink target.
> 
> **Overview**
> Updates public-facing links to avoid the retired `task-master.dev` domain.
> 
> `sync-readme` now generates the “Powered by Task Master” UTM link pointing at `https://tryhamster.com/product/taskmaster`, and the repo `README.md` updates the logo target, fixes the Best Practices quick link URL, and adds a small “More from Hamster” links section. Includes a patch changeset documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b35a4638ef39f8b80596d2a31d158a14db3e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved dead links in documentation that pointed to retired domains.

* **Documentation**
  * Updated README header and quick links to point to current resources.
  * Added new "More from Hamster" section with additional resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->