### PR TITLE
fix: forward maxTokens as maxOutputTokens in generateObject

### DIFF
--- a/.changeset/fix-generateobject-max-output-tokens.md
+++ b/.changeset/fix-generateobject-max-output-tokens.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix the configured token limit being dropped on structured-output commands. `generateObject`-backed operations (e.g. `add-task`, `parse-prd`, `expand`, `analyze-complexity`, `update`) now forward `maxTokens` to the model as `maxOutputTokens`, matching `generateText`/`streamText`/`streamObject`. Previously the limit was silently ignored, so OpenAI-compatible endpoints that default to a small token cap would truncate the response and fail with "No object generated".

--- a/src/ai-providers/base-provider.js
+++ b/src/ai-providers/base-provider.js
@@ -533,7 +533,7 @@ export class BaseAIProvider {
 				mode: this.needsExplicitJsonSchema ? 'json' : 'auto',
 				schemaName: params.objectName,
 				schemaDescription: `Generate a valid JSON object for ${params.objectName}`,
-				maxTokens: params.maxTokens,
+				maxOutputTokens: params.maxTokens,
 				...(this.supportsTemperature && params.temperature !== undefined
 					? { temperature: params.temperature }
 					: {}),

--- a/src/ai-providers/base-provider.js
+++ b/src/ai-providers/base-provider.js
@@ -465,7 +465,7 @@ export class BaseAIProvider {
 				messages: params.messages,
 				schema,
 				mode: params.mode || 'auto',
-				maxOutputTokens: params.maxTokens,
+				...this.prepareTokenParam(params.modelId, params.maxTokens),
 				...(this.supportsTemperature && params.temperature !== undefined
 					? { temperature: params.temperature }
 					: {}),
@@ -533,7 +533,7 @@ export class BaseAIProvider {
 				mode: this.needsExplicitJsonSchema ? 'json' : 'auto',
 				schemaName: params.objectName,
 				schemaDescription: `Generate a valid JSON object for ${params.objectName}`,
-				maxOutputTokens: params.maxTokens,
+				...this.prepareTokenParam(params.modelId, params.maxTokens),
 				...(this.supportsTemperature && params.temperature !== undefined
 					? { temperature: params.temperature }
 					: {}),

--- a/tests/unit/ai-providers/base-provider.test.js
+++ b/tests/unit/ai-providers/base-provider.test.js
@@ -488,9 +488,9 @@ describe('BaseAIProvider', () => {
 
 		it('should forward maxTokens to the AI SDK as maxOutputTokens (regression)', async () => {
 			// AI SDK v5 honors `maxOutputTokens`; the legacy `maxTokens` key is
-			// ignored, silently dropping the limit. Structured-output calls then
-			// fall back to the endpoint default and get truncated. generateText
-			// and streamObject already use `maxOutputTokens`.
+			// ignored, silently dropping the limit so structured-output calls fall
+			// back to the endpoint default and get truncated. generateObject now
+			// routes the limit through prepareTokenParam like the other methods.
 			mockGenerateObject.mockResolvedValue({
 				object: { test: 'value' },
 				usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }
@@ -507,6 +507,27 @@ describe('BaseAIProvider', () => {
 
 			const callArgs = mockGenerateObject.mock.calls[0][0];
 			expect(callArgs.maxOutputTokens).toBe(1000);
+			expect(callArgs).not.toHaveProperty('maxTokens');
+		});
+
+		it('should omit the token limit when maxTokens is not provided', async () => {
+			// prepareTokenParam returns {} when maxTokens is undefined, so the SDK
+			// call must not carry a maxOutputTokens key at all.
+			mockGenerateObject.mockResolvedValue({
+				object: { test: 'value' },
+				usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }
+			});
+
+			await testProvider.generateObject({
+				apiKey: 'key',
+				modelId: 'model',
+				messages: [{ role: 'user', content: 'test' }],
+				schema: { type: 'object' },
+				objectName: 'TestObject'
+			});
+
+			const callArgs = mockGenerateObject.mock.calls[0][0];
+			expect(callArgs).not.toHaveProperty('maxOutputTokens');
 			expect(callArgs).not.toHaveProperty('maxTokens');
 		});
 	});

--- a/tests/unit/ai-providers/base-provider.test.js
+++ b/tests/unit/ai-providers/base-provider.test.js
@@ -485,6 +485,30 @@ describe('BaseAIProvider', () => {
 				})
 			);
 		});
+
+		it('should forward maxTokens to the AI SDK as maxOutputTokens (regression)', async () => {
+			// AI SDK v5 honors `maxOutputTokens`; the legacy `maxTokens` key is
+			// ignored, silently dropping the limit. Structured-output calls then
+			// fall back to the endpoint default and get truncated. generateText
+			// and streamObject already use `maxOutputTokens`.
+			mockGenerateObject.mockResolvedValue({
+				object: { test: 'value' },
+				usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }
+			});
+
+			await testProvider.generateObject({
+				apiKey: 'key',
+				modelId: 'model',
+				messages: [{ role: 'user', content: 'test' }],
+				schema: { type: 'object' },
+				objectName: 'TestObject',
+				maxTokens: 1000
+			});
+
+			const callArgs = mockGenerateObject.mock.calls[0][0];
+			expect(callArgs.maxOutputTokens).toBe(1000);
+			expect(callArgs).not.toHaveProperty('maxTokens');
+		});
 	});
 
 	describe('8. Integration Points - Client Creation', () => {


### PR DESCRIPTION
## Summary

`BaseAIProvider.generateObject()` passes the configured token limit to the AI SDK as `maxTokens`, but Task Master bundles **AI SDK v5** (`ai@^5`), which renamed that option to **`maxOutputTokens`**. The unknown `maxTokens` key is ignored, so the limit is silently dropped for every `generateObject`-backed command — `add-task`, `parse-prd`, `expand`, `analyze-complexity`, `update`, etc.

`generateText`, `streamText`, and `streamObject` are unaffected — they already send `maxOutputTokens` (the first two via `prepareTokenParam`, `streamObject` directly). `generateObject` was the only outlier.

## Root cause

`src/ai-providers/base-provider.js`:

```js
const result = await generateObject({
  ...
  schemaDescription: `Generate a valid JSON object for ${params.objectName}`,
  maxTokens: params.maxTokens,   // ignored by AI SDK v5
  ...
});
```

## Fix

Send `maxOutputTokens`, matching the sibling `streamObject` call in the same file — a one-line change, with no behavior change for providers that don't set a token limit.

## Why it matters (real-world repro)

Against an OpenAI-compatible gateway that defaults `max_tokens` to a small value (e.g. 300) when the client omits it, the dropped limit means no cap is sent on the request. With a reasoning model that emits hidden `reasoning_content`, the whole budget is consumed by reasoning, the visible `content` comes back empty (`finish_reason: "length"`), and the command fails with:

```
[ERROR] ... No object generated: the model did not return a response.
```

Capturing the outbound request body confirmed only `model`, `temperature`, `response_format`, and `messages` were sent — no token-limit field at all. After the fix, `maxOutputTokens` (→ `max_tokens` on the wire) is present and the commands succeed.

## Testing

- Added a regression test in `tests/unit/ai-providers/base-provider.test.js` asserting `generateObject` forwards the limit as `maxOutputTokens` (and not `maxTokens`). It fails before the fix (`Expected: 1000, Received: undefined`) and passes after.
- `base-provider.test.js`: 41/41 pass.
- `npm run changeset:validate`: valid.
- `biome format`: clean.
- `npm run turbo:typecheck`: 9/9 pass.

## Changeset

Added (`patch`, user-facing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token limit for structured-output generation is now correctly applied to the AI model, preventing response truncation and failures on endpoints with low default caps. Behavior is consistent across all generation methods.

* **Tests**
  * Added unit tests to verify correct forwarding and omission of token-limit parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->