### PR TITLE
fix: normalize warning emoji presentation in CLI output

### DIFF
--- a/.changeset/warning-emoji-presentation.md
+++ b/.changeset/warning-emoji-presentation.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix warning sign rendering in CLI output by using emoji presentation consistently, preventing misaligned box titles and warning banners in terminals.

--- a/apps/cli/src/commands/list.command.ts
+++ b/apps/cli/src/commands/list.command.ts
@@ -235,7 +235,7 @@ export class ListTasksCommand extends Command {
 							);
 						}
 					} else if (event.type === 'error' && event.error) {
-						console.error(chalk.red(`\n⚠ Watch error: ${event.error.message}`));
+						console.error(chalk.red(`\n⚠️ Watch error: ${event.error.message}`));
 					}
 				},
 				{ tag: options.tag }

--- a/apps/cli/src/hamster/parse-prd-to-hamster.ts
+++ b/apps/cli/src/hamster/parse-prd-to-hamster.ts
@@ -228,7 +228,7 @@ export async function parsePrdToHamster(
 			);
 		} else {
 			console.log(
-				chalk.yellow('  ⚠ ') +
+				chalk.yellow('  ⚠️ ') +
 					chalk.white('Could not auto-set context. Run ') +
 					chalk.cyan(`tm context ${result.brief.url}`) +
 					chalk.white(' to set it manually.')

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -4839,7 +4839,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm add-tag" is deprecated. Use "tm tags add" instead.'
+					'⚠️ Warning: "tm add-tag" is deprecated. Use "tm tags add" instead.'
 				)
 			);
 			console.log(
@@ -4993,7 +4993,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm delete-tag" is deprecated. Use "tm tags remove" instead.'
+					'⚠️ Warning: "tm delete-tag" is deprecated. Use "tm tags remove" instead.'
 				)
 			);
 			console.log(
@@ -5065,7 +5065,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm use-tag" is deprecated. Use "tm tags use" instead.'
+					'⚠️ Warning: "tm use-tag" is deprecated. Use "tm tags use" instead.'
 				)
 			);
 			console.log(
@@ -5123,7 +5123,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm rename-tag" is deprecated. Use "tm tags rename" instead.'
+					'⚠️ Warning: "tm rename-tag" is deprecated. Use "tm tags rename" instead.'
 				)
 			);
 			console.log(
@@ -5187,7 +5187,7 @@ Examples:
 			// Show deprecation warning
 			console.warn(
 				chalk.yellow(
-					'⚠ Warning: "tm copy-tag" is deprecated. Use "tm tags copy" instead.'
+					'⚠️ Warning: "tm copy-tag" is deprecated. Use "tm tags copy" instead.'
 				)
 			);
 			console.log(

--- a/scripts/modules/error-formatter.js
+++ b/scripts/modules/error-formatter.js
@@ -394,7 +394,7 @@ export function displayFormattedError(error, options = {}) {
  * @param {string[]} [hints] - Optional hints
  */
 export function displayWarning(message, hints = []) {
-	let content = chalk.yellow.bold('⚠ Warning\n\n');
+	let content = chalk.yellow.bold('⚠️ Warning\n\n');
 	content += chalk.white(message);
 
 	if (hints && hints.length > 0) {

--- a/scripts/modules/prompt-manager.js
+++ b/scripts/modules/prompt-manager.js
@@ -67,7 +67,7 @@ export class PromptManager {
 			this.validatePrompt = this.ajv.compile(promptTemplateSchema);
 			log('debug', '✓ JSON schema validation enabled');
 		} catch (error) {
-			log('warn', `⚠ Schema validation disabled: ${error.message}`);
+			log('warn', `⚠️ Schema validation disabled: ${error.message}`);
 			this.validatePrompt = () => true; // Fallback to no validation
 		}
 	}

--- a/scripts/modules/task-manager/migrate.js
+++ b/scripts/modules/task-manager/migrate.js
@@ -15,7 +15,7 @@ const __dirname = path.dirname(__filename);
 // Create a simple log wrapper for CLI use
 const log = createLogWrapper({
 	info: (msg) => console.log(chalk.blue('ℹ'), msg),
-	warn: (msg) => console.log(chalk.yellow('⚠'), msg),
+	warn: (msg) => console.log(chalk.yellow('⚠️'), msg),
 	error: (msg) => console.error(chalk.red('✗'), msg),
 	success: (msg) => console.log(chalk.green('✓'), msg)
 });

--- a/scripts/modules/task-manager/tag-management.js
+++ b/scripts/modules/task-manager/tag-management.js
@@ -325,7 +325,7 @@ async function deleteTag(
 		if (!yes && taskCount > 0 && outputFormat === 'text') {
 			console.log(
 				boxen(
-					chalk.yellow.bold('⚠ WARNING: Tag Deletion') +
+					chalk.yellow.bold('⚠️ WARNING: Tag Deletion') +
 						`\n\nYou are about to delete tag "${chalk.cyan(tagName)}"` +
 						`\nThis will permanently delete ${chalk.red.bold(taskCount)} tasks` +
 						'\n\nThis action cannot be undone!',
@@ -417,7 +417,7 @@ async function deleteTag(
 						`\n\nTag Name: ${chalk.cyan(tagName)}` +
 						`\nTasks Deleted: ${chalk.yellow(taskCount)}` +
 						(isCurrentTag
-							? `\n${chalk.yellow('⚠ Switched current tag to "master"')}`
+							? `\n${chalk.yellow('⚠️ Switched current tag to "master"')}`
 							: ''),
 					{
 						padding: 1,

--- a/tests/unit/warning-emoji-presentation.test.js
+++ b/tests/unit/warning-emoji-presentation.test.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = process.cwd();
+const SOURCE_DIRS = ['apps/cli/src', 'scripts/modules', 'src'];
+const CODE_EXTENSIONS = new Set(['.js', '.ts']);
+const BARE_WARNING_EMOJI = /⚠(?!️)/u;
+
+function collectSourceFiles(dir) {
+	const fullDir = path.join(ROOT, dir);
+	const entries = fs.readdirSync(fullDir, { withFileTypes: true });
+	const files = [];
+
+	for (const entry of entries) {
+		if (entry.isDirectory()) {
+			files.push(...collectSourceFiles(path.join(dir, entry.name)));
+			continue;
+		}
+
+		if (CODE_EXTENSIONS.has(path.extname(entry.name))) {
+			files.push(path.join(dir, entry.name));
+		}
+	}
+
+	return files;
+}
+
+describe('warning emoji presentation', () => {
+	test('user-facing source files use emoji presentation for warning sign', () => {
+		const offenders = SOURCE_DIRS.flatMap((dir) =>
+			collectSourceFiles(dir).flatMap((file) => {
+				const content = fs.readFileSync(path.join(ROOT, file), 'utf8');
+				return BARE_WARNING_EMOJI.test(content) ? [file] : [];
+			})
+		);
+
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Description

Normalizes warning sign usage to emoji presentation (`⚠️`) across CLI output paths so warning banners and centered box titles render with consistent alignment in terminals. Also adds a regression test that fails on bare warning signs in user-facing source files.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 🔌 Integration
- [ ] 📝 Docs
- [ ] 🧹 Refactor
- [ ] Other:

## Related Issues

Fixes #1394

## How to Test This

```bash
npm run format-check
npm run turbo:typecheck
npm test
```

**Expected result:**
- All commands above succeed
- User-facing warning output uses `⚠️` consistently
- Warning banners and centered box titles render without width misalignment

## Contributor Checklist

- [x] Created changeset: `npm run changeset`
- [x] Tests pass: `npm test`
- [ ] Addressed CodeRabbit comments (if any)
- [x] Format check passes: `npm run format-check` (or `npm run format` to fix)
- [x] Linked related issues (if any)
- [x] Manually tested the changes

## Changelog Entry

Normalized warning emoji presentation in CLI output so warning banners and box titles render with consistent alignment.
