### PR TITLE
feat(minimax): upgrade MiniMax model lineup to M3

### DIFF
--- a/.changeset/upgrade-minimax-m3.md
+++ b/.changeset/upgrade-minimax-m3.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": minor
+---
+
+Upgrade the MiniMax provider model lineup to the M3 generation. Adds `MiniMax-M3` as the new flagship model and keeps `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` available for legacy/highspeed workloads. The deprecated M2.5 entries are removed from the supported model list.

--- a/docs/models.md
+++ b/docs/models.md
@@ -123,7 +123,7 @@
 | bedrock     | us.anthropic.claude-3-5-haiku-20241022-v1:0    | 0.4       | 0.8        | 4           |
 | bedrock     | us.anthropic.claude-opus-4-20250514-v1:0       | 0.725     | 15         | 75          |
 | bedrock     | us.anthropic.claude-sonnet-4-20250514-v1:0     | 0.727     | 3          | 15          |
-| minimax     | MiniMax-M3                                     | —         | 1          | 5.5         |
+| minimax     | MiniMax-M3                                     | —         | 0.6        | 2.4         |
 | minimax     | MiniMax-M2.7                                   | —         | 1          | 5.5         |
 | minimax     | MiniMax-M2.7-highspeed                         | —         | 1          | 5.5         |
 
@@ -176,7 +176,7 @@
 | bedrock     | us.anthropic.claude-opus-4-20250514-v1:0     | 0.725     | 15         | 75          |
 | bedrock     | us.anthropic.claude-sonnet-4-20250514-v1:0   | 0.727     | 3          | 15          |
 | bedrock     | us.deepseek.r1-v1:0                          | —         | 1.35       | 5.4         |
-| minimax     | MiniMax-M3                                   | —         | 1          | 5.5         |
+| minimax     | MiniMax-M3                                   | —         | 0.6        | 2.4         |
 | minimax     | MiniMax-M2.7                                 | —         | 1          | 5.5         |
 | minimax     | MiniMax-M2.7-highspeed                       | —         | 1          | 5.5         |
 
@@ -288,7 +288,7 @@
 | bedrock     | us.anthropic.claude-3-5-haiku-20241022-v1:0    | 0.4       | 0.8        | 4           |
 | bedrock     | us.anthropic.claude-opus-4-20250514-v1:0       | 0.725     | 15         | 75          |
 | bedrock     | us.anthropic.claude-sonnet-4-20250514-v1:0     | 0.727     | 3          | 15          |
-| minimax     | MiniMax-M3                                     | —         | 1          | 5.5         |
+| minimax     | MiniMax-M3                                     | —         | 0.6        | 2.4         |
 | minimax     | MiniMax-M2.7                                   | —         | 1          | 5.5         |
 | minimax     | MiniMax-M2.7-highspeed                         | —         | 1          | 5.5         |
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -123,8 +123,9 @@
 | bedrock     | us.anthropic.claude-3-5-haiku-20241022-v1:0    | 0.4       | 0.8        | 4           |
 | bedrock     | us.anthropic.claude-opus-4-20250514-v1:0       | 0.725     | 15         | 75          |
 | bedrock     | us.anthropic.claude-sonnet-4-20250514-v1:0     | 0.727     | 3          | 15          |
-| minimax     | MiniMax-M2.5                                   | —         | 1          | 5.5         |
-| minimax     | MiniMax-M2.5-highspeed                         | —         | 1          | 5.5         |
+| minimax     | MiniMax-M3                                     | —         | 1          | 5.5         |
+| minimax     | MiniMax-M2.7                                   | —         | 1          | 5.5         |
+| minimax     | MiniMax-M2.7-highspeed                         | —         | 1          | 5.5         |
 
 ## Research Models
 
@@ -175,8 +176,9 @@
 | bedrock     | us.anthropic.claude-opus-4-20250514-v1:0     | 0.725     | 15         | 75          |
 | bedrock     | us.anthropic.claude-sonnet-4-20250514-v1:0   | 0.727     | 3          | 15          |
 | bedrock     | us.deepseek.r1-v1:0                          | —         | 1.35       | 5.4         |
-| minimax     | MiniMax-M2.5                                 | —         | 1          | 5.5         |
-| minimax     | MiniMax-M2.5-highspeed                       | —         | 1          | 5.5         |
+| minimax     | MiniMax-M3                                   | —         | 1          | 5.5         |
+| minimax     | MiniMax-M2.7                                 | —         | 1          | 5.5         |
+| minimax     | MiniMax-M2.7-highspeed                       | —         | 1          | 5.5         |
 
 ## Fallback Models
 
@@ -286,8 +288,9 @@
 | bedrock     | us.anthropic.claude-3-5-haiku-20241022-v1:0    | 0.4       | 0.8        | 4           |
 | bedrock     | us.anthropic.claude-opus-4-20250514-v1:0       | 0.725     | 15         | 75          |
 | bedrock     | us.anthropic.claude-sonnet-4-20250514-v1:0     | 0.727     | 3          | 15          |
-| minimax     | MiniMax-M2.5                                   | —         | 1          | 5.5         |
-| minimax     | MiniMax-M2.5-highspeed                         | —         | 1          | 5.5         |
+| minimax     | MiniMax-M3                                     | —         | 1          | 5.5         |
+| minimax     | MiniMax-M2.7                                   | —         | 1          | 5.5         |
+| minimax     | MiniMax-M2.7-highspeed                         | —         | 1          | 5.5         |
 
 ## Unsupported Models
 

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -1446,11 +1446,11 @@
 			"name": "MiniMax M3",
 			"swe_score": null,
 			"cost_per_1m_tokens": {
-				"input": 1.0,
-				"output": 5.5
+				"input": 0.6,
+				"output": 2.4
 			},
 			"allowed_roles": ["main", "fallback", "research"],
-			"max_tokens": 204800,
+			"max_tokens": 128000,
 			"supported": true
 		},
 		{

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -1442,8 +1442,8 @@
 	],
 	"minimax": [
 		{
-			"id": "MiniMax-M2.5",
-			"name": "MiniMax M2.5",
+			"id": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"swe_score": null,
 			"cost_per_1m_tokens": {
 				"input": 1.0,
@@ -1454,8 +1454,20 @@
 			"supported": true
 		},
 		{
-			"id": "MiniMax-M2.5-highspeed",
-			"name": "MiniMax M2.5 Highspeed",
+			"id": "MiniMax-M2.7",
+			"name": "MiniMax M2.7",
+			"swe_score": null,
+			"cost_per_1m_tokens": {
+				"input": 1.0,
+				"output": 5.5
+			},
+			"allowed_roles": ["main", "fallback", "research"],
+			"max_tokens": 204800,
+			"supported": true
+		},
+		{
+			"id": "MiniMax-M2.7-highspeed",
+			"name": "MiniMax M2.7 Highspeed",
 			"swe_score": null,
 			"cost_per_1m_tokens": {
 				"input": 1.0,

--- a/src/ai-providers/minimax.js
+++ b/src/ai-providers/minimax.js
@@ -7,7 +7,7 @@
 import { OpenAICompatibleProvider } from './openai-compatible.js';
 
 /**
- * MiniMax provider supporting MiniMax-M2.5 models through OpenAI-compatible API.
+ * MiniMax provider supporting MiniMax-M3 (default) and MiniMax-M2.7 family models through OpenAI-compatible API.
  */
 export class MiniMaxProvider extends OpenAICompatibleProvider {
 	constructor() {


### PR DESCRIPTION
## Description

Upgrades the MiniMax (minimax) provider model lineup to the M3 generation:

- Adds `MiniMax-M3` as the new flagship MiniMax model (default)
- Keeps `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` available as legacy / highspeed options
- Removes the deprecated `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` entries

`MiniMax-M3` is priced at `$0.6 / $2.4` per 1M input/output tokens with a 128K max output cap, reflecting the official M3 pay-as-you-go rates and output limit. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` retain their existing `$1 / $5.5` per 1M token pricing and 200K max output cap. The provider class itself, the OpenAI-compatible base URL (`https://api.minimax.io/v1`), and the `MINIMAX_API_KEY` env var are unchanged.

## Type of Change

- [x] New feature (model addition: `MiniMax-M3` as default)
- [x] Breaking change (removal of deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` IDs)

Users that had pinned their main / research / fallback role to `MiniMax-M2.5` will need to switch to `MiniMax-M3` (or `MiniMax-M2.7`) via `task-master models --setup`.

## Files Touched

- `scripts/modules/supported-models.json` — replaced the two M2.5 entries with M3 (new pricing/max_tokens) plus M2.7 (regular and highspeed)
- `docs/models.md` — refreshed the three minimax rows under Main / Research / Fallback tables
- `src/ai-providers/minimax.js` — updated the JSDoc comment to reflect the M3 default
- `.changeset/upgrade-minimax-m3.md` — user-facing changeset entry

## Testing

- [x] `tests/unit/ai-providers/minimax.test.js` — provider constructor / auth / client tests intact (no model-id assertions)
- [x] `npm run format-check` — clean (biome)
- [x] `npm run turbo:typecheck` — JSON / markdown changes only

## Changeset

- [x] Added `.changeset/upgrade-minimax-m3.md` (minor bump)

## Additional Notes

The M3 entry is intentionally placed at the top of the `minimax` array in `supported-models.json` and at the top of the three minimax blocks in `docs/models.md`, so listings naturally surface it first. The provider's `defaultBaseURL` (`https://api.minimax.io/v1`) and the `MINIMAX_API_KEY` env var are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MiniMax-M3 is now available as the flagship MiniMax model with updated input/output cost metrics.
  * MiniMax-M2.7 and MiniMax-M2.7-highspeed are available for legacy and high-speed inference with preserved cost values.

* **Deprecations**
  * MiniMax-M2.5 and MiniMax-M2.5-highspeed entries removed from supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->