### PR TITLE
fix: pass context correctly to fixDependenciesCommand to prevent tag data loss

### DIFF
--- a/.changeset/fix-fix-dependencies-tag-wipe.md
+++ b/.changeset/fix-fix-dependencies-tag-wipe.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix fix_dependencies MCP tool wiping all tags except 'master' from tasks.json. The tool now correctly scopes dependency fixes to the specified tag, preserving all other tags in multi-tag workspaces.

--- a/mcp-server/src/core/direct-functions/fix-dependencies.js
+++ b/mcp-server/src/core/direct-functions/fix-dependencies.js
@@ -53,7 +53,7 @@ export async function fixDependenciesDirect(args, log) {
 		// Enable silent mode to prevent console logs from interfering with JSON response
 		enableSilentMode();
 
-		const options = { projectRoot, tag };
+		const options = { context: { projectRoot, tag } };
 		// Call the original command function using the provided path and proper context
 		await fixDependenciesCommand(tasksPath, options);
 


### PR DESCRIPTION
Fixes #1636

## Problem

The `fix_dependencies` MCP tool (and `task-master fix-dependencies` CLI) was silently wiping all tags except the resolved one from `tasks.json` in multi-tag workspaces.

**Root cause:** `fixDependenciesDirect` was passing `{ projectRoot, tag }` directly as options, but `fixDependenciesCommand` destructures these from a nested `context` key:

```js
// Before (broken):
const options = { projectRoot, tag };
await fixDependenciesCommand(tasksPath, options);

// Inside fixDependenciesCommand:
const { context = {} } = options;
// context = {} — projectRoot and tag are undefined!
```

With `context.projectRoot` undefined, `writeJSON` skipped the tag-merging branch (which requires `projectRoot`) and wrote only the resolved tag's tasks directly, discarding all other tags.

## Solution

Wrap `projectRoot` and `tag` under the `context` key that `fixDependenciesCommand` expects:

```js
const options = { context: { projectRoot, tag } };
await fixDependenciesCommand(tasksPath, options);
```

## Testing

- Reproduced the bug with a multi-tag `tasks.json` — confirmed tags were wiped
- After fix, all tags are preserved when running `fix_dependencies` against a specific tag
- The fix is minimal: one line changed in the MCP direct function wrapper

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the path that reads/writes `tasks.json`; while the change is a small options-shape fix, mistakes here could still affect task data persistence across tags.
> 
> **Overview**
> Ensures the `fix_dependencies` MCP tool correctly scopes dependency repairs to the requested tag by passing `{ context: { projectRoot, tag } }` into `fixDependenciesCommand`, preventing other tags in multi-tag `tasks.json` from being wiped.
> 
> Adds a patch changeset documenting the data-loss fix and expected behavior in multi-tag workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83cd9df9748bef1b2d8715b814e0d03d3d64b06d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the fix dependencies tool that incorrectly removed tags from task files, leaving only the master tag. The tool now properly scopes dependency fixes to the intended tag while preserving other tags in multi-tag workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->