### PR TITLE
fix(mcp): pass resolved tag through to handleApiResult in JS tools

### DIFF
--- a/.changeset/fix-mcp-response-tag.md
+++ b/.changeset/fix-mcp-response-tag.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix MCP tool responses returning the wrong active tag when a `tag` argument is passed explicitly. Tools like `next_task`, `add_task`, `update_task`, `update_subtask`, `expand_task`, `remove_task`, `move_task` and others now report the requested tag in their response payload instead of falling back to `currentTag` from `.taskmaster/state.json`. Resolves #1683 (and related symptom in #1638).

--- a/apps/mcp/tests/integration/tools/generate.tool.test.ts
+++ b/apps/mcp/tests/integration/tools/generate.tool.test.ts
@@ -7,7 +7,7 @@
  * @integration
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -31,7 +31,7 @@ describe('generate MCP tool', () => {
 		);
 
 		// Initialize Task Master in test directory
-		execSync(`node "${cliPath}" init --yes`, {
+		execFileSync(process.execPath, [cliPath, 'init', '--yes'], {
 			stdio: 'pipe',
 			env: { ...process.env, TASKMASTER_SKIP_AUTO_UPDATE: '1' }
 		});
@@ -66,12 +66,25 @@ describe('generate MCP tool', () => {
 	 * The inspector returns MCP protocol format: { content: [{ type: "text", text: "<json>" }] }
 	 */
 	const callMCPTool = (toolName: string, args: Record<string, any>): any => {
-		const toolArgs = Object.entries(args)
-			.map(([key, value]) => `--tool-arg ${key}=${value}`)
-			.join(' ');
+		const toolArgs = Object.entries(args).flatMap(([key, value]) => [
+			'--tool-arg',
+			`${key}=${value}`
+		]);
 
-		const output = execSync(
-			`npx @modelcontextprotocol/inspector --cli node "${mcpServerPath}" --method tools/call --tool-name ${toolName} ${toolArgs}`,
+		const npxBin = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+		const output = execFileSync(
+			npxBin,
+			[
+				'@modelcontextprotocol/inspector',
+				'--cli',
+				'node',
+				mcpServerPath,
+				'--method',
+				'tools/call',
+				'--tool-name',
+				toolName,
+				...toolArgs
+			],
 			{
 				encoding: 'utf-8',
 				stdio: 'pipe',

--- a/apps/mcp/tests/integration/tools/get-tasks.tool.test.ts
+++ b/apps/mcp/tests/integration/tools/get-tasks.tool.test.ts
@@ -7,7 +7,7 @@
  * @integration
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -31,7 +31,7 @@ describe('get_tasks MCP tool', () => {
 		);
 
 		// Initialize Task Master in test directory
-		execSync(`node "${cliPath}" init --yes`, {
+		execFileSync(process.execPath, [cliPath, 'init', '--yes'], {
 			stdio: 'pipe',
 			env: { ...process.env, TASKMASTER_SKIP_AUTO_UPDATE: '1' }
 		});
@@ -66,12 +66,25 @@ describe('get_tasks MCP tool', () => {
 	 * The inspector returns MCP protocol format: { content: [{ type: "text", text: "<json>" }] }
 	 */
 	const callMCPTool = (toolName: string, args: Record<string, any>): any => {
-		const toolArgs = Object.entries(args)
-			.map(([key, value]) => `--tool-arg ${key}=${value}`)
-			.join(' ');
+		const toolArgs = Object.entries(args).flatMap(([key, value]) => [
+			'--tool-arg',
+			`${key}=${value}`
+		]);
 
-		const output = execSync(
-			`npx @modelcontextprotocol/inspector --cli node "${mcpServerPath}" --method tools/call --tool-name ${toolName} ${toolArgs}`,
+		const npxBin = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+		const output = execFileSync(
+			npxBin,
+			[
+				'@modelcontextprotocol/inspector',
+				'--cli',
+				'node',
+				mcpServerPath,
+				'--method',
+				'tools/call',
+				'--tool-name',
+				toolName,
+				...toolArgs
+			],
 			{ encoding: 'utf-8', stdio: 'pipe' }
 		);
 

--- a/apps/mcp/tests/integration/tools/next-task-tag.tool.test.ts
+++ b/apps/mcp/tests/integration/tools/next-task-tag.tool.test.ts
@@ -11,7 +11,7 @@
  * @integration
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -35,7 +35,7 @@ describe('MCP response tag honors explicit tag arg (issue #1683)', () => {
 			'../../../../../dist/mcp-server.js'
 		);
 
-		execSync(`node "${cliPath}" init --yes`, {
+		execFileSync(process.execPath, [cliPath, 'init', '--yes'], {
 			stdio: 'pipe',
 			env: { ...process.env, TASKMASTER_SKIP_AUTO_UPDATE: '1' }
 		});
@@ -94,12 +94,25 @@ describe('MCP response tag honors explicit tag arg (issue #1683)', () => {
 	});
 
 	const callMCPTool = (toolName: string, args: Record<string, string>): any => {
-		const toolArgs = Object.entries(args)
-			.map(([key, value]) => `--tool-arg ${key}=${value}`)
-			.join(' ');
+		const toolArgs = Object.entries(args).flatMap(([key, value]) => [
+			'--tool-arg',
+			`${key}=${value}`
+		]);
 
-		const output = execSync(
-			`npx @modelcontextprotocol/inspector --cli node "${mcpServerPath}" --method tools/call --tool-name ${toolName} ${toolArgs}`,
+		const npxBin = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+		const output = execFileSync(
+			npxBin,
+			[
+				'@modelcontextprotocol/inspector',
+				'--cli',
+				'node',
+				mcpServerPath,
+				'--method',
+				'tools/call',
+				'--tool-name',
+				toolName,
+				...toolArgs
+			],
 			{ encoding: 'utf-8', stdio: 'pipe' }
 		);
 		const mcpResponse = JSON.parse(output);

--- a/apps/mcp/tests/integration/tools/next-task-tag.tool.test.ts
+++ b/apps/mcp/tests/integration/tools/next-task-tag.tool.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview Regression test for upstream issue #1683 (and #1638)
+ *
+ * Verifies that JS-side MCP tools which take a `tag` parameter
+ * return that same tag back in their response payload, instead of
+ * silently falling back to the `currentTag` from `.taskmaster/state.json`.
+ *
+ * Before the fix, `next_task(tag="phase3")` would respond with
+ * `{ ..., "tag": "master" }` whenever state.json still pointed at master.
+ *
+ * @integration
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createTask } from '@tm/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('MCP response tag honors explicit tag arg (issue #1683)', () => {
+	let testDir: string;
+	let tasksPath: string;
+	let statePath: string;
+	let cliPath: string;
+	let mcpServerPath: string;
+
+	beforeEach(() => {
+		testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-mcp-1683-'));
+		process.chdir(testDir);
+
+		cliPath = path.resolve(__dirname, '../../../../../dist/task-master.js');
+		mcpServerPath = path.resolve(
+			__dirname,
+			'../../../../../dist/mcp-server.js'
+		);
+
+		execSync(`node "${cliPath}" init --yes`, {
+			stdio: 'pipe',
+			env: { ...process.env, TASKMASTER_SKIP_AUTO_UPDATE: '1' }
+		});
+
+		tasksPath = path.join(testDir, '.taskmaster', 'tasks', 'tasks.json');
+		statePath = path.join(testDir, '.taskmaster', 'state.json');
+
+		// Multi-tag tasks file with master + phase3
+		const data = {
+			master: {
+				tasks: [
+					createTask({ id: 1, title: 'Master task', status: 'pending' })
+				],
+				metadata: {
+					version: '1.0.0',
+					lastModified: new Date().toISOString(),
+					taskCount: 1,
+					completedCount: 0,
+					tags: ['master']
+				}
+			},
+			phase3: {
+				tasks: [
+					createTask({
+						id: 41,
+						title: 'Phase3 task',
+						status: 'pending',
+						priority: 'high'
+					})
+				],
+				metadata: {
+					version: '1.0.0',
+					lastModified: new Date().toISOString(),
+					taskCount: 1,
+					completedCount: 0,
+					tags: ['phase3']
+				}
+			}
+		};
+		fs.writeFileSync(tasksPath, JSON.stringify(data, null, 2));
+
+		// Pin currentTag to master so we can detect a fallback bug
+		fs.writeFileSync(
+			statePath,
+			JSON.stringify({ currentTag: 'master' }, null, 2)
+		);
+	});
+
+	afterEach(() => {
+		try {
+			process.chdir(path.resolve(__dirname, '../../../../..'));
+		} catch {
+			process.chdir(os.homedir());
+		}
+		if (testDir && fs.existsSync(testDir)) {
+			fs.rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	const callMCPTool = (
+		toolName: string,
+		args: Record<string, string>
+	): any => {
+		const toolArgs = Object.entries(args)
+			.map(([key, value]) => `--tool-arg ${key}=${value}`)
+			.join(' ');
+
+		const output = execSync(
+			`npx @modelcontextprotocol/inspector --cli node "${mcpServerPath}" --method tools/call --tool-name ${toolName} ${toolArgs}`,
+			{ encoding: 'utf-8', stdio: 'pipe' }
+		);
+		const mcpResponse = JSON.parse(output);
+		const resultText = mcpResponse.content[0].text;
+		return JSON.parse(resultText);
+	};
+
+	it('next_task(tag="phase3") response carries tag="phase3" even when state.json points at master', () => {
+		const data = callMCPTool('next_task', {
+			projectRoot: testDir,
+			tag: 'phase3'
+		});
+		expect(data.tag).toBe('phase3');
+	}, 30000);
+});

--- a/apps/mcp/tests/integration/tools/next-task-tag.tool.test.ts
+++ b/apps/mcp/tests/integration/tools/next-task-tag.tool.test.ts
@@ -46,9 +46,7 @@ describe('MCP response tag honors explicit tag arg (issue #1683)', () => {
 		// Multi-tag tasks file with master + phase3
 		const data = {
 			master: {
-				tasks: [
-					createTask({ id: 1, title: 'Master task', status: 'pending' })
-				],
+				tasks: [createTask({ id: 1, title: 'Master task', status: 'pending' })],
 				metadata: {
 					version: '1.0.0',
 					lastModified: new Date().toISOString(),
@@ -95,10 +93,7 @@ describe('MCP response tag honors explicit tag arg (issue #1683)', () => {
 		}
 	});
 
-	const callMCPTool = (
-		toolName: string,
-		args: Record<string, string>
-	): any => {
+	const callMCPTool = (toolName: string, args: Record<string, string>): any => {
 		const toolArgs = Object.entries(args)
 			.map(([key, value]) => `--tool-arg ${key}=${value}`)
 			.join(' ');

--- a/mcp-server/src/tools/add-subtask.js
+++ b/mcp-server/src/tools/add-subtask.js
@@ -116,7 +116,8 @@ export function registerAddSubtaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error adding subtask',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in addSubtask tool: ${error.message}`);

--- a/mcp-server/src/tools/add-task.js
+++ b/mcp-server/src/tools/add-task.js
@@ -115,7 +115,8 @@ export function registerAddTaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error adding task',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in add-task tool: ${error.message}`);

--- a/mcp-server/src/tools/analyze.js
+++ b/mcp-server/src/tools/analyze.js
@@ -158,7 +158,8 @@ export function registerAnalyzeProjectComplexityTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error analyzing task complexity',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(

--- a/mcp-server/src/tools/clear-subtasks.js
+++ b/mcp-server/src/tools/clear-subtasks.js
@@ -95,7 +95,8 @@ export function registerClearSubtasksTool(server) {
 					result,
 					log: context.log,
 					errorPrefix: 'Error clearing subtasks',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				context.log.error(`Error in clearSubtasks tool: ${error.message}`);

--- a/mcp-server/src/tools/expand-all.js
+++ b/mcp-server/src/tools/expand-all.js
@@ -119,7 +119,8 @@ export function registerExpandAllTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error expanding all tasks',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(

--- a/mcp-server/src/tools/expand-task.js
+++ b/mcp-server/src/tools/expand-task.js
@@ -102,7 +102,8 @@ export function registerExpandTaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error expanding task',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in expand-task tool: ${error.message}`);

--- a/mcp-server/src/tools/fix-dependencies.js
+++ b/mcp-server/src/tools/fix-dependencies.js
@@ -76,7 +76,8 @@ export function registerFixDependenciesTool(server) {
 					result,
 					log: context.log,
 					errorPrefix: 'Error fixing dependencies',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				context.log.error(`Error in fixDependencies tool: ${error.message}`);

--- a/mcp-server/src/tools/move-task.js
+++ b/mcp-server/src/tools/move-task.js
@@ -103,7 +103,8 @@ export function registerMoveTaskTool(server) {
 						),
 						log,
 						errorPrefix: 'Error moving tasks between tags',
-						projectRoot: args.projectRoot
+						projectRoot: args.projectRoot,
+						tag: args.toTag
 					});
 				} else {
 					// Within-tag move logic (existing functionality)
@@ -180,7 +181,8 @@ export function registerMoveTaskTool(server) {
 								},
 								log,
 								errorPrefix: 'Error moving multiple tasks',
-								projectRoot: args.projectRoot
+								projectRoot: args.projectRoot,
+								tag: resolvedTag
 							});
 						}
 						return handleApiResult({
@@ -194,7 +196,8 @@ export function registerMoveTaskTool(server) {
 							},
 							log,
 							errorPrefix: 'Error moving multiple tasks',
-							projectRoot: args.projectRoot
+							projectRoot: args.projectRoot,
+							tag: resolvedTag
 						});
 					} else {
 						// Moving a single task
@@ -213,7 +216,8 @@ export function registerMoveTaskTool(server) {
 							),
 							log,
 							errorPrefix: 'Error moving task',
-							projectRoot: args.projectRoot
+							projectRoot: args.projectRoot,
+							tag: resolvedTag
 						});
 					}
 				}

--- a/mcp-server/src/tools/next-task.js
+++ b/mcp-server/src/tools/next-task.js
@@ -90,7 +90,8 @@ export function registerNextTaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error finding next task',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error finding next task: ${error.message}`);

--- a/mcp-server/src/tools/parse-prd.js
+++ b/mcp-server/src/tools/parse-prd.js
@@ -92,7 +92,8 @@ export function registerParsePRDTool(server) {
 						result,
 						log: log,
 						errorPrefix: 'Error parsing PRD',
-						projectRoot: args.projectRoot
+						projectRoot: args.projectRoot,
+						tag: resolvedTag
 					});
 				} catch (error) {
 					log.error(`Error in parse_prd: ${error.message}`);

--- a/mcp-server/src/tools/remove-dependency.js
+++ b/mcp-server/src/tools/remove-dependency.js
@@ -84,7 +84,8 @@ export function registerRemoveDependencyTool(server) {
 					result,
 					log: context.log,
 					errorPrefix: 'Error removing dependency',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				context.log.error(`Error in removeDependency tool: ${error.message}`);

--- a/mcp-server/src/tools/remove-subtask.js
+++ b/mcp-server/src/tools/remove-subtask.js
@@ -97,7 +97,8 @@ export function registerRemoveSubtaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error removing subtask',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in removeSubtask tool: ${error.message}`);

--- a/mcp-server/src/tools/remove-task.js
+++ b/mcp-server/src/tools/remove-task.js
@@ -92,7 +92,8 @@ export function registerRemoveTaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error removing task',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in remove-task tool: ${error.message}`);

--- a/mcp-server/src/tools/research.js
+++ b/mcp-server/src/tools/research.js
@@ -103,7 +103,8 @@ export function registerResearchTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error performing research',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in research tool: ${error.message}`);

--- a/mcp-server/src/tools/scope-down.js
+++ b/mcp-server/src/tools/scope-down.js
@@ -96,7 +96,8 @@ export function registerScopeDownTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error scoping down task',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in scope-down tool: ${error.message}`);

--- a/mcp-server/src/tools/scope-up.js
+++ b/mcp-server/src/tools/scope-up.js
@@ -96,7 +96,8 @@ export function registerScopeUpTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error scoping up task',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in scope-up tool: ${error.message}`);

--- a/mcp-server/src/tools/set-task-status.js
+++ b/mcp-server/src/tools/set-task-status.js
@@ -121,7 +121,8 @@ export function registerSetTaskStatusTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error setting task status',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(`Error in setTaskStatus tool: ${error.message}`);

--- a/mcp-server/src/tools/update-subtask.js
+++ b/mcp-server/src/tools/update-subtask.js
@@ -119,7 +119,8 @@ export function registerUpdateSubtaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error updating subtask',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(

--- a/mcp-server/src/tools/update-task.js
+++ b/mcp-server/src/tools/update-task.js
@@ -126,7 +126,8 @@ export function registerUpdateTaskTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error updating task',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(

--- a/mcp-server/src/tools/update.js
+++ b/mcp-server/src/tools/update.js
@@ -96,7 +96,8 @@ export function registerUpdateTool(server) {
 					result,
 					log: log,
 					errorPrefix: 'Error updating tasks',
-					projectRoot: args.projectRoot
+					projectRoot: args.projectRoot,
+					tag: resolvedTag
 				});
 			} catch (error) {
 				log.error(


### PR DESCRIPTION
## Summary

Fixes #1683. When an MCP tool is called with an explicit `tag` argument (e.g. `next_task tag=phase3`), the response payload was still carrying the `currentTag` from `.taskmaster/state.json` (usually `master`). The data was loaded from the correct tag, but the response's `tag` field misled callers into thinking the operation ran on a different tag — leading to destructive corrective actions in multi-tag / multi-agent workspaces.

The fix threads the already-resolved `tag` into `handleApiResult` in every JS-side MCP tool that wasn't already doing so, matching the existing pattern in `add-dependency.js` and the TS tools in `@tm/mcp`.

## Changes

- Updated 19 JS MCP tools under `mcp-server/src/tools/` to pass `resolvedTag` (or `args.tag`) through to `handleApiResult`:
  `add-subtask`, `add-task`, `analyze`, `clear-subtasks`, `expand-all`, `expand-task`, `fix-dependencies`, `move-task`, `next-task`, `parse-prd`, `remove-dependency`, `remove-subtask`, `remove-task`, `research`, `scope-down`, `scope-up`, `set-task-status`, `update-subtask`, `update-task`, `update`.
- Added regression test `apps/mcp/tests/integration/tools/next-task-tag.tool.test.ts` that pins `state.json` to `master`, calls `next_task` with `tag=phase3`, and asserts the response carries `"tag": "phase3"`.
- Added changeset.

## Test plan

- [ ] `npm run test -w apps/mcp` passes (includes the new regression test)
- [ ] Manual: in a multi-tag workspace, call `next_task` / `set_task_status` / `update_task` with an explicit `tag` arg and confirm the response's `tag` field matches the argument
- [ ] Verify `add-dependency.js` and TS tools remain unchanged (they already handled this correctly)

Resolves #1683.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP tools now report the explicitly requested tag in responses (no longer falling back to a default), ensuring correct tag context across task operations.

* **Tests**
  * Added an integration test to verify explicit tag preservation in tool calls.
  * Improved integration test CLI invocation for more reliable, platform-aware execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eyaltoledano/claude-task-master/pull/1703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->