### PR TITLE
fix(tm-core): slugify tag before using it in file paths (CWE-23 path traversal)

### DIFF
--- a/.changeset/fix-tag-path-traversal.md
+++ b/.changeset/fix-tag-path-traversal.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": patch
+---
+
+Fix path traversal via unsanitized `tag` in tm-core file path builders (CWE-23). The complexity-report reader and the per-task file generator interpolated the tag straight into a filename, so a tag containing `../` (from a CLI/MCP argument, `.taskmaster/state.json` `currentTag`, or `TASKMASTER_TAG`) could read or write files outside the `.taskmaster/` directory. Tags are now slugified with a shared `slugifyTagForFilePath` helper, restoring parity with the legacy JS path writer; legitimately named tags are unaffected.

--- a/packages/tm-core/src/common/utils/index.ts
+++ b/packages/tm-core/src/common/utils/index.ts
@@ -57,6 +57,9 @@ export {
 // Export path construction utilities
 export { getProjectPaths } from './path-helpers.js';
 
+// Export tag-aware path safety utilities
+export { slugifyTagForFilePath } from './tag-path.js';
+
 // Additional utility exports
 
 /**

--- a/packages/tm-core/src/common/utils/tag-path.spec.ts
+++ b/packages/tm-core/src/common/utils/tag-path.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { slugifyTagForFilePath } from './tag-path.js';
+
+describe('slugifyTagForFilePath', () => {
+	describe('legitimate tags are preserved (no mangling)', () => {
+		it('keeps a simple valid tag unchanged', () => {
+			expect(slugifyTagForFilePath('feature-v2')).toBe('feature-v2');
+		});
+
+		it('keeps underscores and digits', () => {
+			expect(slugifyTagForFilePath('release_2026_01')).toBe('release_2026_01');
+		});
+
+		it('lowercases (parity with legacy slugify)', () => {
+			expect(slugifyTagForFilePath('MyFeature')).toBe('myfeature');
+		});
+	});
+
+	describe('path traversal is neutralized (negative oracle)', () => {
+		// These are the inputs an attacker would use to escape the target dir.
+		const traversals = [
+			'../../x',
+			'../../../../../etc/passwd',
+			'..\\..\\x',
+			'..%2f..%2fx',
+			'foo/../bar',
+			'a/b/c',
+			'tag\0null'
+		];
+
+		it.each(traversals)(
+			'produces no path separators or dot segments for %j',
+			(input) => {
+				const slug = slugifyTagForFilePath(input);
+				expect(slug).not.toContain('/');
+				expect(slug).not.toContain('\\');
+				expect(slug).not.toContain('..');
+				expect(slug).not.toContain('\0');
+				// must be a single safe filename fragment
+				expect(slug).toMatch(/^[a-z0-9_-]*$/);
+			}
+		);
+
+		it('cannot escape when embedded in a filename', () => {
+			const slug = slugifyTagForFilePath('../../../../../escape/secret');
+			const fileName = `task-complexity-report_${slug}.json`;
+			expect(fileName).not.toContain('/');
+			expect(fileName).not.toContain('..');
+		});
+	});
+
+	describe('hyphen handling and length', () => {
+		it('collapses and trims hyphens introduced by invalid chars', () => {
+			expect(slugifyTagForFilePath('../../etc/passwd')).toBe('etc-passwd');
+		});
+
+		it('caps the length at 50 characters', () => {
+			const long = 'a'.repeat(120);
+			expect(slugifyTagForFilePath(long).length).toBe(50);
+		});
+	});
+
+	describe('empty / invalid input', () => {
+		it('returns a fallback for empty string', () => {
+			expect(slugifyTagForFilePath('')).toBe('unknown-tag');
+		});
+
+		it('returns a fallback for null/undefined', () => {
+			expect(slugifyTagForFilePath(null)).toBe('unknown-tag');
+			expect(slugifyTagForFilePath(undefined)).toBe('unknown-tag');
+		});
+	});
+});

--- a/packages/tm-core/src/common/utils/tag-path.spec.ts
+++ b/packages/tm-core/src/common/utils/tag-path.spec.ts
@@ -69,5 +69,11 @@ describe('slugifyTagForFilePath', () => {
 			expect(slugifyTagForFilePath(null)).toBe('unknown-tag');
 			expect(slugifyTagForFilePath(undefined)).toBe('unknown-tag');
 		});
+
+		it('returns the fallback when every character is invalid (slug collapses to empty)', () => {
+			// Without the fallback this would yield a malformed `..._.json` suffix.
+			expect(slugifyTagForFilePath('../../../')).toBe('unknown-tag');
+			expect(slugifyTagForFilePath('////')).toBe('unknown-tag');
+		});
 	});
 });

--- a/packages/tm-core/src/common/utils/tag-path.ts
+++ b/packages/tm-core/src/common/utils/tag-path.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Tag-aware filesystem path safety utilities.
+ *
+ * Tag names are user/agent/config-controllable (CLI `--tag`, MCP `tag` argument,
+ * `.taskmaster/state.json` `currentTag`, and the `TASKMASTER_TAG` env var). When a
+ * tag is interpolated into a filename, it MUST be slugified first so that path
+ * separators and `..` segments cannot escape the intended directory.
+ *
+ * This mirrors the behavior of the legacy `slugifyTagForFilePath` in
+ * `scripts/modules/utils.js` so that file paths produced by the TypeScript
+ * (`tm-core`) code stay in parity with the legacy JS code that writes those same
+ * files (e.g. the complexity report and per-task markdown files).
+ */
+
+/** Maximum slug length, to avoid overly long filenames. */
+const MAX_TAG_SLUG_LENGTH = 50;
+
+/**
+ * Slugify a tag name into a filesystem-safe fragment.
+ *
+ * Replaces every character outside `[a-zA-Z0-9_-]` with a hyphen (so `/`, `\`,
+ * `.` and NUL cannot survive), trims and collapses hyphens, lowercases, and caps
+ * the length. As a result a value such as `../../etc/passwd` becomes a harmless
+ * `etc-passwd` instead of traversing out of the target directory.
+ *
+ * Legitimately created tags already match `^[a-zA-Z0-9_-]+$` (enforced by
+ * `validateTagName` at creation), so for valid tags this only ever lowercases —
+ * it never rejects or mangles a real tag.
+ *
+ * @param tagName - The raw tag name (may be untrusted).
+ * @returns A filesystem-safe slug; `'unknown-tag'` for empty/non-string input.
+ *
+ * @example
+ * ```ts
+ * slugifyTagForFilePath('feature-v2');        // 'feature-v2'
+ * slugifyTagForFilePath('../../etc/passwd');  // 'etc-passwd' (no traversal)
+ * ```
+ */
+export function slugifyTagForFilePath(
+	tagName: string | null | undefined
+): string {
+	if (!tagName || typeof tagName !== 'string') {
+		return 'unknown-tag';
+	}
+
+	return tagName
+		.replace(/[^a-zA-Z0-9_-]/g, '-') // Replace invalid chars with hyphens
+		.replace(/^-+|-+$/g, '') // Remove leading/trailing hyphens
+		.replace(/-+/g, '-') // Collapse multiple hyphens
+		.toLowerCase() // Convert to lowercase
+		.substring(0, MAX_TAG_SLUG_LENGTH); // Cap length
+}

--- a/packages/tm-core/src/common/utils/tag-path.ts
+++ b/packages/tm-core/src/common/utils/tag-path.ts
@@ -43,10 +43,15 @@ export function slugifyTagForFilePath(
 		return 'unknown-tag';
 	}
 
-	return tagName
+	const slug = tagName
 		.replace(/[^a-zA-Z0-9_-]/g, '-') // Replace invalid chars with hyphens
 		.replace(/^-+|-+$/g, '') // Remove leading/trailing hyphens
 		.replace(/-+/g, '-') // Collapse multiple hyphens
 		.toLowerCase() // Convert to lowercase
 		.substring(0, MAX_TAG_SLUG_LENGTH); // Cap length
+
+	// An all-invalid-char tag (e.g. `../../../`) collapses to an empty string,
+	// which would yield a malformed suffix like `task-complexity-report_.json`.
+	// Fall back to the same sentinel used for empty/non-string input.
+	return slug || 'unknown-tag';
 }

--- a/packages/tm-core/src/modules/reports/managers/complexity-report-manager.ts
+++ b/packages/tm-core/src/modules/reports/managers/complexity-report-manager.ts
@@ -6,6 +6,7 @@
 import fs from 'node:fs/promises';
 import path from 'path';
 import { getLogger } from '../../../common/logger/index.js';
+import { slugifyTagForFilePath } from '../../../common/utils/tag-path.js';
 import type {
 	ComplexityAnalysis,
 	ComplexityReport,
@@ -31,7 +32,11 @@ export class ComplexityReportManager {
 	 */
 	private getReportPath(tag?: string): string {
 		const reportsDir = path.join(this.projectRoot, '.taskmaster', 'reports');
-		const tagSuffix = tag && tag !== 'master' ? `_${tag}` : '';
+		// Slugify the tag before using it in a filename: tags are user/agent/config
+		// controllable, so a raw `..`/`/` would escape the reports directory.
+		// Matches the legacy `getTagAwareFilePath` writer for read/write parity.
+		const tagSuffix =
+			tag && tag !== 'master' ? `_${slugifyTagForFilePath(tag)}` : '';
 		return path.join(reportsDir, `task-complexity-report${tagSuffix}.json`);
 	}
 

--- a/packages/tm-core/src/modules/tasks/services/task-file-generator.service.ts
+++ b/packages/tm-core/src/modules/tasks/services/task-file-generator.service.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import type { Task, Subtask, TaskStatus } from '../../../common/types/index.js';
 import type { IStorage } from '../../../common/interfaces/storage.interface.js';
 import type { ConfigManager } from '../../config/managers/config-manager.js';
+import { slugifyTagForFilePath } from '../../../common/utils/tag-path.js';
 
 /**
  * Options for generating task files
@@ -133,9 +134,11 @@ export class TaskFileGeneratorService {
 	 */
 	private getTaskFileName(taskId: string | number, tag: string): string {
 		const paddedId = String(taskId).padStart(3, '0');
+		// Slugify the tag: it is user/agent/config controllable, so a raw `..`/`/`
+		// would let `path.join` write the task file outside the tasks directory.
 		return tag === 'master'
 			? `task_${paddedId}.md`
-			: `task_${paddedId}_${tag}.md`;
+			: `task_${paddedId}_${slugifyTagForFilePath(tag)}.md`;
 	}
 
 	/**
@@ -160,9 +163,12 @@ export class TaskFileGeneratorService {
 			const files = await fs.readdir(outputDir);
 			const validTaskIds = tasks.map((task) => String(task.id));
 
-			// Tag-aware file patterns
+			// Tag-aware file patterns. The tag is slugified to match the names
+			// produced by getTaskFileName(), keeping cleanup in sync with writes.
 			const masterFilePattern = /^task_(\d+)\.md$/;
-			const taggedFilePattern = new RegExp(`^task_(\\d+)_${this.escapeRegExp(tag)}\\.md$`);
+			const taggedFilePattern = new RegExp(
+				`^task_(\\d+)_${this.escapeRegExp(slugifyTagForFilePath(tag))}\\.md$`
+			);
 
 			// Collect files to remove
 			const filesToRemove: string[] = [];


### PR DESCRIPTION
# What type of PR is this?

 - [x] 🐛 Bug fix

## Description

`tag` is interpolated **raw** into filenames in two `tm-core` path builders:

- `ComplexityReportManager.getReportPath` → `task-complexity-report_<tag>.json` (read)
- `TaskFileGeneratorService.getTaskFileName` → `task_<id>_<tag>.md` (write)

Tags are user/agent/config controllable (CLI `--tag`, MCP `tag` argument,
`.taskmaster/state.json` `currentTag`, `TASKMASTER_TAG`), and none of these entry
points validates the value on the read/generate path (`validateTagName` only runs
on create/rename/copy). So a tag like `../../../../../escape/x` escapes
`.taskmaster/` — an out-of-project file **read** (complexity report) and **write**
(task `.md`). CWE-22/23/73.

This is a parity regression: the legacy JS path slugified the tag
(`slugifyTagForFilePath` in `scripts/modules/utils.js`); the TypeScript rewrite
dropped it, and the `sanitizeTag` helper on the storage interface was never wired in.

**Fix:** a shared `slugifyTagForFilePath` helper (mirroring the legacy behavior),
applied at both path builders and at `cleanupOrphanedFiles` so written names and
the orphan-cleanup pattern stay in sync. Sanitizing at the path-building chokepoint
covers all three entry vectors at once. Legitimately named tags (already
`^[a-zA-Z0-9_-]+$`) are unaffected beyond lowercasing. Honest severity: **Medium** —
the extension is forced (`.md`/`.json`), so this is not arbitrary-file overwrite or RCE.

## Related Issues

Fixes #1711.

## How to Test This

```bash
npm run test -w @tm/core -- tag-path.spec.ts task-file-generator.service.spec.ts
```

**Expected result:** all tests pass, including the new negative-oracle cases where
`../../x`, `..\..\x`, NUL and `..%2f..` are neutralized while `feature-v2` is preserved.

Manual before/after (project root `/work/project`): tag `../../../../../escape/secret`
resolved **outside** the project before the fix and resolves to
`…/.taskmaster/reports/task-complexity-report_escape-secret.json` (contained) after.

## Contributor Checklist

- [x] Created changeset: `npm run changeset`
- [x] Tests pass: `npm test` (vitest 26/26 on the new + touched specs; `tsc --noEmit` clean)
- [x] Format check passes: `npm run format-check` (biome, no changes)
- [ ] Addressed CodeRabbit comments (if any)
- [x] Linked related issues (Fixes #1711)
- [x] Manually tested the changes

## Changelog Entry

Fix path traversal via an unsanitized `tag` in the complexity-report reader and task-file generator (tags are now slugified before use in file paths).

---

*Disclosure: this fix was AI-assisted and human-reviewed; it was tested on the repo's
own vitest/tsc/biome before submission. Happy to follow whatever disclosure format you prefer.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Patched a security vulnerability where crafted tags could be interpolated into report/task filenames, enabling path traversal.
  * Tags are now converted into filesystem-safe, lowercased slugs before being used in filenames, preventing `../`, slashes, and other unsafe characters from escaping the intended directory.
* **Tests**
  * Added coverage to verify safe slug generation, expected fallback behavior, and protection against traversal-style inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->