### PR TITLE
fix Claude Code install guidance

### DIFF
--- a/.changeset/rare-badgers-ring.md
+++ b/.changeset/rare-badgers-ring.md
@@ -1,0 +1,5 @@
+---
+'task-master-ai': patch
+---
+
+Update Claude Code CLI install guidance to point users to Anthropic's official setup docs.

--- a/docs/examples/claude-code-usage.md
+++ b/docs/examples/claude-code-usage.md
@@ -59,7 +59,7 @@ task-master set-status --id=task-001 --status=in-progress
 
 ## Requirements
 
-1. Claude Code CLI must be installed and authenticated on your system
+1. Claude Code CLI must be installed and authenticated on your system. Follow [Anthropic's official setup guide](https://docs.anthropic.com/en/docs/claude-code/getting-started).
 2. Install the optional `@anthropic-ai/claude-code` package if you enable this provider:
    ```bash
    npm install @anthropic-ai/claude-code

--- a/packages/tm-core/src/modules/loop/services/loop.service.ts
+++ b/packages/tm-core/src/modules/loop/services/loop.service.ts
@@ -19,6 +19,9 @@ export interface LoopServiceOptions {
 	projectRoot: string;
 }
 
+const CLAUDE_CODE_SETUP_URL =
+	'https://docs.anthropic.com/en/docs/claude-code/getting-started';
+
 export class LoopService {
 	private readonly projectRoot: string;
 	private readonly logger = getLogger('LoopService');
@@ -586,7 +589,7 @@ Loop iteration ${iteration} of ${config.iterations}${tagInfo}`;
 		if (error.code === 'ENOENT') {
 			return sandbox
 				? 'Docker is not installed. Install Docker Desktop to use --sandbox mode.'
-				: 'Claude CLI is not installed. Install with: npm install -g @anthropic-ai/claude-code';
+				: `Claude Code CLI is not installed. Follow the official setup guide: ${CLAUDE_CODE_SETUP_URL}`;
 		}
 
 		if (error.code === 'EACCES') {

--- a/packages/tm-core/tests/integration/loop/loop-service-error-messages.test.ts
+++ b/packages/tm-core/tests/integration/loop/loop-service-error-messages.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { LoopService } from '../../../src/modules/loop/services/loop.service.js';
+
+describe('LoopService error messaging', () => {
+	it('should direct Claude CLI install errors to the official setup guide', () => {
+		const service = new LoopService({ projectRoot: '/tmp/task-master' });
+
+		const message = (
+			service as unknown as {
+				formatCommandError: (
+					error: NodeJS.ErrnoException,
+					command: string,
+					sandbox: boolean
+				) => string;
+			}
+		).formatCommandError(
+			{ code: 'ENOENT', message: 'spawn claude ENOENT' },
+			'claude',
+			false
+		);
+
+		expect(message).toBe(
+			'Claude Code CLI is not installed. Follow the official setup guide: https://docs.anthropic.com/en/docs/claude-code/getting-started'
+		);
+	});
+
+	it('should preserve the Docker sandbox guidance for sandbox mode', () => {
+		const service = new LoopService({ projectRoot: '/tmp/task-master' });
+
+		const message = (
+			service as unknown as {
+				formatCommandError: (
+					error: NodeJS.ErrnoException,
+					command: string,
+					sandbox: boolean
+				) => string;
+			}
+		).formatCommandError(
+			{ code: 'ENOENT', message: 'spawn docker ENOENT' },
+			'docker',
+			true
+		);
+
+		expect(message).toBe(
+			'Docker is not installed. Install Docker Desktop to use --sandbox mode.'
+		);
+	});
+});

--- a/packages/tm-core/tests/integration/loop/loop-service-error-messages.test.ts
+++ b/packages/tm-core/tests/integration/loop/loop-service-error-messages.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { LoopService } from '../../../src/modules/loop/services/loop.service.js';
 
+function createErrnoException(message: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(message), {
+		code: 'ENOENT' as const
+	});
+}
+
 describe('LoopService error messaging', () => {
 	it('should direct Claude CLI install errors to the official setup guide', () => {
 		const service = new LoopService({ projectRoot: '/tmp/task-master' });
@@ -13,11 +19,7 @@ describe('LoopService error messaging', () => {
 					sandbox: boolean
 				) => string;
 			}
-		).formatCommandError(
-			{ code: 'ENOENT', message: 'spawn claude ENOENT' },
-			'claude',
-			false
-		);
+		).formatCommandError(createErrnoException('spawn claude ENOENT'), 'claude', false);
 
 		expect(message).toBe(
 			'Claude Code CLI is not installed. Follow the official setup guide: https://docs.anthropic.com/en/docs/claude-code/getting-started'
@@ -35,11 +37,7 @@ describe('LoopService error messaging', () => {
 					sandbox: boolean
 				) => string;
 			}
-		).formatCommandError(
-			{ code: 'ENOENT', message: 'spawn docker ENOENT' },
-			'docker',
-			true
-		);
+		).formatCommandError(createErrnoException('spawn docker ENOENT'), 'docker', true);
 
 		expect(message).toBe(
 			'Docker is not installed. Install Docker Desktop to use --sandbox mode.'

--- a/src/ai-providers/claude-code.js
+++ b/src/ai-providers/claude-code.js
@@ -22,6 +22,8 @@ import { BaseAIProvider } from './base-provider.js';
 
 let _claudeCliChecked = false;
 let _claudeCliAvailable = null;
+const CLAUDE_CODE_SETUP_URL =
+	'https://docs.anthropic.com/en/docs/claude-code/getting-started';
 
 /**
  * Provider for Claude Code CLI integration via AI SDK
@@ -85,7 +87,7 @@ export class ClaudeCodeProvider extends BaseAIProvider {
 				_claudeCliAvailable = false;
 				log(
 					'warn',
-					'Claude Code CLI not detected. Install it with: npm install -g @anthropic-ai/claude-code'
+					`Claude Code CLI not detected. Follow the official setup guide: ${CLAUDE_CODE_SETUP_URL}`
 				);
 			} finally {
 				_claudeCliChecked = true;
@@ -147,7 +149,7 @@ export class ClaudeCodeProvider extends BaseAIProvider {
 			const code = error?.code;
 			if (code === 'ENOENT' || /claude/i.test(msg)) {
 				const enhancedError = new Error(
-					`Claude Code CLI not available. Please install Claude Code CLI first. Original error: ${error.message}`
+					`Claude Code CLI not available. Follow the official setup guide: ${CLAUDE_CODE_SETUP_URL}. Original error: ${error.message}`
 				);
 				enhancedError.cause = error;
 				this.handleError('Claude Code CLI initialization', enhancedError);

--- a/tests/integration/claude-code-error-handling.test.js
+++ b/tests/integration/claude-code-error-handling.test.js
@@ -31,10 +31,10 @@ describe('Claude Code Error Handling', () => {
 	it('should throw a CLI-not-available error (with or without commandName)', () => {
 		const provider = new ClaudeCodeProvider();
 		expect(() => provider.getClient()).toThrow(
-			/Claude Code CLI not available/i
+			/Claude Code CLI not available\. Follow the official setup guide: https:\/\/docs\.anthropic\.com\/en\/docs\/claude-code\/getting-started/i
 		);
 		expect(() => provider.getClient({ commandName: 'test' })).toThrow(
-			/Claude Code CLI not available/i
+			/Claude Code CLI not available\. Follow the official setup guide: https:\/\/docs\.anthropic\.com\/en\/docs\/claude-code\/getting-started/i
 		);
 	});
 

--- a/tests/integration/claude-code-error-handling.test.js
+++ b/tests/integration/claude-code-error-handling.test.js
@@ -30,12 +30,20 @@ describe('Claude Code Error Handling', () => {
 
 	it('should throw a CLI-not-available error (with or without commandName)', () => {
 		const provider = new ClaudeCodeProvider();
-		expect(() => provider.getClient()).toThrow(
-			/Claude Code CLI not available\. Follow the official setup guide: https:\/\/docs\.anthropic\.com\/en\/docs\/claude-code\/getting-started/i
-		);
-		expect(() => provider.getClient({ commandName: 'test' })).toThrow(
-			/Claude Code CLI not available\. Follow the official setup guide: https:\/\/docs\.anthropic\.com\/en\/docs\/claude-code\/getting-started/i
-		);
+		for (const getClient of [
+			() => provider.getClient(),
+			() => provider.getClient({ commandName: 'test' })
+		]) {
+			try {
+				getClient();
+				throw new Error('Expected provider.getClient() to throw');
+			} catch (error) {
+				expect(error.message).toMatch(/Claude Code CLI not available/i);
+				expect(error.message).toMatch(/official setup guide/i);
+				expect(error.message).toContain('docs.anthropic.com');
+				expect(error.message).toMatch(/claude-code\/getting-started/i);
+			}
+		}
 	});
 
 	it('should still support basic provider functionality', () => {


### PR DESCRIPTION
## Summary

This PR updates Claude Code install guidance to point users to Anthropic's official setup docs instead of hard-coding a single install path.

## What Changed

- updated Claude Code CLI warning/error messages to use a shared official setup URL
- aligned loop service ENOENT guidance with the same docs-first wording
- removed the install-script example from the Claude Code usage example and linked directly to Anthropic's setup guide
- tightened the Claude Code error-handling test to assert the new guidance
- added a tm-core integration test covering the loop service install message
- added a patch changeset for the user-facing fix

## Why

The current guidance was inconsistent across the codebase and could go stale as Claude Code installation flows evolve. Pointing users to the official setup guide is more durable and avoids steering them to a single installation path.

## Validation

- `npm run format-check`
- `npm test -- tests/integration/claude-code-error-handling.test.js tests/unit/ai-providers/claude-code.test.js`
- `../../node_modules/.bin/vitest run --config vitest.config.ts --coverage.enabled=false tests/integration/loop/loop-service-error-messages.test.ts` from `packages/tm-core`
- `npm run build`
- `./node_modules/.bin/cross-env NODE_ENV=test node --experimental-vm-modules node_modules/.bin/jest tests/integration/cli/complex-cross-tag-scenarios.test.js --runInBand`

## Notes

I also ran the repository-wide `npm test`, but there are unrelated pre-existing Jest ESM teardown failures in profile-related suites.

Closes #1634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Referenced Anthropic’s official Claude Code setup guide in installation/authentication instructions and fixed trailing newline in an example.

* **Bug Fixes**
  * Updated user-facing messages to direct users to the official Claude Code CLI setup documentation when the CLI is not detected.

* **Tests**
  * Added integration tests to validate CLI-detection and sandbox-related error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->