### PR TITLE
fix: disable AI content recording and PII collection in Sentry by default

### DIFF
--- a/.changeset/fix-sentry-pii-defaults.md
+++ b/.changeset/fix-sentry-pii-defaults.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix telemetry privacy defaults: AI prompt/response recording and PII collection are now disabled by default. Sentry telemetry still tracks errors and performance spans, but no longer sends AI prompt content, task descriptions, or PRD text to Sentry.

--- a/.changeset/fix-sentry-pii-defaults.md
+++ b/.changeset/fix-sentry-pii-defaults.md
@@ -2,4 +2,4 @@
 "task-master-ai": patch
 ---
 
-Fix telemetry privacy defaults: AI prompt/response recording and PII collection are now disabled by default. Sentry telemetry still tracks errors and performance spans, but no longer sends AI prompt content, task descriptions, or PRD text to Sentry.
+Fix telemetry privacy defaults: AI prompt/response recording and PII collection are now disabled by default. Sentry telemetry still tracks errors and performance spans, but no longer sends AI prompt content, task descriptions, or PRD text to Sentry. The default trace sample rate is also lowered from 1.0 to 0.1 to reduce production overhead.

--- a/src/telemetry/sentry.js
+++ b/src/telemetry/sentry.js
@@ -88,8 +88,10 @@ export function initializeSentry(options = {}) {
 				// Add Zod error tracking for better validation error reporting
 				Sentry.zodErrorsIntegration()
 			],
-			// Tracing must be enabled for AI monitoring to work
-			tracesSampleRate: options.tracesSampleRate ?? 1.0,
+			// Tracing must be enabled for AI monitoring to work.
+			// Default to 0.1 (10%) — Sentry's recommended production rate.
+			// Override via options.tracesSampleRate or SENTRY_TRACES_SAMPLE_RATE.
+			tracesSampleRate: options.tracesSampleRate ?? 0.1,
 			// Disabled to avoid capturing personally identifiable information.
 			sendDefaultPii: options.sendDefaultPii ?? false,
 			// Enable debug mode with SENTRY_DEBUG=true env var
@@ -102,7 +104,7 @@ export function initializeSentry(options = {}) {
 			console.log(
 				`  Environment: ${options.environment || process.env.NODE_ENV || 'production'}`
 			);
-			console.log(`  Traces Sample Rate: ${options.tracesSampleRate ?? 1.0}`);
+			console.log(`  Traces Sample Rate: ${options.tracesSampleRate ?? 0.1}`);
 		}
 	} catch (error) {
 		console.error(`Failed to initialize telemetry: ${error.message}`);

--- a/src/telemetry/sentry.js
+++ b/src/telemetry/sentry.js
@@ -79,16 +79,19 @@ export function initializeSentry(options = {}) {
 			environment: options.environment || process.env.NODE_ENV || 'production',
 			integrations: [
 				// Add the Vercel AI SDK integration for automatic AI operation tracking
+				// recordInputs/recordOutputs are disabled by default to avoid capturing
+				// sensitive content such as PRDs, task descriptions, and AI-generated code.
 				Sentry.vercelAIIntegration({
-					recordInputs: true,
-					recordOutputs: true
+					recordInputs: false,
+					recordOutputs: false
 				}),
 				// Add Zod error tracking for better validation error reporting
 				Sentry.zodErrorsIntegration()
 			],
 			// Tracing must be enabled for AI monitoring to work
 			tracesSampleRate: options.tracesSampleRate ?? 1.0,
-			sendDefaultPii: options.sendDefaultPii ?? true,
+			// Disabled to avoid capturing personally identifiable information.
+			sendDefaultPii: options.sendDefaultPii ?? false,
 			// Enable debug mode with SENTRY_DEBUG=true env var
 			debug: process.env.SENTRY_DEBUG === 'true'
 		});
@@ -130,8 +133,8 @@ export function getAITelemetryConfig(functionId, metadata = {}) {
 
 	const config = {
 		isEnabled: true,
-		recordInputs: true,
-		recordOutputs: true
+		recordInputs: false,
+		recordOutputs: false
 	};
 
 	// Add functionId if provided - helps correlate captured spans with function calls


### PR DESCRIPTION
Fixes #1681

## Problem

The default Sentry telemetry configuration was recording **100% of AI prompts and responses** — including full PRD text, task descriptions, and AI-generated code — and sending them to Sentry with PII collection enabled:

```js
// Before:
Sentry.vercelAIIntegration({ recordInputs: true, recordOutputs: true })
sendDefaultPii: true
```

This meant every `generateText`, `streamText`, `generateObject`, and `streamObject` call was captured as a span attribute and sent to Sentry by default, even though the telemetry was described as "anonymous."

## Solution

Change the defaults to disable AI content recording and PII collection:

```js
// After:
Sentry.vercelAIIntegration({ recordInputs: false, recordOutputs: false })
sendDefaultPii: false
```

The same change is applied to `getAITelemetryConfig` for consistency.

Sentry still captures **errors and performance spans** (traces), which is the intended purpose of error tracking telemetry. Only the capture of full prompt/response content is disabled by default.

## Testing

- Reviewed Sentry init flow — error and trace capture still works with these settings
- `recordInputs`/`recordOutputs` only control whether AI span content is attached to traces; setting them to `false` does not break error tracking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Sentry telemetry to stop sending AI prompt/response content and PII, and reduces default trace sampling, which could slightly reduce observability if deployments relied on prior defaults.
> 
> **Overview**
> Tightens Sentry telemetry privacy defaults by **disabling AI prompt/response recording** (`recordInputs`/`recordOutputs` now default to `false`) both in `Sentry.vercelAIIntegration()` and the `getAITelemetryConfig()` used by AI SDK calls.
> 
> Also **opts out of PII collection by default** (`sendDefaultPii: false`) and lowers the default `tracesSampleRate` from `1.0` to `0.1`, while keeping error/performance telemetry enabled when configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d747589dd7a3937855ca7e37dece9392ff31febe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI prompt/response telemetry recording disabled by default to improve privacy.
  * PII collection disabled by default; explicit opt-in required.
  * Error tracking and performance monitoring remain active to maintain reliability.

* **Chores**
  * Reduced default performance tracing sample rate to lower production overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->