### PR TITLE
fix: use default variant for update-task/update-subtask with --research flag

### DIFF
--- a/.changeset/fix-update-task-research-variant.md
+++ b/.changeset/fix-update-task-research-variant.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix `update-task` and `update-subtask` crashing with `Cannot read properties of undefined (reading 'replace')` when the `--research` flag is used. Both commands were requesting a non-existent `research` prompt variant; they now correctly use the `default` variant, which already handles research mode via template conditionals.

--- a/scripts/modules/task-manager/update-subtask-by-id.js
+++ b/scripts/modules/task-manager/update-subtask-by-id.js
@@ -302,7 +302,7 @@ async function updateSubtaskById(
 				projectRoot: projectRoot
 			};
 
-			const variantKey = useResearch ? 'research' : 'default';
+			const variantKey = 'default';
 			const { systemPrompt, userPrompt } = await promptManager.loadPrompt(
 				'update-subtask',
 				promptParams,

--- a/scripts/modules/task-manager/update-task-by-id.js
+++ b/scripts/modules/task-manager/update-task-by-id.js
@@ -305,11 +305,7 @@ async function updateTaskById(
 			projectRoot: projectRoot
 		};
 
-		const variantKey = appendMode
-			? 'append'
-			: useResearch
-				? 'research'
-				: 'default';
+		const variantKey = appendMode ? 'append' : 'default';
 
 		report(
 			'info',

--- a/tests/unit/scripts/modules/task-manager/update-task-by-id.test.js
+++ b/tests/unit/scripts/modules/task-manager/update-task-by-id.test.js
@@ -684,6 +684,61 @@ describe('Prompt Manager Integration', () => {
 		const promptManagerInstance = getPromptManager.mock.results[0].value;
 		expect(promptManagerInstance.loadPrompt).toHaveBeenCalled();
 	});
+
+	test('should use "default" variant when useResearch is true (regression: #1689)', async () => {
+		// Arrange
+		fs.existsSync.mockReturnValue(true);
+		readJSON.mockReturnValue({
+			tag: 'master',
+			tasks: [
+				{
+					id: 1,
+					title: 'Task',
+					description: 'Description',
+					status: 'pending',
+					dependencies: [],
+					priority: 'medium',
+					details: 'Details',
+					testStrategy: 'Test strategy',
+					subtasks: []
+				}
+			]
+		});
+
+		generateObjectService.mockResolvedValue({
+			mainResult: {
+				task: {
+					id: 1,
+					title: 'Updated Task',
+					description: 'Updated description',
+					status: 'pending',
+					dependencies: [],
+					priority: 'medium',
+					details: 'Updated details',
+					testStrategy: 'Updated test strategy',
+					subtasks: []
+				}
+			},
+			telemetryData: {}
+		});
+
+		// Act - pass useResearch: true as 4th argument
+		await updateTaskById(
+			'tasks/tasks.json',
+			1,
+			'Update this task',
+			true, // useResearch
+			{ tag: 'master', projectRoot: '/mock/project' },
+			'json'
+		);
+
+		// Assert - loadPrompt must be called with 'default', not 'research'
+		// (the update-task template has no 'research' variant; useResearch is handled
+		// via {{#if useResearch}} conditionals inside the 'default' variant)
+		const promptManagerInstance = getPromptManager.mock.results[0].value;
+		const loadPromptCall = promptManagerInstance.loadPrompt.mock.calls[0];
+		expect(loadPromptCall[2]).toBe('default');
+	});
 });
 
 describe('Context Gathering Integration', () => {


### PR DESCRIPTION
Fixes #1689

## Problem

When running `task-master update-task --id=<n> --research --prompt="..."`, the command crashes immediately with:

```
[ERROR] Failed to load prompt update-task: Cannot read properties of undefined (reading 'replace')
```

The same error also affects `update-subtask --research`.

**Root cause:** Both `update-task-by-id.js` and `update-subtask-by-id.js` computed `variantKey = 'research'` when `useResearch` is `true`. However, neither `update-task.json` nor `update-subtask.json` define a `'research'` variant (only `expand-task.json` does). Accessing `template.prompts['research']` returns `undefined`, so spreading it produces `{}` with no `system` or `user` keys — causing `renderTemplate(undefined, …)` to crash.

## Solution

Use the `'default'` variant in both files when `useResearch` is `true`. The `default` variant in both templates already contains `{{#if useResearch}}` / `{{#if (not useResearch)}}` Handlebars conditionals that produce the appropriate research-aware prompt. No changes to the prompt templates are needed.

- `update-task-by-id.js`: simplified `variantKey` selection to `appendMode ? 'append' : 'default'`
- `update-subtask-by-id.js`: simplified to always `'default'`

## Testing

- Added a regression test in `update-task-by-id.test.js` that verifies `loadPrompt` is called with `'default'` (not `'research'`) when `useResearch` is `true`.
- All existing tests continue to pass (`npm test -- --testPathPattern=update-task-by-id`: 13/13 passing).
- `npm run format-check` passes (biome reports no issues).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small change to prompt variant selection to avoid loading a non-existent template variant, plus a regression test to lock the behavior in.
> 
> **Overview**
> Fixes `update-task` and `update-subtask` crashing when run with `--research` by **stopping use of a non-existent `research` prompt variant** and always loading the `default` variant (while still using the research AI role when requested). Adds a regression unit test to assert `update-task` calls `loadPrompt` with `default` when `useResearch` is `true`, and includes a patch changeset documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b24e713ad3b2a4c7415d0ce9c921aeea00a29be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crash occurring when task and subtask update commands are invoked with research mode enabled. Commands now use the correct prompt template variant to avoid undefined reference errors.

* **Tests**
  * Added regression test to verify proper prompt variant selection when research mode is enabled during task updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->